### PR TITLE
Add ptbs skill

### DIFF
--- a/ptbs/SKILL.md
+++ b/ptbs/SKILL.md
@@ -16,10 +16,10 @@ This skill routes to focused reference files. Load only the ones relevant to the
 
 All patterns in this skill are derived from:
 - https://docs.sui.io/concepts/transactions/prog-txn-blocks
-- https://docs.sui.io/guides/developer/sui-101/building-ptb
+- https://docs.sui.io/develop/transactions/ptbs/building-ptb
 - https://docs.sui.io/references/ptb-commands
 - https://docs.sui.io/concepts/sui-architecture/epochs (equivocation)
-- https://sdk.mystenlabs.com/typescript/transaction-building
+- https://sdk.mystenlabs.com/typescript/transaction-building/basics
 
 If unsure about any API, method signature, or error message, fetch the relevant page before answering. Do not guess or extrapolate from Ethereum, Solana, or other chains — PTBs have no direct analog.
 

--- a/ptbs/SKILL.md
+++ b/ptbs/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: ptbs
+description: >
+  Sui Programmable Transaction Blocks (PTBs). Use when writing, reviewing, or
+  debugging code that composes multiple Sui transaction commands into a single
+  atomic transaction — including TypeScript SDK `Transaction` usage, gas coin
+  handling, sponsored transactions, shared-object inputs, chaining command
+  results, preventing equivocation, or troubleshooting PTB execution errors.
+---
+
+# Sui Programmable Transaction Blocks (PTBs)
+
+A PTB is one Sui transaction that batches up to **1,024 commands** — Move calls, coin splits/merges, object transfers, vector construction, package publish/upgrade — executed in order, atomically (one command fails ⇒ whole block fails), sharing inputs and chaining results. PTBs are the only way to execute transactions on Sui; there is no "single call" mode.
+
+This skill routes to focused reference files. Load only the ones relevant to the current task.
+
+All patterns in this skill are derived from:
+- https://docs.sui.io/concepts/transactions/prog-txn-blocks
+- https://docs.sui.io/guides/developer/sui-101/building-ptb
+- https://docs.sui.io/references/ptb-commands
+- https://docs.sui.io/concepts/sui-architecture/epochs (equivocation)
+- https://sdk.mystenlabs.com/typescript/transaction-building
+
+If unsure about any API, method signature, or error message, fetch the relevant page before answering. Do not guess or extrapolate from Ethereum, Solana, or other chains — PTBs have no direct analog.
+
+---
+
+## Reference files
+
+### fundamentals — PTB data model
+**Path:** `fundamentals.md`
+**Load when:** explaining what a PTB is, talking about `Input`, `Argument`, `NestedResult`, `GasCoin`, owned vs shared vs immutable vs receiving object references, pure-input BCS rules, command chaining semantics, or execution ordering / atomicity.
+**Covers:** PTB structure, `Input` (CallArg) and `ObjectArg` variants, pure input types, `Argument` enum, result chaining, execution semantics (borrow rules, move/copy, hot potato cliques, end-of-tx constraints), protocol limits.
+
+### commands — Command reference
+**Path:** `commands.md`
+**Load when:** writing or reviewing any specific command — `MoveCall`, `SplitCoins`, `MergeCoins`, `TransferObjects`, `MakeMoveVec`, `Publish`, `Upgrade` — or debugging argument-type mismatches and return-value shape.
+**Covers:** signature, argument rules, return shape, and common pitfalls for each of the seven commands.
+
+### building — TypeScript SDK `Transaction` class
+**Path:** `building.md`
+**Load when:** writing TS/JS code that constructs a PTB with `@mysten/sui/transactions`, configuring gas, building for wallets, serializing across services, or sending PTBs between app ↔ wallet ↔ sponsor.
+**Covers:** `Transaction` API (`tx.moveCall`, `tx.splitCoins`, `tx.mergeCoins`, `tx.transferObjects`, `tx.makeMoveVec`, `tx.publish`, `tx.upgrade`, `tx.object`, `tx.pure`, `tx.gas`, `tx.setSender/setGasPrice/setGasBudget/setGasPayment/setGasOwner`), `Inputs.*Ref` helpers, result destructuring, `build({ onlyTransactionKind: true })`, `Transaction.from` / `fromKind`, sponsored transaction flow, signing & executing.
+
+### equivocation — Preventing object lock
+**Path:** `equivocation.md`
+**Load when:** writing any code that submits multiple transactions concurrently, operating a gas station or faucet, building a sponsor service, designing high-throughput client code, or recovering from `"objects is equivocated until the next epoch"` errors.
+**Covers:** definition, mechanism (per-version validator locks), how it happens (shared gas coin, stale full nodes, bad sponsor flow), recovery (`sui-tool locked-object --rescue`), and prevention — PTB batching, `SerialTransactionExecutor`, `ParallelTransactionExecutor`, separate owned objects per thread, shared-object wrappers.
+
+### troubleshooting — Common errors
+**Path:** `troubleshooting.md`
+**Load when:** diagnosing a failing PTB — any `ServerError`, `UnusedValueWithoutDrop`, `VMVerificationOrDeserializationError`, `No valid gas coins`, `objects is reserved`, `objects is equivocated`, `InsufficientGas`, shared-object congestion, or cryptic "transaction failed" output.
+**Covers:** each error category with the Move/PTB-level cause and concrete fix.
+
+## Routing guide
+
+| Task | Load |
+|------|------|
+| "What is a PTB?" / conceptual explanation | fundamentals |
+| Writing a new PTB in TypeScript | building + commands |
+| Reviewing a PTB for correctness | fundamentals + commands + building |
+| A specific command fails type checking | commands |
+| Concurrent/high-throughput transaction submission | equivocation + building |
+| Sponsored / gasless transactions | building + equivocation |
+| Debugging a failing PTB | troubleshooting + (fundamentals if execution-semantics related) |
+| Publishing or upgrading a package in a PTB | commands |
+| Building PTB bytes across services (app/wallet/sponsor) | building |
+| Full code review | **all reference files** |
+
+## Skill Content
+
+### Key concepts
+
+- **A PTB is the transaction.** Every Sui transaction is a PTB — even a single `moveCall` is a one-command PTB. There is no non-PTB execution path.
+- **Inputs vs commands.** `inputs` are values fed in from outside (objects and BCS-encoded "pure" bytes). `commands` operate on those inputs and on each other's results. Commands reference values via the `Argument` enum: `Input(i)`, `GasCoin`, `Result(i)`, `NestedResult(cmd, result)`.
+- **Chaining.** Each command produces an array of results. The next command can consume any result (by `NestedResult(cmd, idx)` or, when a command has exactly one return, `Result(cmd)`). The TS SDK surfaces this as destructurable values: `const [coin] = tx.splitCoins(tx.gas, [tx.pure.u64(100)]);`.
+- **Atomicity.** Commands execute in order. Any failure reverts the entire block; no partial effects.
+- **End-of-tx constraints.** Every non-`drop` value produced during execution must be consumed (transferred, destroyed, or fed into another command). Shared objects must be re-shared or deleted — they cannot be transferred or frozen. Gas coin is returned to its owner with unused gas refunded.
+
+### Rules
+
+1. **Never sign two concurrent transactions that touch the same owned object** (including the same gas coin). This causes equivocation and locks the object until the next epoch (~24h on mainnet). Batch into one PTB, or serialize through `SerialTransactionExecutor`, or use separate owned objects per thread.
+2. **`tx.gas` must be used by reference, except in `transferObjects`.** To get an owned `Coin<SUI>` from the gas coin, use `SplitCoins(tx.gas, [amount])` first.
+3. **Leave gas config to the wallet when possible.** Do not hardcode `setGasBudget` / `setGasPrice` / `setGasPayment` in app code that will be signed by a user wallet — the wallet dry-runs and selects coins correctly. Only set them for backend-signed flows.
+4. **In app code that hands a PTB to a wallet, use `tx.serialize()` (not `tx.build()`).** The wallet must perform gas logic and coin selection itself; building bytes in app code preempts that.
+5. **Use `Transaction.fromKind(kindBytes)` for sponsored flows.** Build in app with `tx.build({ client, onlyTransactionKind: true })`, send the kind-only bytes to the sponsor service, rehydrate there with `fromKind`, then `setSender`, `setGasOwner`, `setGasPayment`.
+6. **Every non-`drop` value must be consumed.** If `moveCall` returns a value you don't need, pass it to `transferObjects` (if it has `key + store`), to `public_transfer`, or to a destructor. `UnusedValueWithoutDrop` is the PTB-level error.
+7. **Shared objects cannot be transferred, frozen, or consumed by value if passed as read-only** (`mutable: false`). If you need mutable access, mark them mutable when building the input.
+8. **Types coming from Move calls cannot be references.** `MoveCall` results are values; if a Move function returns `&T`, it cannot be called from a PTB.
+9. **For multi-return Move calls, use destructuring or array indexing.** `const [a, b] = tx.moveCall(...)` or `const r = tx.moveCall(...); r[0]; r[1];`. Do not assume single-return shape.
+10. **Cite the docs when unsure.** Canonical sources above. Legacy `/develop/transactions/ptbs/*` URLs still render but prefer `/concepts/transactions/prog-txn-blocks` and `/guides/developer/sui-101/building-ptb`.
+
+### Common mistakes
+
+- **Calling `tx.pure(value)` without a type.** Untyped pure values fail at input resolution. Use typed helpers: `tx.pure.u64(n)`, `tx.pure.address(addr)`, `tx.pure.string(s)`, or the generic `tx.pure('u64', n)`.
+- **Passing a string object ID to `moveCall` arguments without `tx.object(...)`.** Mixed-type arguments require explicit `tx.object(id)` wrapping; otherwise the SDK can't distinguish pure from object.
+- **Reusing the gas coin across concurrent txs.** This is the #1 cause of equivocation in backend services. Use `SerialTransactionExecutor` or maintain a gas coin pool.
+- **Transferring a shared object.** Sharing is permanent (except via explicit `unshare` patterns that re-share or delete before tx end). Do not include shared objects in `transferObjects`.
+- **Forgetting to `setSender` on offline builds.** When calling `tx.build()` without signing through a signer that sets the sender, the sender field stays empty and the build fails.
+- **Treating multi-return `moveCall` results as single values.** The return is a vector; index or destructure.
+- **Using `transfer::transfer` / `transfer::share_object` on generic types from a PTB.** Those entries require a module-private type param. From a PTB, use `transfer::public_transfer` / `transfer::public_share_object`, which require the type to have `store`.
+- **Setting a gas budget that's too tight.** A tx that exceeds budget aborts but still charges the gas coin. Prefer the SDK's dry-run-based auto-budget.
+- **Looping in app code to submit N individual transactions.** Batch into one PTB (up to 1,024 ops). One PTB is cheaper, atomic, and equivocation-free.

