### PR TITLE
Adds skill and eval templates for contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,28 @@ Supporting files (anything that isn't `SKILL.md`) are bundled with the skill but
 
 ## Contributing
 
+### Quick start
+
+```bash
+# Copy the template
+cp -r template/ your-skill-name/
+
+# Edit the skill definition
+$EDITOR your-skill-name/SKILL.md
+
+# Add supporting reference files
+touch your-skill-name/setup.md
+touch your-skill-name/core.md
+touch your-skill-name/patterns.md
+touch your-skill-name/examples.md
+
+# Add evals
+mkdir your-skill-name/evals
+touch your-skill-name/evals/evals.json
+```
+
+### Steps
+
 1. Create a new directory under the repo root: `your-skill-name/`
 2. Add a `SKILL.md` with frontmatter:
 
@@ -50,12 +72,51 @@ description: What this skill does and when to use it. Be specific — this is wh
 ```
 
 3. Add supporting files to the same directory as needed
-4. Open a PR
+4. Add evals to `your-skill-name/evals/evals.json` (see [Evals](#evals) below)
+5. Open a PR
 
-A few things that make skills work well:
-- **Description as a trigger rule**, not a title — include the contexts and keywords that should activate it
-- **`SKILL.md` for the core workflow** — move reference material, large docs, and examples into separate files
-- **One skill per capability** — if it has a meaningfully different trigger, it should be its own skill
+### Checklist
+
+- [ ] Replace `name` and `description` in SKILL.md frontmatter
+- [ ] Write a clear opening paragraph describing what the skill covers
+- [ ] Create reference files for each section listed under "Reference files"
+- [ ] Update the routing guide table to match your actual reference files
+- [ ] Edit or remove the "Sui-specific reminders" section as needed
+- [ ] Add evals to validate the skill produces correct output
+- [ ] Open a PR
+
+### Evals
+
+Every new skill must include evals. Evals verify that the skill produces correct, reliable output and prevent regressions as the skill evolves. PRs without evals will not be merged.
+
+Place an `evals/evals.json` file in your skill directory:
+
+```json
+[
+  {
+    "id": "your-skill-basic",
+    "prompt": "A realistic prompt a user would give the agent",
+    "expected_output": "Description of what correct output looks like",
+    "expectations": [
+      "Specific thing the output must include or satisfy",
+      "Another requirement"
+    ]
+  }
+]
+```
+
+When writing evals:
+- Cover the core use cases your skill is designed to handle
+- Use realistic prompts that match how a user would actually invoke the skill
+- Include edge cases where the skill's domain has common pitfalls
+- Each eval should test a distinct capability — avoid redundant prompts
+
+### Tips
+
+- **Description is a trigger rule.** The `description` field in frontmatter determines when agents activate your skill. Write it like a conditional: "Use when X, Y, or Z."
+- **SKILL.md routes, reference files teach.** Keep SKILL.md short — it tells the agent which files to load. Put the actual knowledge in reference files.
+- **One skill per capability.** If two things have meaningfully different triggers, they should be separate skills.
+- **Sui-first.** Assume the user is building on Sui. Call out where Sui differs from other chains or general-purpose patterns.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Place an `evals/evals.json` file in your skill directory:
   {
     "id": "your-skill-basic",
     "prompt": "A realistic prompt a user would give the agent",
+    "sources": [
+        "https://source-1.com",
+        "https://source-2.com"
+        ],
     "expected_output": "Description of what correct output looks like",
     "expectations": [
       "Specific thing the output must include or satisfy",

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ When writing evals:
 - Use realistic prompts that match how a user would actually invoke the skill
 - Include edge cases where the skill's domain has common pitfalls
 - Each eval should test a distinct capability — avoid redundant prompts
+- Each prompt should include a `sources` field that links out to documentation that should be used to verify the output of the eval. Sources can be set for individual prompts, or if the entire eval pulls from the same source, you can use the `source_constraint` heading at the top of the eval file. 
 
 ### Tips
 

--- a/template/SKILL.md
+++ b/template/SKILL.md
@@ -24,6 +24,12 @@ confusing Sui with other chains, misunderstanding the object model).
 This skill routes to focused reference files. Load only the ones relevant to the
 current task.
 
+All patterns in this skill are derived from:
+  https://sdk.mystenlabs.com/sui
+
+If unsure about any API, fetch the relevant page before answering.
+Do not guess or extrapolate from other SDKs.
+
 ---
 
 ## Reference files

--- a/template/SKILL.md
+++ b/template/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: your-skill-name
+description: >
+  Replace with a trigger-style description of when this skill should activate.
+  Be specific — this is what the agent uses to decide whether to load the skill.
+  Example: "Sui TypeScript SDK integration. Use when writing, reviewing, or
+  debugging TypeScript code that interacts with Sui RPCs, transactions, or
+  on-chain state."
+---
+
+# Skill Title
+
+<!-- 
+  Replace "Skill Title" with a clear name, e.g. "Sui TypeScript SDK Skill".
+  The opening paragraph should orient the agent: what domain does this cover,
+  what common mistakes does it prevent, and what makes Sui-specific usage
+  different from general-purpose patterns?
+-->
+
+Brief description of what this skill covers and why it exists. Call out the most
+common AI-coding mistakes this skill prevents (e.g., using deprecated APIs,
+confusing Sui with other chains, misunderstanding the object model).
+
+This skill routes to focused reference files. Load only the ones relevant to the
+current task.
+
+---
+
+## Reference files
+
+<!--
+  List each supporting markdown file in the skill directory.
+  Each entry should follow this format:
+
+  ### slug — Human-Readable Title
+  **Path:** `slug.md`
+  **Load when:** describe the tasks/contexts that require this file.
+  **Covers:** list the sections or topics inside the file.
+
+  Tips:
+  - Keep files focused on a single concern (setup, syntax, patterns, etc.)
+  - Name files with short, descriptive slugs (e.g., setup.md, objects.md)
+  - "Load when" should use task-oriented language the agent can match against
+-->
+
+## Routing guide
+
+<!--
+  Map common tasks to which reference files the agent should load.
+  This table is the primary decision tool — keep it comprehensive.
+  Use "all reference files" for broad tasks like full builds or code review.
+-->
+
+| Task | Load |
+|------|------|
+| Setting up a new project | setup |
+| Writing core logic | core |
+| Following best practices | patterns |
+| Seeing a worked example | examples |
+| Implementing a complete feature | core + patterns |
+| Full project from scratch | **all reference files** |
+| Code review | **all reference files** |
+
+## Skill Content
+
+<!--
+  This is where the core knowledge of your skill lives — the rules, guidelines,
+  and domain expertise that the agent should always have loaded when this skill
+  is active. Unlike reference files (which are loaded on demand), everything in
+  this section is available to the agent immediately.
+
+  Structure this section around:
+  - Key concepts the agent must understand to work in this domain
+  - Rules and constraints that always apply (e.g., "always use X instead of Y")
+  - Common mistakes and how to avoid them
+  - Sui-specific differences from general-purpose patterns
+
+  Keep it concise. If a topic requires extended explanation, examples, or
+  reference tables, put it in a reference file instead and link to it from the
+  routing guide above.
+-->
+
+### Key concepts
+
+<!-- Define the core abstractions and mental model for this domain. -->
+
+### Rules
+
+<!-- List the non-negotiable rules the agent must follow. Be direct and specific. -->
+
+### Common mistakes
+
+<!-- Describe frequent errors and their correct alternatives. -->
+

--- a/template/SKILL.md
+++ b/template/SKILL.md
@@ -24,11 +24,23 @@ confusing Sui with other chains, misunderstanding the object model).
 This skill routes to focused reference files. Load only the ones relevant to the
 current task.
 
+<!--
+  Cite the canonical source(s) this skill is derived from (official docs,
+  spec, repo, etc.) and instruct the agent to fetch from them when unsure
+  rather than guessing or extrapolating from related tools. Example:
+
+  All patterns in this skill are derived from:
+    https://docs.example.com/
+
+  If unsure about any API, fetch the relevant page before answering.
+  Do not guess or extrapolate from other SDKs or libraries.
+-->
+
 All patterns in this skill are derived from:
-  https://sdk.mystenlabs.com/sui
+  <CANONICAL_SOURCE_URL>
 
 If unsure about any API, fetch the relevant page before answering.
-Do not guess or extrapolate from other SDKs.
+Do not guess or extrapolate from other SDKs or libraries.
 
 ---
 

--- a/template/evals/evals.json
+++ b/template/evals/evals.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "your-skill-basic",
+    "prompt": "A realistic prompt a user would give the agent",
+    "expected_output": "Description of what correct output looks like",
+    "expectations": [
+      "Specific thing the output must include or satisfy",
+      "Another requirement"
+    ]
+  },
+  {
+    "id": "your-skill-edge-case",
+    "prompt": "A prompt that targets a common pitfall or edge case in this domain",
+    "expected_output": "Description of what correct output looks like",
+    "expectations": [
+      "The output avoids the common mistake",
+      "The output follows the skill's rules"
+    ]
+  }
+]

--- a/template/evals/evals.json
+++ b/template/evals/evals.json
@@ -2,6 +2,10 @@
   {
     "id": "your-skill-basic",
     "prompt": "A realistic prompt a user would give the agent",
+    "sources": [
+        "link-to-docs.com (description of what to get from those docs)",
+        "docs.sui.io/references/framework/* (sui, std, bridge, system framework API reference)"
+    ],
     "expected_output": "Description of what correct output looks like",
     "expectations": [
       "Specific thing the output must include or satisfy",


### PR DESCRIPTION
Summary                                                   

  - Merged template/README.md content into the root README.md contributing      
  section, then removed template/README.md to avoid duplication
  - Expanded contributing guide with quick start commands, a checklist, eval    
  requirements, and tips                                                        
  - Made evals a requirement for all new skills — PRs without evals will not be
  merged                                                                        
  - Added a "Skill Content" section to template/SKILL.md with scaffolding for
  key concepts, rules, and common mistakes                                      
  - Added template/evals/evals.json with two example entries (basic use case +
  edge case) as a starting point for contributors     