--- a/ptbs/building.md
+++ b/ptbs/building.md
@@ -2,7 +2,7 @@
 
 How to construct, sign, serialize, and execute PTBs with `@mysten/sui/transactions`.
 
-Source: https://docs.sui.io/guides/developer/sui-101/building-ptb · https://sdk.mystenlabs.com/typescript/transaction-building
+Source: https://docs.sui.io/develop/transactions/ptbs/building-ptb · https://sdk.mystenlabs.com/typescript/transaction-building/basics
 
 ## Setup
 

--- a/ptbs/building.md
+++ b/ptbs/building.md
@@ -1,0 +1,291 @@
+# Building PTBs with the TypeScript SDK
+
+How to construct, sign, serialize, and execute PTBs with `@mysten/sui/transactions`.
+
+Source: https://docs.sui.io/guides/developer/sui-101/building-ptb · https://sdk.mystenlabs.com/typescript/transaction-building
+
+## Setup
+
+```ts
+import { Transaction, Inputs } from '@mysten/sui/transactions';
+import { SuiClient, getFullnodeUrl } from '@mysten/sui/client';
+
+const tx = new Transaction();
+const client = new SuiClient({ url: getFullnodeUrl('mainnet') });
+```
+
+## Inputs
+
+### Object inputs
+
+```ts
+tx.object(objectId)                     // by string ID; SDK resolves version via RPC
+tx.object(Inputs.ObjectRef({            // fully-specified (owned / immutable), offline-buildable
+  objectId, version, digest,
+}))
+tx.object(Inputs.SharedObjectRef({      // fully-specified shared
+  objectId, initialSharedVersion, mutable,
+}))
+tx.object(Inputs.ReceivingRef({         // fully-specified receiving
+  objectId, version, digest,
+}))
+
+// System object helpers:
+tx.object.system()
+tx.object.clock()
+tx.object.random()
+tx.object.denyList()
+tx.object.option({ type: '0x123::m::T', value: '0xabc' })  // helper for Option<Object>
+```
+
+**When wrapping is required:** for `moveCall` arguments that mix pure and object inputs, always wrap object IDs with `tx.object(id)` so the SDK knows which call-arg kind to emit. Many other methods accept raw string IDs directly.
+
+### Pure inputs
+
+Typed helpers (preferred):
+```ts
+tx.pure.u8(255)
+tx.pure.u16(n) ; tx.pure.u32(n) ; tx.pure.u64(n) ; tx.pure.u128(n) ; tx.pure.u256(n)
+tx.pure.bool(true)
+tx.pure.address('0x...')
+tx.pure.string('hello')
+tx.pure.vector('u8', [1, 2, 3])
+tx.pure.option('u64', 42)      // Option<u64> = Some(42)
+tx.pure.option('u64', null)    // Option<u64> = None
+```
+
+Generic form:
+```ts
+tx.pure('u64', 100)
+tx.pure('vector<u8>', [1, 2, 3])
+tx.pure('option<u8>', 1)
+```
+
+Raw BCS:
+```ts
+import { bcs } from '@mysten/sui/bcs';
+tx.pure(bcs.U64.serialize(100))
+tx.pure(bcs.vector(bcs.U8).serialize([1, 2, 3]))
+// Or raw Uint8Array — used directly:
+tx.pure(new Uint8Array([0, 1, 2]))
+```
+
+### The gas coin
+
+`tx.gas` references the `GasCoin` argument. Usage rules:
+- Valid as any arg position, but **must be by reference** unless passed to `transferObjects` (value) or used as the source of `splitCoins` (mutable borrow).
+- `tx.splitCoins(tx.gas, [tx.pure.u64(amount)])` — most common pattern: derive an owned `Coin<SUI>` from gas.
+- `tx.mergeCoins(tx.gas, [tx.object(extra1), tx.object(extra2)])` — consolidate owned SUI into the gas coin before using it.
+
+## Commands — TS SDK signatures
+
+```ts
+tx.splitCoins(coin, amounts)
+//   coin:    tx.gas | tx.object(id) | prior result
+//   amounts: Arg[] (u64 pure or result)
+//   returns: destructurable result (one coin per amount)
+
+tx.mergeCoins(destination, sources)
+//   returns: nothing meaningful
+
+tx.transferObjects(objects, recipient)
+//   objects:   Arg[]
+//   recipient: Arg (address pure or result)
+
+tx.moveCall({
+  target: 'pkg::module::function',
+  arguments?: Arg[],
+  typeArguments?: string[],
+})
+//   returns: destructurable result (per Move fn signature)
+
+tx.makeMoveVec({ type?: string, elements: Arg[] })
+//   type required for empty vectors or non-object element types
+//   returns: single vector value
+
+tx.publish({ modules: number[][], dependencies: string[] })
+//   returns: UpgradeCap
+
+tx.upgrade({ modules, dependencies, packageId, ticket })
+//   returns: UpgradeReceipt
+```
+
+## Result chaining
+
+Each command returns a destructurable/indexable result:
+
+```ts
+// Single-return: destructure
+const [coin] = tx.splitCoins(tx.gas, [tx.pure.u64(100)]);
+tx.transferObjects([coin], tx.pure.address(to));
+
+// Multi-return: destructure
+const [nft1, nft2] = tx.moveCall({ target: '0xpkg::mint::two' });
+tx.transferObjects([nft1, nft2], tx.pure.address(to));
+
+// Or index into the result
+const minted = tx.moveCall({ target: '0xpkg::mint::two' });
+tx.transferObjects([minted[0], minted[1]], tx.pure.address(to));
+
+// Pass the whole result when a single value is expected
+const hero = tx.moveCall({ target: '0x123::hero::mint_hero' });
+const sword = tx.moveCall({ target: '0x123::hero::new_sword', arguments: [tx.pure.u64(10)] });
+tx.moveCall({ target: '0x123::hero::equip_sword', arguments: [hero, sword] });
+```
+
+## Sender and gas configuration
+
+```ts
+tx.setSender(senderAddress);        // required if building offline or sending kind-only
+tx.setGasPrice(gasPrice);           // default: network reference gas price
+tx.setGasBudget(gasBudgetMist);     // default: auto (SDK dry-runs and picks)
+tx.setGasPayment([                  // default: auto (all coins at sender not used as inputs)
+  { objectId, version, digest },
+  ...
+]);
+tx.setGasOwner(sponsorAddress);     // for sponsored txs — gas coins owned by someone else
+```
+
+### Defaults — leave them alone when a wallet signs
+
+The SDK:
+- Sets `gas price` to the network's reference gas price.
+- **Dry-runs the PTB** to auto-derive `gas budget`.
+- Selects gas payment coins (all SUI coins at the sender not used as inputs). Multiple coins get merged into the 0-index coin during execution; the others are deleted.
+
+For user-signed transactions in apps, **don't set these** — let the wallet handle it. See "App ↔ wallet handoff" below.
+
+### Batch transfers pattern
+
+```ts
+interface Transfer { to: string; amount: number }
+const transfers: Transfer[] = getTransfers();
+
+const tx = new Transaction();
+const coins = tx.splitCoins(
+  tx.gas,
+  transfers.map(t => tx.pure.u64(t.amount)),
+);
+transfers.forEach((t, i) => {
+  tx.transferObjects([coins[i]], tx.pure.address(t.to));
+});
+```
+
+One PTB replaces N transactions — cheaper, atomic, equivocation-free.
+
+## Building, serializing, rehydrating
+
+```ts
+// Normal build: SDK resolves input versions via RPC
+const bytes = await tx.build({ client });
+
+// Kind-only (for sponsored flows — no gas data)
+const kindBytes = await tx.build({ client, onlyTransactionKind: true });
+
+// Offline build: all inputs must be fully-specified (Inputs.ObjectRef/SharedObjectRef/ReceivingRef)
+// and gas data must be set manually. setSender is required.
+const offlineBytes = await tx.build();
+
+// Rehydrate
+const tx2 = Transaction.from(bytes);           // full tx
+const tx3 = Transaction.fromKind(kindBytes);   // kind-only; set sender + gas data before building
+```
+
+## App ↔ wallet handoff — use `serialize`, not `build`
+
+In frontend code that hands a PTB to a wallet:
+
+```ts
+// App code:
+const tx = new Transaction();
+tx.transferObjects([tx.object(nftId)], tx.pure.address(recipient));
+await wallet.signTransaction({ transaction: tx });  // pass Transaction instance
+
+// The wallet adapter internally does:
+sendToWalletContext({ transaction: input.transaction.serialize() });
+// And the wallet does:
+const userTx = Transaction.from(input.transaction);
+userTx.setSender(walletAddress);
+// wallet builds bytes (picks gas, sets budget via dry-run), signs, executes.
+```
+
+**Why not `build`:** if the app calls `tx.build()` and hands bytes to the wallet, the wallet cannot do gas coin selection or budget dry-running on the caller's behalf. Use `tx.serialize()` (or pass the `Transaction` instance) so the wallet controls gas logic.
+
+## Sponsored transactions
+
+Flow:
+1. **App** builds the PTB kind-only.
+2. **Sponsor service** rehydrates, fills gas, signs as gas owner.
+3. **User** signs as sender.
+4. Either party submits the dual-signed bytes (user is safer — submitting via sponsor allows censorship).
+
+```ts
+// App:
+const tx = new Transaction();
+tx.moveCall({ /* ... */ });
+const kindBytes = await tx.build({ client, onlyTransactionKind: true });
+sendToSponsor(kindBytes);
+
+// Sponsor:
+const sponsored = Transaction.fromKind(kindBytes);
+sponsored.setSender(userAddress);
+sponsored.setGasOwner(sponsorAddress);
+sponsored.setGasPayment(sponsorCoins);   // [{ objectId, version, digest }]
+const sponsorSigned = await sponsorSigner.signTransaction(sponsored);
+sendBackToUser(sponsorSigned);
+
+// User signs (over the same TransactionData, including GasData) and submits.
+```
+
+Both parties sign over the **entire TransactionData** including `GasData`. Signing only parts lets a malicious full node substitute gas data. See `equivocation.md` for how to defend the gas station against client equivocation.
+
+## Signing & executing
+
+```ts
+const result = await client.signAndExecuteTransaction({
+  signer: keypair,
+  transaction: tx,
+  options: {
+    showObjectChanges: true,
+    showBalanceChanges: true,
+    showEffects: true,
+  },
+});
+
+if (result.effects?.status?.status !== 'success') {
+  throw new Error(`Tx failed: ${result.effects?.status?.error}`);
+}
+
+// Ensure the RPC you'll read from next has indexed these effects
+await client.waitForTransaction({ digest: result.digest });
+```
+
+**Always check status.** A transaction can execute (validators accept it) but still fail at the Move level (assertion, insufficient gas budget, etc.). Inspect `effects.status`.
+
+## Dry-running and dev-inspect
+
+```ts
+// Dry-run: full execution against current state, no signature required
+const dry = await client.dryRunTransactionBlock({
+  transactionBlock: await tx.build({ client }),
+});
+
+// Dev-inspect: like dry-run but also returns result values
+const inspect = await client.devInspectTransactionBlock({
+  transactionBlock: tx,
+  sender: senderAddress,
+});
+```
+
+Use `devInspectTransactionBlock` when you need return values from a view-like Move call without publishing a custom view function.
+
+## Checklist for a PTB ready to ship
+
+- Inputs: either `tx.object(stringId)` (online) or `Inputs.*Ref` (offline); pure values typed.
+- No shared object passed to `transferObjects`.
+- Every non-`drop` result either consumed or transferred.
+- `tx.gas` only by value in `transferObjects`; otherwise `splitCoins`/`mergeCoins`/borrow.
+- Multi-return `moveCall` results destructured or indexed.
+- For user-signed flows: no `setGasBudget`/`setGasPrice`/`setGasPayment`, no `tx.build()` before handing to wallet — use `tx.serialize()` or pass the `Transaction` directly.
+- For sponsored flows: `build({ onlyTransactionKind: true })` → sponsor `setSender`/`setGasOwner`/`setGasPayment` → both signatures over full `TransactionData`.
+- `waitForTransaction` before reading mutated state from the same client.

--- a/ptbs/commands.md
+++ b/ptbs/commands.md
@@ -1,0 +1,135 @@
+# PTB Command Reference
+
+All seven PTB commands, with argument types, return shape, and common pitfalls.
+
+Source: https://docs.sui.io/references/ptb-commands · https://docs.sui.io/concepts/transactions/prog-txn-blocks
+
+## `TransferObjects`
+
+Transfers a list of objects to an address. Objects are taken **by value**.
+
+```
+TransferObjects(ObjectArgs: [Argument], AddressArg: Argument)
+Signature:  (vector<forall T: key + store. T>, address): ()
+Returns:    []
+```
+
+- All object arguments must have `key + store`.
+- Address can be a `Pure` input or a `Result` (e.g., the return of a `MoveCall` that produces an address).
+- TS SDK: `tx.transferObjects([coin1, coin2], tx.pure.address(to))`.
+- The one case where `tx.gas` can be passed by value: `tx.transferObjects([tx.gas], to)` transfers the entire remaining gas balance.
+- Do **not** include shared objects — sharing is permanent; such a tx will fail at commit.
+
+## `SplitCoins`
+
+Splits a source coin into one or more new coins.
+
+```
+SplitCoins(CoinArg: Argument, AmountArgs: [Argument])
+Signature:  <T: key + store>(coin: &mut Coin<T>, amounts: vector<u64>): vector<Coin<T>>
+Returns:    [Coin<T>, Coin<T>, …]  (one per amount, in order)
+```
+
+- `CoinArg` is taken by `&mut` — can be `tx.gas`, a `tx.object(coinId)`, or a prior result.
+- `AmountArgs` are `u64` values (pure or result); copied, so they're reusable.
+- TS SDK: `const [a, b] = tx.splitCoins(tx.gas, [tx.pure.u64(100), tx.pure.u64(200)]);`
+- Amounts array must be **non-empty**; empty arrays fail pre-execution.
+
+## `MergeCoins`
+
+Merges coins into a destination coin. Merged coins are **consumed**.
+
+```
+MergeCoins(CoinArg: Argument, ToMergeArgs: [Argument])
+Signature:  <T: key + store>(coin: &mut Coin<T>, to_merge: vector<Coin<T>>): ()
+Returns:    []
+```
+
+- Destination is `&mut`; sources are moved.
+- Common pattern: consolidate owned gas coins at start of tx — `tx.mergeCoins(tx.gas, [tx.object(coin1), tx.object(coin2)])`.
+- `ToMergeArgs` must be non-empty.
+
+## `MakeMoveVec`
+
+Builds a `vector<T>` usable as a Move call argument.
+
+```
+MakeMoveVec(VecTypeOption: Option<TypeTag>, Args: [Argument])
+Signature:  (T...): vector<T>
+Returns:    [vector<T>]  (single result)
+```
+
+- `VecTypeOption` is **required** for non-object element types or empty vectors; optional when elements are objects whose type can be inferred.
+- Elements **cannot** be accessed individually via `NestedResult`. The vector is one result; pass it as a whole to a `MoveCall` to work with elements.
+- TS SDK:
+  - `tx.makeMoveVec({ elements: [tx.object(id1), tx.object(id2)] })`
+  - `tx.makeMoveVec({ type: '0x2::foo::Bar', elements: [] })` — empty vector needs explicit type.
+
+## `MoveCall`
+
+Call a Move function. The core command for business logic.
+
+```
+MoveCall(Package, Module, Function, TypeArgs, Args)
+Returns:  values per the Move function signature (no references)
+```
+
+- Callable functions: **`public`** functions, **all `entry` functions** (including private `entry fun` and `public(package) entry`). Non-entry private or non-entry `public(package)` functions are **not** callable.
+- **Cannot** return `&T` or `&mut T`. Returning a reference makes the function uncallable from a PTB.
+- `TxContext` parameters (`&TxContext` / `&mut TxContext`) are auto-injected. Do **not** supply them; do **not** count them when indexing arguments. They can appear at any position and multiple `&TxContext` are allowed.
+- **Module-private type parameters can't be supplied from PTBs.** For generics, use `transfer::public_transfer` instead of `transfer::transfer`, and `transfer::public_share_object` instead of `transfer::share_object` — the `public_*` variants require `T: store` instead of a private type witness.
+- TS SDK:
+  ```ts
+  tx.moveCall({
+    target: '0x2::devnet_nft::mint',
+    arguments: [tx.pure.string(name), tx.pure.string(desc), tx.pure.string(url)],
+    typeArguments: ['0x2::sui::SUI'],
+  });
+  ```
+- Multi-return destructuring:
+  ```ts
+  const [nft1, nft2] = tx.moveCall({ target: '0xpkg::mint::two' });
+  tx.transferObjects([nft1, nft2], tx.pure.address(to));
+  ```
+
+## `Publish`
+
+Publish a new Move package.
+
+```
+Publish(ModuleBytes: vector<vector<u8>>, TransitiveDependencies: vector<ObjectID>)
+Returns:  [UpgradeCap]   (sui::package::UpgradeCap)
+```
+
+- `ModuleBytes` must be non-empty.
+- After bytecode verification, each module's `init` function (if present) is called **in the order modules appear** in the byte vector. `init` takes `&mut TxContext` and optionally a one-time witness.
+- The returned `UpgradeCap` is a regular object — you must transfer or consume it (typically `tx.transferObjects([cap], tx.pure.address(deployer))`).
+- TS SDK: `tx.publish({ modules, dependencies })`.
+
+## `Upgrade`
+
+Upgrade an existing Move package.
+
+```
+Upgrade(ModuleBytes, TransitiveDependencies, PackageID, UpgradeTicket)
+Returns:  [UpgradeReceipt]   (sui::package::UpgradeReceipt)
+```
+
+- Takes exactly one PTB argument: the `UpgradeTicket` (by value). The ticket is produced by calling the `UpgradeCap`'s authorization function.
+- Does **not** call `init` on new modules. New modules cannot define `init` (restriction may be lifted).
+- Module digest and package ID in the ticket must match exactly.
+- Upgrade policy (compatible / additive / dep-only) is enforced from the ticket.
+- The `UpgradeReceipt` must be committed back to the `UpgradeCap` via `package::commit_upgrade` (typically another `MoveCall` in the same PTB).
+- TS SDK: `tx.upgrade({ modules, dependencies, packageId, ticket })`.
+
+## Quick reference
+
+| Command | Mutates | Consumes | Returns |
+|---|---|---|---|
+| `TransferObjects` | — | all object args | — |
+| `SplitCoins` | source coin | — | `[Coin<T>]` per amount |
+| `MergeCoins` | dest coin | source coins | — |
+| `MakeMoveVec` | — | element args | `[vector<T>]` |
+| `MoveCall` | per signature | per signature | per signature |
+| `Publish` | — | — | `[UpgradeCap]` |
+| `Upgrade` | — | `UpgradeTicket` | `[UpgradeReceipt]` |

--- a/ptbs/equivocation.md
+++ b/ptbs/equivocation.md
@@ -1,0 +1,146 @@
+# Equivocation — preventing object lock
+
+Equivocation is the **single biggest footgun** for any code that submits Sui transactions concurrently. It locks owned objects (including gas coins) until the next epoch — ~24h on mainnet/testnet, ~1h on devnet.
+
+Source: https://docs.sui.io/concepts/sui-architecture/epochs · https://docs.sui.io/guides/developer/sui-101/avoid-equivocation · https://docs.sui.io/concepts/transactions/sponsored-transactions
+
+## What it is
+
+Equivocation occurs when an owned object pair `(ObjectID, SequenceNumber)` is used concurrently in multiple non-finalized transactions. The canonical definition:
+
+> Equivocation occurs when an owned object pair (`ObjectId`, `SequenceNumber`) is used concurrently in multiple non-finalized transactions.
+
+> Client equivocation occurs when multiple valid transactions that share at least one owned object (such as a gas coin) at the same version are submitted to the network simultaneously.
+
+## Why it locks the object
+
+Validators accept **at most one transaction per (object, version)**. When a validator first sees a tx referencing `(obj, v)`, it locks that object at that version to the tx digest and refuses to sign any other tx at the same version.
+
+If two competing txs are broadcast simultaneously, validators may receive them in different orders. Validator A locks to tx1; validator B locks to tx2. Neither tx collects 2/3 validator signatures ⇒ neither finalizes. The object stays locked until the end of the epoch.
+
+Epoch lengths:
+- Mainnet / Testnet: ~24 hours
+- Devnet: ~1 hour
+
+Result: **neither tx proceeds, and the object cannot be used in any other transaction** for the rest of the epoch.
+
+## How it happens in practice
+
+All real-world causes are variations on "the same owned object was signed into two txs before the first finalized":
+
+1. **Backend service reusing a single gas coin across concurrent requests.** Each incoming request builds and submits a tx; if two requests hit in parallel, the second sees the same gas coin version.
+2. **Stale full node.** A client queries the full node for the gas coin's version, but the node hasn't indexed a recent tx that bumped the version. Two builds see the same stale version.
+3. **Sponsored-transaction flows without object isolation.** A malicious user submits a competing tx using an owned object from the gas station's signed tx — locking the gas station's coin. Symmetrically, a malicious gas station can lock a user's object.
+4. **Wallet plus external signing.** A wallet signs two transactions that both reference the same coin before either finalizes.
+5. **Retries without version refresh.** Client times out, retries, but constructs the retry against the same (now-maybe-committed) object version.
+
+## Punishment
+
+The network has safeguards to punish validators who equivocate — but the *client* side is where most equivocation bugs originate. There's no protocol-level protection for bad client behavior beyond the object lock.
+
+## Prevention
+
+### 1. Batch into a single PTB
+
+Up to 1,024 operations fit in one PTB. One PTB = one signature over one set of object versions = zero equivocation risk. Prefer this whenever the ops come from the same sender.
+
+Bad: 512 separate `transfer` transactions for an airdrop.
+Good: one PTB with 512 `splitCoins`/`transferObjects` pairs against `tx.gas`.
+
+### 2. `SerialTransactionExecutor` (TS SDK)
+
+For wallets / services that own the signing key and are the **only** writer of the address's coins:
+
+```ts
+import { SerialTransactionExecutor } from '@mysten/sui/transactions';
+
+const executor = new SerialTransactionExecutor({
+  client,
+  signer: keypair,
+  defaultBudget: 50_000_000n,   // optional
+});
+
+// Even concurrent calls are serialized internally:
+await Promise.all([
+  executor.executeTransaction(tx1),
+  executor.executeTransaction(tx2),
+  executor.executeTransaction(tx3),
+]);
+```
+
+- On first use, selects all SUI coins at the address, merges into one gas coin, and reuses that coin serially.
+- Internal queue with cached object versions — clients don't need to read RPC between txs.
+- **Assumption:** no other process signs for this address. If another wallet or service is active, this collides.
+
+### 3. `ParallelTransactionExecutor` (experimental)
+
+For higher throughput where you can afford a gas-coin pool:
+
+```ts
+import { ParallelTransactionExecutor } from '@mysten/sui/transactions';
+
+const executor = new ParallelTransactionExecutor({
+  client,
+  signer: keypair,
+  // Tuning:
+  coinBatchSize: 20,              // pool size
+  initialCoinBalance: 200_000_000n,
+  minimumCoinBalance: 50_000_000n,
+  maxPoolSize: 50,
+  epochBoundaryWindow: 1000,       // ms before epoch boundary to pause
+  sourceCoins,                     // optional explicit source
+});
+```
+
+Schedules transactions to avoid object conflicts using a maintained gas-coin pool; auto-refills and locks around epoch boundaries. **Do not run multiple executors or other clients against the same coins concurrently** — that reintroduces the bug it's solving.
+
+### 4. Separate owned object per thread
+
+If multi-threaded client code can't be serialized:
+- Create one owned object (e.g., a coin or a per-worker counter object) for each thread.
+- Each thread signs only against its own object.
+- Gas coins are the most common "shared owned object" that causes equivocation; split enough up-front so every thread has its own.
+
+### 5. Shared-object wrapper with allowlist
+
+When separate owned objects per thread aren't practical, wrap the contested state in a **shared object** with an allowlist. Shared objects are scheduled through consensus, so there's no version-lock issue — at the cost of a sequential bottleneck. Safe, but slower.
+
+### 6. Gas station mitigations
+
+Gas stations are prime equivocation targets. Best practices:
+
+- **Don't reuse the same gas coin across users.** Maintain a pool; each tx gets a dedicated coin.
+- **Sign over the full `TransactionData`** (including `GasData`) on both user and sponsor sides, so a malicious full node can't substitute gas.
+- **Submit directly to a full node**, not via the sponsor, to avoid censorship and shrink the equivocation window.
+- **Monitor and rate-limit users** — repeated failed txs from the same user are a signal.
+- **Counterparty reputation matters.** Treat unknown sponsors as adversaries; treat unknown users the same.
+
+## Recovery — what to do when an object is locked
+
+`sui-tool` provides diagnostics and best-effort rescue:
+
+```bash
+# Check lock status for a specific object
+sui-tool locked-object --fullnode-rpc-url <url> --id <object-id>
+
+# Check all owned gas objects for an address
+sui-tool locked-object --fullnode-rpc-url <url> --address <addr>
+
+# Attempt to unlock (only works if the object isn't already locked by a majority)
+sui-tool locked-object --rescue --fullnode-rpc-url <url> --id <object-id>
+```
+
+Rescue is only possible if **less than a majority** of validators have locked the object to competing txs. Otherwise you wait for the epoch to end.
+
+## Error messages you'll see
+
+- `"Failed to sign transaction by a quorum of validators because one or more of its objects is reserved for another transaction."` → another tx is holding the lock; wait for it or wait for epoch end.
+- `"Failed to sign transaction … objects is equivocated until the next epoch."` → you've equivocated; no recovery except waiting.
+
+## Quick defaults
+
+- **Single user / wallet signer**: use `SerialTransactionExecutor`.
+- **High-throughput backend**: use `ParallelTransactionExecutor` with a gas-coin pool.
+- **Airdrops, batch mints, bulk transfers**: one PTB, up to 1,024 ops.
+- **Sponsored flows**: sign over full `TransactionData`, submit directly to full node.
+- **Never**: submit two transactions from the same signer that touch the same owned object without waiting for the first to finalize.

--- a/ptbs/equivocation.md
+++ b/ptbs/equivocation.md
@@ -2,7 +2,7 @@
 
 Equivocation is the **single biggest footgun** for any code that submits Sui transactions concurrently. It locks owned objects (including gas coins) until the next epoch — ~24h on mainnet/testnet, ~1h on devnet.
 
-Source: https://docs.sui.io/concepts/sui-architecture/epochs · https://docs.sui.io/guides/developer/sui-101/avoid-equivocation · https://docs.sui.io/concepts/transactions/sponsored-transactions
+Source: https://docs.sui.io/concepts/sui-architecture/epochs · https://docs.sui.io/develop/sui-architecture/epochs · https://docs.sui.io/develop/transaction-payment/sponsor-txn
 
 ## What it is
 

--- a/ptbs/evals/evals.json
+++ b/ptbs/evals/evals.json
@@ -3,7 +3,7 @@
     "id": "ptbs-basic-transfer",
     "prompt": "Using the Sui TypeScript SDK, write a function that transfers 100 MIST to the address 0xabc... from the connected wallet in a single transaction. Show me the code.",
     "sources": [
-      "https://docs.sui.io/guides/developer/sui-101/building-ptb",
+      "https://docs.sui.io/develop/transactions/ptbs/building-ptb",
       "https://sdk.mystenlabs.com/typescript/transaction-building/basics"
     ],
     "expected_output": "A TypeScript snippet that imports Transaction from '@mysten/sui/transactions', creates a Transaction, splits the specified amount off tx.gas (not a separately-fetched coin), transfers that new coin to the recipient address, and hands the Transaction off to the wallet via signTransaction/signAndExecuteTransaction. Should not call setGasBudget / setGasPrice / setGasPayment (let the wallet handle gas). Should use typed pure helpers (tx.pure.u64, tx.pure.address).",
@@ -21,7 +21,7 @@
     "prompt": "I need to airdrop variable amounts of SUI to 400 recipients. What's the best way to do this on Sui?",
     "sources": [
       "https://docs.sui.io/concepts/transactions/prog-txn-blocks",
-      "https://docs.sui.io/guides/developer/sui-101/building-ptb",
+      "https://docs.sui.io/develop/transactions/ptbs/building-ptb",
       "https://docs.sui.io/concepts/sui-architecture/epochs"
     ],
     "expected_output": "Recommendation to use a single PTB containing 400 splitCoins + transferObjects pairs against tx.gas, since a PTB supports up to 1024 commands and batching prevents equivocation risk inherent in submitting 400 separate transactions. Includes example code using tx.splitCoins(tx.gas, amounts.map(...)) and a loop calling tx.transferObjects per recipient.",
@@ -55,7 +55,7 @@
     "prompt": "I'm building a backend service that processes incoming webhook events and, for each event, submits a Sui transaction that updates a shared counter object and pays a small reward in SUI from a service-owned address. Requests come in concurrently. What do I need to watch out for and how should I structure the submission?",
     "sources": [
       "https://docs.sui.io/concepts/sui-architecture/epochs",
-      "https://docs.sui.io/guides/developer/sui-101/avoid-equivocation",
+      "https://docs.sui.io/develop/sui-architecture/epochs",
       "https://sdk.mystenlabs.com/typescript/executors"
     ],
     "expected_output": "Explanation of equivocation risk on the service's gas coin when concurrent requests sign against the same owned-object version. Recommends either (a) SerialTransactionExecutor from @mysten/sui/transactions if throughput allows, or (b) ParallelTransactionExecutor with a gas coin pool for higher throughput. Notes that the shared counter is not itself the equivocation risk (shared objects are consensus-ordered) — the owned gas coin is.",
@@ -71,9 +71,9 @@
     "id": "ptbs-sponsored-transaction-flow",
     "prompt": "Explain how to build a sponsored transaction where my app constructs the PTB, a sponsor service pays the gas, and the user signs as sender. Show the code on all three sides.",
     "sources": [
-      "https://docs.sui.io/concepts/transactions/sponsored-transactions",
+      "https://docs.sui.io/develop/transaction-payment/sponsor-txn",
       "https://sdk.mystenlabs.com/typescript/transaction-building/sponsored-transactions",
-      "https://docs.sui.io/guides/developer/sui-101/building-ptb"
+      "https://docs.sui.io/develop/transactions/ptbs/building-ptb"
     ],
     "expected_output": "Three code blocks. (1) App: constructs Transaction, builds kind-only bytes with tx.build({ client, onlyTransactionKind: true }), sends to sponsor. (2) Sponsor: rehydrates with Transaction.fromKind(kindBytes), setSender(userAddress), setGasOwner(sponsorAddress), setGasPayment([…]), signs. (3) User signs over the resulting TransactionData (full data including GasData) and submits. Explanation notes both signatures cover the full TransactionData including GasData, and recommends submitting directly to a full node rather than via the sponsor.",
     "expectations": [
@@ -90,7 +90,7 @@
     "prompt": "Review this PTB for bugs:\n\n```ts\nconst tx = new Transaction();\ntx.moveCall({\n  target: '0xpkg::vault::deposit',\n  arguments: [tx.object(vaultId), tx.gas],\n});\ntx.transferObjects([tx.gas], tx.pure.address(recipient));\n```",
     "sources": [
       "https://docs.sui.io/concepts/transactions/prog-txn-blocks",
-      "https://docs.sui.io/guides/developer/sui-101/building-ptb"
+      "https://docs.sui.io/develop/transactions/ptbs/building-ptb"
     ],
     "expected_output": "Identifies two bugs. (1) tx.gas is passed by value to the deposit moveCall where the function probably expects Coin<SUI> (or &mut Coin<SUI>) — tx.gas can only be used by reference, never by value, except in transferObjects. The fix is to splitCoins off tx.gas first: const [payment] = tx.splitCoins(tx.gas, [tx.pure.u64(amount)]); and pass payment. (2) Even after fixing, if deposit takes the coin by value the gas coin would be consumed and the subsequent transferObjects([tx.gas], ...) would reference a moved value. Corrected version uses splitCoins for a payment coin and either leaves gas alone or transfers it separately.",
     "expectations": [
@@ -104,7 +104,7 @@
     "id": "ptbs-unused-value-error",
     "prompt": "My PTB fails with error 'UnusedValueWithoutDrop { result_idx: 1, secondary_idx: 0 }'. My code is:\n\n```ts\nconst tx = new Transaction();\ntx.moveCall({ target: '0xpkg::game::start_round', arguments: [tx.object(gameId)] });\ntx.moveCall({ target: '0xpkg::game::mint_ticket', arguments: [tx.object(gameId)] });\n```\n\nWhat's wrong and how do I fix it?",
     "sources": [
-      "https://docs.sui.io/references/testing-debugging/common-errors",
+      "https://docs.sui.io/develop/testing-debugging/common-errors",
       "https://docs.sui.io/concepts/transactions/prog-txn-blocks"
     ],
     "expected_output": "Explains that command index 1 (mint_ticket) returns a value without the drop ability (a Ticket object, likely with key + store). Every non-drop value in a PTB must be consumed — transferred, destroyed, or passed into another command. Fix: capture the result and transferObjects it to the sender (or a specified recipient), or pass it into a subsequent moveCall that consumes it.",

--- a/ptbs/evals/evals.json
+++ b/ptbs/evals/evals.json
@@ -1,0 +1,134 @@
+[
+  {
+    "id": "ptbs-basic-transfer",
+    "prompt": "Using the Sui TypeScript SDK, write a function that transfers 100 MIST to the address 0xabc... from the connected wallet in a single transaction. Show me the code.",
+    "sources": [
+      "https://docs.sui.io/guides/developer/sui-101/building-ptb",
+      "https://sdk.mystenlabs.com/typescript/transaction-building/basics"
+    ],
+    "expected_output": "A TypeScript snippet that imports Transaction from '@mysten/sui/transactions', creates a Transaction, splits the specified amount off tx.gas (not a separately-fetched coin), transfers that new coin to the recipient address, and hands the Transaction off to the wallet via signTransaction/signAndExecuteTransaction. Should not call setGasBudget / setGasPrice / setGasPayment (let the wallet handle gas). Should use typed pure helpers (tx.pure.u64, tx.pure.address).",
+    "expectations": [
+      "Imports from '@mysten/sui/transactions'",
+      "Uses tx.splitCoins(tx.gas, [tx.pure.u64(100)]) to derive an owned coin from the gas coin rather than fetching a separate Coin<SUI> object",
+      "Uses tx.transferObjects with tx.pure.address(recipient) — not a raw string argument",
+      "Does NOT call tx.setGasBudget / tx.setGasPrice / tx.setGasPayment for a wallet-signed flow",
+      "Does NOT call tx.build() before handing to the wallet (uses tx.serialize() or passes the Transaction instance directly)",
+      "Checks the execution result status before treating the transfer as successful"
+    ]
+  },
+  {
+    "id": "ptbs-batch-airdrop",
+    "prompt": "I need to airdrop variable amounts of SUI to 400 recipients. What's the best way to do this on Sui?",
+    "sources": [
+      "https://docs.sui.io/concepts/transactions/prog-txn-blocks",
+      "https://docs.sui.io/guides/developer/sui-101/building-ptb",
+      "https://docs.sui.io/concepts/sui-architecture/epochs"
+    ],
+    "expected_output": "Recommendation to use a single PTB containing 400 splitCoins + transferObjects pairs against tx.gas, since a PTB supports up to 1024 commands and batching prevents equivocation risk inherent in submitting 400 separate transactions. Includes example code using tx.splitCoins(tx.gas, amounts.map(...)) and a loop calling tx.transferObjects per recipient.",
+    "expectations": [
+      "Recommends a single PTB over 400 individual transactions",
+      "Mentions the 1024-command PTB limit (not 400 or some other incorrect number)",
+      "Mentions that batching avoids equivocation risk on the gas coin",
+      "Example code uses tx.splitCoins(tx.gas, …) — not fetching a separate Coin<SUI>",
+      "Example iterates over recipients using an index into the splitCoins result (e.g., coins[i])",
+      "Does NOT suggest using transfer::transfer — uses tx.transferObjects"
+    ]
+  },
+  {
+    "id": "ptbs-chained-move-calls",
+    "prompt": "I have a Move function mint_hero that returns a Hero, and another function new_sword(power: u64) that returns a Sword, and a third function equip_sword(hero: Hero, sword: Sword) that returns a Hero. I want to mint a hero, mint a sword with power 10, equip the sword, and transfer the final hero to the sender — all in one transaction. Show me the code.",
+    "sources": [
+      "https://docs.sui.io/concepts/transactions/prog-txn-blocks",
+      "https://docs.sui.io/develop/transactions/ptbs/inputs-and-results"
+    ],
+    "expected_output": "A TypeScript snippet that chains three moveCall commands by passing the result of one as the argument to the next (no intermediate RPC round trips), then calls a fourth moveCall or uses tx.moveCall to 'sui::tx_context::sender' (or sets sender and passes it as a pure) and transfers the final hero with tx.transferObjects. Must not submit multiple transactions or store intermediate objects on-chain between calls.",
+    "expectations": [
+      "Uses a single Transaction (single PTB) for all four operations",
+      "Passes the result of mint_hero directly as an argument to equip_sword (command chaining), not an object ID fetched between transactions",
+      "Passes tx.pure.u64(10) to new_sword — uses typed pure helper, not a raw number or untyped tx.pure",
+      "Uses the final equipped hero result as input to tx.transferObjects, consuming it so no UnusedValueWithoutDrop error occurs",
+      "Does NOT fetch intermediate object IDs via RPC between commands"
+    ]
+  },
+  {
+    "id": "ptbs-equivocation-backend",
+    "prompt": "I'm building a backend service that processes incoming webhook events and, for each event, submits a Sui transaction that updates a shared counter object and pays a small reward in SUI from a service-owned address. Requests come in concurrently. What do I need to watch out for and how should I structure the submission?",
+    "sources": [
+      "https://docs.sui.io/concepts/sui-architecture/epochs",
+      "https://docs.sui.io/guides/developer/sui-101/avoid-equivocation",
+      "https://sdk.mystenlabs.com/typescript/executors"
+    ],
+    "expected_output": "Explanation of equivocation risk on the service's gas coin when concurrent requests sign against the same owned-object version. Recommends either (a) SerialTransactionExecutor from @mysten/sui/transactions if throughput allows, or (b) ParallelTransactionExecutor with a gas coin pool for higher throughput. Notes that the shared counter is not itself the equivocation risk (shared objects are consensus-ordered) — the owned gas coin is.",
+    "expectations": [
+      "Identifies the gas coin (or any owned object) as the equivocation risk, not the shared counter",
+      "Correctly explains that shared objects are not subject to client equivocation because consensus orders them",
+      "Recommends SerialTransactionExecutor or ParallelTransactionExecutor from @mysten/sui — not a naive mutex around client.signAndExecuteTransaction (or if mentioning a mutex, still recommends the executor as the real fix)",
+      "Mentions that equivocation locks the object until the end of the current epoch (~24h on mainnet)",
+      "Does NOT recommend retrying failed txs without refreshing gas coin state — that compounds the problem"
+    ]
+  },
+  {
+    "id": "ptbs-sponsored-transaction-flow",
+    "prompt": "Explain how to build a sponsored transaction where my app constructs the PTB, a sponsor service pays the gas, and the user signs as sender. Show the code on all three sides.",
+    "sources": [
+      "https://docs.sui.io/concepts/transactions/sponsored-transactions",
+      "https://sdk.mystenlabs.com/typescript/transaction-building/sponsored-transactions",
+      "https://docs.sui.io/guides/developer/sui-101/building-ptb"
+    ],
+    "expected_output": "Three code blocks. (1) App: constructs Transaction, builds kind-only bytes with tx.build({ client, onlyTransactionKind: true }), sends to sponsor. (2) Sponsor: rehydrates with Transaction.fromKind(kindBytes), setSender(userAddress), setGasOwner(sponsorAddress), setGasPayment([…]), signs. (3) User signs over the resulting TransactionData (full data including GasData) and submits. Explanation notes both signatures cover the full TransactionData including GasData, and recommends submitting directly to a full node rather than via the sponsor.",
+    "expectations": [
+      "App side uses tx.build({ client, onlyTransactionKind: true }) — NOT a full tx.build()",
+      "Sponsor side uses Transaction.fromKind — NOT Transaction.from",
+      "Sponsor sets setSender, setGasOwner, and setGasPayment",
+      "Mentions both signatures must cover the full TransactionData including GasData",
+      "Recommends user (or either party) submits directly to a full node, not via the sponsor, to avoid censorship",
+      "Flags client-equivocation risk on the gas station's coin and recommends per-user gas coin isolation"
+    ]
+  },
+  {
+    "id": "ptbs-gas-coin-misuse",
+    "prompt": "Review this PTB for bugs:\n\n```ts\nconst tx = new Transaction();\ntx.moveCall({\n  target: '0xpkg::vault::deposit',\n  arguments: [tx.object(vaultId), tx.gas],\n});\ntx.transferObjects([tx.gas], tx.pure.address(recipient));\n```",
+    "sources": [
+      "https://docs.sui.io/concepts/transactions/prog-txn-blocks",
+      "https://docs.sui.io/guides/developer/sui-101/building-ptb"
+    ],
+    "expected_output": "Identifies two bugs. (1) tx.gas is passed by value to the deposit moveCall where the function probably expects Coin<SUI> (or &mut Coin<SUI>) — tx.gas can only be used by reference, never by value, except in transferObjects. The fix is to splitCoins off tx.gas first: const [payment] = tx.splitCoins(tx.gas, [tx.pure.u64(amount)]); and pass payment. (2) Even after fixing, if deposit takes the coin by value the gas coin would be consumed and the subsequent transferObjects([tx.gas], ...) would reference a moved value. Corrected version uses splitCoins for a payment coin and either leaves gas alone or transfers it separately.",
+    "expectations": [
+      "Identifies that tx.gas cannot be used by value as a moveCall argument (only by reference, except in transferObjects)",
+      "Recommends tx.splitCoins(tx.gas, [amount]) to derive an owned coin for the deposit",
+      "Notes the order/move issue: even if the first bug is fixed naively by passing tx.gas by reference, passing tx.gas by value to transferObjects after it's been borrowed must come after all other uses",
+      "Does NOT suggest fetching a separate Coin<SUI> object via RPC as the primary fix"
+    ]
+  },
+  {
+    "id": "ptbs-unused-value-error",
+    "prompt": "My PTB fails with error 'UnusedValueWithoutDrop { result_idx: 1, secondary_idx: 0 }'. My code is:\n\n```ts\nconst tx = new Transaction();\ntx.moveCall({ target: '0xpkg::game::start_round', arguments: [tx.object(gameId)] });\ntx.moveCall({ target: '0xpkg::game::mint_ticket', arguments: [tx.object(gameId)] });\n```\n\nWhat's wrong and how do I fix it?",
+    "sources": [
+      "https://docs.sui.io/references/testing-debugging/common-errors",
+      "https://docs.sui.io/concepts/transactions/prog-txn-blocks"
+    ],
+    "expected_output": "Explains that command index 1 (mint_ticket) returns a value without the drop ability (a Ticket object, likely with key + store). Every non-drop value in a PTB must be consumed — transferred, destroyed, or passed into another command. Fix: capture the result and transferObjects it to the sender (or a specified recipient), or pass it into a subsequent moveCall that consumes it.",
+    "expectations": [
+      "Correctly identifies result_idx: 1 as referring to the second command (mint_ticket), not the second argument",
+      "Explains the general rule: non-drop values must be consumed by end of PTB",
+      "Suggests tx.transferObjects([ticket], tx.pure.address(recipient)) as the fix, capturing the moveCall return via destructuring (const [ticket] = tx.moveCall(...)) or direct use of the result reference",
+      "Does NOT suggest suppressing the error or modifying the Move module to add drop (when that would change semantics) as the first-line fix"
+    ]
+  },
+  {
+    "id": "ptbs-shared-object-rules",
+    "prompt": "I have a shared object representing a liquidity pool. I want a PTB that reads some state from the pool, does a swap, and then deletes the pool object. Is this possible? What are the constraints on shared objects in PTBs?",
+    "sources": [
+      "https://docs.sui.io/concepts/transactions/prog-txn-blocks",
+      "https://docs.sui.io/develop/transactions/ptbs/inputs-and-results"
+    ],
+    "expected_output": "Explains constraints: shared objects cannot be transferred or frozen in a PTB (tx fails at commit). They can be wrapped or converted to dynamic fields mid-execution, but must be re-shared or deleted before the transaction completes — so deleting is allowed. Read-only shared inputs (mutable: false) cannot be used by value; for the stated workflow the pool must be marked mutable. Note that consuming a shared object by value permanently marks its hot-potato clique as hot.",
+    "expectations": [
+      "Correctly states that deleting a shared object mid-PTB IS allowed (re-share or delete are the two legal endings)",
+      "States that transferring or freezing a shared object is NOT allowed and causes tx failure at commit",
+      "Notes the pool must be passed as mutable: true (not read-only) to be consumed",
+      "Mentions that consuming a shared object by value permanently marks the clique as hot, which blocks subsequent non-public entry calls on entangled values",
+      "Does NOT falsely claim shared objects are immutable or that they cannot be deleted"
+    ]
+  }
+]

--- a/ptbs/fundamentals.md
+++ b/ptbs/fundamentals.md
@@ -1,0 +1,164 @@
+# PTB Fundamentals
+
+The data model, execution semantics, and protocol constraints for Sui Programmable Transaction Blocks.
+
+Source: https://docs.sui.io/concepts/transactions/prog-txn-blocks · https://docs.sui.io/develop/transactions/ptbs/inputs-and-results
+
+## Structure
+
+```
+{
+  inputs:   [Input],     // external values (CallArg in Rust)
+  commands: [Command],   // operations executed in order
+}
+```
+
+- Commands execute **in declaration order**.
+- Effects are applied **atomically at the end**. Any failing command reverts the entire block.
+- A PTB can contain up to **1,024 commands**. More intricate flows (loops, conditionals) require publishing a Move package.
+
+Transaction metadata surrounding the PTB:
+- `sender` — address that signed.
+- `gas_data` — `{ payment: [ObjectRef], owner, price, budget }`. Max budget is withdrawn from the gas coin at tx start; unused is refunded.
+- `expiration` — optional epoch; validators reject after.
+- `tx_signatures` — user signature and, for sponsored txs, sponsor signature too.
+
+## Inputs
+
+An `Input` is either an object or a pure (BCS-encoded) value.
+
+### Object inputs — `ObjectArg` variants
+
+- **`ImmOrOwnedObject(ObjectID, SequenceNumber, ObjectDigest)`** — owned by an address, or immutable. Specify a concrete version.
+- **`SharedObject { id, initial_shared_version, mutable }`** — shared object. `initial_shared_version` is the version at which it was first shared (used by consensus routing). `mutable: false` makes it read-only and enables parallel execution across transactions that all read it.
+- **`Receiving(ObjectID, SequenceNumber, ObjectDigest)`** — object owned by *another* object (sent via `TransferObjects` or `sui::transfer::transfer` to an object ID). Has type `sui::transfer::Receiving<T>`; unwrap inside Move with `sui::transfer::receive(&mut parent, receiving)`.
+
+### Pure inputs — allowed BCS types
+
+Pure values are raw BCS bytes. The pure type is **deferred**: bytes are validated against the expected Move type on first use. Allowed:
+
+- Primitives: `u8, u16, u32, u64, u128, u256, bool, address`
+- `std::ascii::String`, `std::string::String` (bytes verified for encoding)
+- `sui::object::ID`
+- `vector<T>` where `T` is itself a valid pure type
+- `std::option::Option<T>` where `T` is itself a valid pure type
+
+The same pure bytes can be used at multiple compatible types if they deserialize cleanly for each.
+
+## The `Argument` enum
+
+Commands reference values via four `Argument` kinds:
+
+- **`Input(u16)`** — input at index `u16` in the `inputs` vector.
+- **`GasCoin`** — the SUI coin paying for gas. Special rules:
+  - Can be used by `&` or `&mut` anywhere.
+  - Can be passed by value **only** to `TransferObjects` (or `sui::coin::send_funds`).
+  - To get an owned `Coin<SUI>` from the gas coin, split it first: `SplitCoins(GasCoin, [amount])`.
+- **`Result(u16)`** — shorthand for `NestedResult(i, 0)`. Valid only when command `i` has exactly one return value.
+- **`NestedResult(u16, u16)`** — `(command_index, result_index_within_that_command)`.
+
+## Results
+
+Each command produces a (possibly empty) vector of typed results:
+
+| Command | Results |
+|---------|---------|
+| `MoveCall` | Whatever the Move function returns (zero or more; no references) |
+| `SplitCoins` | `[Coin<T>, Coin<T>, …]` (one per amount) |
+| `MergeCoins` | empty |
+| `TransferObjects` | empty |
+| `MakeMoveVec` | one `vector<T>` (elements not individually addressable) |
+| `Publish` | `UpgradeCap` |
+| `Upgrade` | `UpgradeReceipt` |
+
+Chaining example (verbatim from the docs):
+```ts
+const tx = new Transaction();
+const hero = tx.moveCall({ target: `0x123::hero::mint_hero`, arguments: [], typeArguments: [] });
+const sword = tx.moveCall({
+  target: `0x123::hero::new_sword`,
+  arguments: [tx.pure.u64(10)],
+  typeArguments: [],
+});
+tx.moveCall({ target: `0x123::hero::equip_sword`, arguments: [hero, sword] });
+```
+
+## Execution semantics
+
+### Start-of-transaction
+
+1. Input objects loaded (ownership + existence validated upstream).
+2. Pure bytes loaded but not yet typed.
+3. **Max gas budget (in MIST) is withdrawn from the gas coin.** Unused gas is refunded at end of execution, even if the gas coin changed owners.
+
+### Argument usage rules
+
+For each argument position:
+- **`&mut T` expected** — mutable borrow. Fails if any other borrow is outstanding.
+- **`&T` expected** — immutable borrow. Fails if a mutable borrow is outstanding; multiple immutable borrows are fine.
+- **`T` expected** — copy if `T: copy`, else move. Objects are always moved because `sui::object::UID` has no `copy`.
+- Using an argument **after it's been moved** fails the transaction.
+- For `copy` + no-`drop` types, the **last use must be by value**.
+
+### Object consumption
+
+- Every value created or returned by a Move command must be **consumed** by end of tx: transferred, destroyed, or passed into another command. Exception: values whose type has `drop` can be left to drop.
+- Shared objects **cannot** be transferred or frozen at tx end (the ops "succeed" during execution but the tx fails at commit).
+- Shared objects can be wrapped or converted to dynamic fields mid-execution, but must be re-shared or deleted before commit.
+- Gas coin returns to its owner; remaining budget refunded.
+
+### Hot-potato cliques (non-public `entry` calls)
+
+Values without `drop` or `store` (hot potatoes) must be consumed before tx end. Cliques track entangled values:
+- Each input starts in its own clique with hot count 0.
+- Using values together as args merges their cliques.
+- Non-public `entry` calls require their argument clique to have hot count **0**.
+- Consuming a hot potato decrements the count.
+- **Consuming a shared object by value permanently marks its clique hot.**
+
+If you're calling non-public entries, resolve hot potatoes (e.g., repay a flash loan) before the entry call.
+
+### End-of-transaction
+
+- Immutable / read-only inputs: skipped.
+- Mutable input objects: returned to original owner.
+- Pure inputs: dropped.
+- Shared objects: must be re-shared or deleted; else tx fails.
+- Results with `drop`: dropped automatically.
+- Results with `copy` but no `drop`: last use must have been by value.
+- Other unused non-`drop` values: transaction error.
+- Gas coin: returned to owner with unused gas refunded.
+
+## Protocol limits
+
+- **Max unique operations per PTB: 1,024.**
+- **Max Move object size: 250 KB.** Exceeding aborts the tx.
+- `vector`-backed collections (`vector`, `VecSet`, `VecMap`, `PriorityQueue`): recommend ≤ 1,000 items. Use `Table`, `Bag`, `ObjectBag`, `ObjectTable`, `LinkedTable` for unbounded or third-party-written collections.
+- `MoveCall` return values **cannot be references** (`&T`, `&mut T`) — restriction may be lifted later.
+- Only `public` functions and `entry` functions (including private `entry` and `public(package) entry`) are callable from a PTB.
+- Shared objects passed as `mutable: false` cannot be used by value.
+- Module-private type parameters cannot be supplied from a PTB — use the `public_*` variants of `transfer::transfer` / `transfer::share_object`.
+
+## Worked execution example
+
+Verbatim from the PTB concept page:
+
+```
+{
+  inputs: [
+    Pure(<@0x808 BCS bytes>),
+    Object(SharedObject { id: market_id, ... }),
+    Pure(<100u64 BCS bytes>),
+  ]
+  commands: [
+    SplitCoins(GasCoin, [Input(2)]),                                // -> [Coin<SUI>]
+    MoveCall("some_package", "some_marketplace", "buy_two", [],
+             [Input(1), NestedResult(0, 0)]),                       // -> [Nft, Nft]
+    TransferObjects([GasCoin, NestedResult(1, 0)], Input(0)),       // gas + first NFT -> 0x808
+    MoveCall("sui", "tx_context", "sender", [], []),                // -> [address]
+    TransferObjects([NestedResult(1, 1)], NestedResult(3, 0)),      // second NFT -> sender
+  ]
+}
+```
+
+State transitions (gas balance shifts, moved-value tracking) are walked through in the source page — consult it if you need the complete trace.

--- a/ptbs/troubleshooting.md
+++ b/ptbs/troubleshooting.md
@@ -1,0 +1,158 @@
+# PTB Troubleshooting
+
+Common errors from failing PTBs, with causes and fixes.
+
+Source: https://docs.sui.io/references/testing-debugging/common-errors · https://docs.sui.io/concepts/transactions/prog-txn-blocks
+
+## `UnusedValueWithoutDrop { result_idx, secondary_idx }`
+
+**Cause:** a Move call produced a value that has no `drop` ability and the PTB didn't consume it. `result_idx` is the command index; `secondary_idx` is the index within that command's return vector.
+
+**Fix:** consume the value. Common options:
+- `tx.transferObjects([value], tx.pure.address(to))` if `value` has `key + store`.
+- Pass it into a later `moveCall` that takes it by value.
+- Call a destructor that the module exposes (e.g., `module::destroy(value)`).
+
+## `VMVerificationOrDeserializationError in command N`
+
+**Cause:** the Move bytecode failed verification. Subcodes include `ZERO_SIZED_STRUCT`, `FIELD_MISSING_TYPE_ABILITY`, `UNKNOWN_VERSION`, `CONSTRAINT_NOT_SATISFIED`, `WRITEREF_WITHOUT_DROP_ABILITY`.
+
+**Fix:** the Move source or toolchain is wrong. Not a PTB-layer issue. Rebuild the package with a matching `sui` CLI version and fix the flagged module.
+
+## `"Failed to sign transaction by a quorum of validators because one or more of its objects is reserved for another transaction."`
+
+**Cause:** the object is locked by a competing in-flight transaction.
+
+**Fix:** wait for the other tx to finalize. If you submitted both, you're about to equivocate — stop the second submission. See `equivocation.md`.
+
+## `"Failed to sign transaction … objects is equivocated until the next epoch."`
+
+**Cause:** two conflicting transactions already signed by different validator groups. Object is locked until epoch end.
+
+**Fix:** no in-epoch recovery. Use `sui-tool locked-object --rescue` if less than a majority locked it; otherwise wait (~24h on mainnet). Then prevent recurrence — see `equivocation.md`.
+
+## `"No valid gas coins found for the transaction."`
+
+**Cause:** the sender has no `Coin<SUI>` sufficient to cover `gas_budget × gas_price`, or all their SUI coins are already used as non-gas inputs.
+
+**Fix:**
+- Fund the address.
+- Don't pass your only SUI coin as a `tx.object(...)` input — use `tx.gas` for gas and split from it.
+- Lower `setGasBudget` if artificially high.
+
+## `ServerError(-32002)`
+
+**Cause:** bucket error for "invalid input at submit time." Includes:
+- Missing object (wrong ID).
+- Stale object version (your full node was behind, or you cached a version across a change).
+- Same object referenced twice in inputs.
+- Input exceeds protocol byte limits.
+- Invalid signature.
+
+**Fix:** re-fetch objects against a fresh full node before building, dedupe input references, verify signature generation.
+
+## Insufficient gas budget
+
+**Symptom:** tx executes but status is failure; effects show the gas coin charged.
+
+**Cause:** `setGasBudget` too low for actual execution cost. The max budget is withdrawn at tx start and the tx aborts without effects except charging the gas input.
+
+**Fix:** let the SDK auto-dry-run and pick the budget (don't call `setGasBudget`), or call `client.dryRunTransactionBlock` first and use the reported `gasUsed`.
+
+## Shared object: cannot be transferred or frozen
+
+**Symptom:** tx passes individual command validation but fails at commit.
+
+**Cause:** passed a shared object to `transferObjects`, or called `transfer::freeze_object` on it mid-PTB.
+
+**Fix:** shared objects must remain shared (or be deleted). Do not attempt to transfer them. For "unshare" patterns, the module must take the shared object, operate, and explicitly re-share before returning.
+
+## Read-only shared object used by value
+
+**Symptom:** validation error referring to shared-object immutability.
+
+**Cause:** passed a shared object as `mutable: false` and then consumed it by value in a command.
+
+**Fix:** either (a) mark the input `mutable: true` when you need value/mutable access, or (b) only use `&T` borrows of the read-only input.
+
+## Module-private type / non-public function
+
+**Symptom:** `"function not callable"` or similar from verifier.
+
+**Causes:**
+- Calling a `public(package)` non-entry function from a PTB.
+- Supplying a type parameter whose constructor is module-private.
+- Calling `transfer::transfer` / `transfer::share_object` on a generic `T` from a PTB (those require a module-private type witness).
+
+**Fix:**
+- Only call `public` or `entry` functions from a PTB.
+- Use `transfer::public_transfer` / `transfer::public_share_object` for generic types with `T: store`.
+- Expose a wrapper `public` / `entry` function in your module if you need to call a restricted internal function from a PTB.
+
+## `tx.gas` misuse
+
+**Symptoms:**
+- `"argument used by value where reference expected"` on `tx.gas`.
+- Gas coin disappears mid-PTB.
+
+**Causes:**
+- Passing `tx.gas` by value to anything except `transferObjects`.
+- Using `tx.gas` after it was passed by value to `transferObjects` — it's gone.
+
+**Fix:**
+- For an owned `Coin<SUI>` derived from gas: `const [coin] = tx.splitCoins(tx.gas, [tx.pure.u64(n)]);`
+- Transfer entire remaining gas balance at end: `tx.transferObjects([tx.gas], to);`
+- Don't reference `tx.gas` after transferring it.
+
+## Multi-return result treated as single value
+
+**Symptom:** type error from the Move layer; argument shape doesn't match.
+
+**Cause:** a `moveCall` that returns multiple values was passed as one argument.
+
+**Fix:** destructure or index.
+```ts
+const [a, b] = tx.moveCall({ target: '0xpkg::m::pair' });
+// or
+const r = tx.moveCall({ target: '0xpkg::m::pair' });
+nextCall(r[0], r[1]);
+```
+
+## Pure input type mismatch
+
+**Symptom:** `"cannot deserialize pure value as type T"` or similar.
+
+**Cause:** used untyped `tx.pure(value)` or mismatched BCS encoding.
+
+**Fix:** use typed helpers (`tx.pure.u64(n)`, `tx.pure.address(addr)`, `tx.pure.string(s)`). For complex types, explicit `tx.pure('vector<u64>', [...])` or `tx.pure(bcs.XYZ.serialize(value))`.
+
+## Shared-object congestion
+
+**Symptom:** shared-object txs take seconds and fail during high contention.
+
+**Cause:** many writers serialized through consensus on the same hot object.
+
+**Fix:**
+- Shard the shared object (many smaller shared objects keyed by hash).
+- Move writes to owned objects and periodically consolidate.
+- For reads, mark the input `mutable: false` so validators can schedule it in parallel.
+
+## Empty input arrays
+
+**Symptom:** pre-execution validation error on `SplitCoins`, `MergeCoins`, `MakeMoveVec`, or `Publish`.
+
+**Cause:** empty amount list, empty source list, empty-but-untyped vector, empty module bytes.
+
+**Fix:**
+- `SplitCoins`: at least one amount.
+- `MergeCoins`: at least one source coin.
+- `MakeMoveVec`: specify `type` when `elements` is empty or non-object.
+- `Publish`: at least one module.
+
+## Sender unset on offline build
+
+**Symptom:** `tx.build()` throws about missing sender.
+
+**Cause:** offline build (no client) without `tx.setSender(...)`.
+
+**Fix:** call `tx.setSender(addr)` before `tx.build()` when not going through a signer that sets it.

--- a/ptbs/troubleshooting.md
+++ b/ptbs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 Common errors from failing PTBs, with causes and fixes.
 
-Source: https://docs.sui.io/references/testing-debugging/common-errors · https://docs.sui.io/concepts/transactions/prog-txn-blocks
+Source: https://docs.sui.io/develop/testing-debugging/common-errors · https://docs.sui.io/concepts/transactions/prog-txn-blocks
 
 ## `UnusedValueWithoutDrop { result_idx, secondary_idx }`
 


### PR DESCRIPTION
## Summary
- Adds a `ptbs/` skill covering Sui Programmable Transaction Blocks: the data model, the seven command types, building with the TypeScript SDK, sponsored transactions, equivocation prevention, and common errors.
- Routes via `SKILL.md` to focused reference files (`fundamentals`, `commands`, `building`, `equivocation`, `troubleshooting`) so only the relevant file loads for a given task.
- Anchors everything to canonical docs (`docs.sui.io/concepts/transactions/prog-txn-blocks`, `sdk.mystenlabs.com/typescript/transaction-building`, equivocation guide) and instructs the agent to fetch from those sources when unsure rather than extrapolating.

## Skill rules worth highlighting
- Never sign two concurrent transactions that touch the same owned object (incl. gas coin) — equivocation locks until the next epoch.
- `tx.gas` must be used by reference, except in `transferObjects`. Derive owned SUI via `tx.splitCoins(tx.gas, [...])`.
- Apps that hand PTBs to a wallet must use `tx.serialize()` (not `tx.build()`) so the wallet does gas coin selection.
- Sponsored flow: `tx.build({ onlyTransactionKind: true })` → sponsor `Transaction.fromKind` + `setSender`/`setGasOwner`/`setGasPayment`; both signatures cover full `TransactionData`.

## Test plan
- [ ] Evals in `ptbs/evals/evals.json` cover: basic transfer, batch airdrop (1024-command limit), chained moveCalls, concurrent backend + equivocation, sponsored flow, gas coin misuse, `UnusedValueWithoutDrop`, shared-object constraints.
- [ ] Each eval has explicit `expectations` asserting patterns to include and pitfalls to avoid.
- [ ] Sources field on each eval points back to the canonical docs page used to verify output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)