### PR TITLE
Add sui-sdks skill

### DIFF
--- a/sui-sdks/SKILL.md
+++ b/sui-sdks/SKILL.md
@@ -63,6 +63,7 @@ If unsure about any specific API in any SDK, fetch from the relevant doc page â€
 | Writing TS/JS code against Sui | typescript + llm-docs |
 | Writing Rust code against Sui | rust |
 | Using pysui / ksui / suikit / sui-go / mofalabs/sui | community |
+| User mentions Go / Python / Dart / Kotlin / Swift / Vue (even casually, e.g. "my team uses Go") | community (always â€” language constraint trumps perf recommendations) |
 | Porting between languages | mapping + (target SDK file) |
 | Migrating from `@mysten/sui.js` / SDK v1 | typescript |
 | Frontend / React integration | route to `frontend-apps` skill first, then typescript here |
@@ -84,7 +85,7 @@ If unsure about any specific API in any SDK, fetch from the relevant doc page â€
 
 ### Rules
 
-1. **Default to TypeScript or Rust.** For any new Sui project, recommend TypeScript (`@mysten/sui`) or Rust (`sui-rust-sdk` crates) unless the user has a strict language constraint that forces a community SDK.
+1. **Default to TypeScript or Rust, but respect language constraints.** For any new Sui project, recommend TypeScript (`@mysten/sui`) or Rust (`sui-rust-sdk` crates) â€” unless the user has named a language (Go, Python, Dart, Kotlin, Swift, Vue) or said "my team uses X". Then `community.md` is the load: name the canonical community SDK (`block-vision/sui-go-sdk` for Go, `pysui` for Python, etc.), flag the staleness risk, and offer FFI-to-Rust as a fallback. Don't just push them to TS/Rust if their team can't use those.
 2. **For TypeScript, always use `@mysten/sui`, never `@mysten/sui.js`.** The `.js`-suffixed package is frozen at v1 and will not receive updates. Legacy code using it should be migrated.
 3. **For TypeScript v2, use `SuiGrpcClient` by default.** `SuiJsonRpcClient` exists for legacy compatibility; `SuiGraphQLClient` is for specialized query flows. See `typescript.md` for the decision.
 4. **For Rust, prefer `sui-rust-sdk` crates over the legacy monorepo `sui-sdk`.** Import `sui-transaction-builder`, `sui-sdk-types`, `sui-crypto`, `sui-rpc` individually â€” pay only for what you use.

--- a/sui-sdks/SKILL.md
+++ b/sui-sdks/SKILL.md
@@ -92,7 +92,7 @@ If unsure about any specific API in any SDK, fetch from the relevant doc page �
 6. **Do not mix v1 and v2 TS patterns.** Code that uses `SuiClient`, `TransactionBlock`, `getFullnodeUrl`, `options: { showEffects }`, `signAndExecuteTransactionBlock`, or `result.effects?.status?.status` is v1. Migrate wholesale or keep everything on v1 — a half-migrated file is a bug surface.
 7. **Community SDK caveat is mandatory.** When recommending or using a community SDK, mention that it's community-maintained and may lag protocol updates. Check the repo's last commit and latest Sui version support before relying on it.
 8. **Frameworks integrate via `$extend()` in v2.** `client.$extend(suins(), deepbook({ address }))` is the v2 pattern. Do not instantiate `SuinsClient` or `DeepBookClient` directly — that's the v1 style.
-9. **Cite the docs when unsure.** Official TS SDK docs live at `sdk.mystenlabs.com`. The inventory list lives at `docs.sui.io/references/sui-sdks`. Rust SDK docs live on `docs.rs` and `mystenlabs.github.io/sui-rust-sdk`.
+9. **Cite the docs when unsure.** Official TS SDK docs live at `sdk.mystenlabs.com`. The inventory list lives at `docs.sui.io/references/sui-sdks`. Rust SDK docs live on `docs.rs` (per-crate) and `mystenlabs.github.io/sui-rust-sdk/<crate_name>/` (e.g., `/sui_transaction_builder/`).
 
 ### Common mistakes
 

--- a/sui-sdks/SKILL.md
+++ b/sui-sdks/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: sui-sdks
+description: >
+  Sui SDK landscape — which SDK to pick (TypeScript, Rust, or community-maintained
+  Python/Go/Dart/Kotlin/Swift), how they map to each other, and how to install and
+  wire each one up. Use when a user is starting a new Sui project in any language,
+  migrating between languages, comparing APIs across SDKs, or asking "what SDK
+  should I use for X?". For deep patterns inside a single SDK, route to that
+  SDK's reference file.
+---
+
+# Sui SDKs
+
+Most AI agents give confusing, outdated, or cross-wired answers about Sui SDKs. This skill fixes the three most common failure modes:
+
+1. **Recommending a community SDK as if it were official.** Only two SDKs are maintained by Mysten Labs: TypeScript (`@mysten/sui`) and Rust (`sui-rust-sdk` family of crates). Everything else is community-maintained.
+2. **Mixing up TypeScript SDK generations.** The old `@mysten/sui.js` package was renamed to `@mysten/sui` at v1.0. The v2 client API (`client.core.*`, `include` instead of `show*`, `SuiGrpcClient` replacing `SuiClient`) is distinct from v1.
+3. **Not using the installed LLM docs.** Every `@mysten/*` package ships `docs/llms-index.md` + topic-specific markdown files to `node_modules`. Agents should read those before answering; they are guaranteed to match the installed version.
+
+All patterns in this skill are derived from:
+- https://docs.sui.io/references/sui-sdks (canonical SDK inventory)
+- https://sdk.mystenlabs.com/sui (TypeScript SDK reference)
+- https://sdk.mystenlabs.com/sui/llm-docs (bundled LLM docs convention)
+- https://github.com/MystenLabs/sui-rust-sdk (Rust SDK source)
+- https://docs.rs/sui-transaction-builder (Rust PTB builder)
+
+If unsure about any specific API in any SDK, fetch from the relevant doc page — do not extrapolate from a different SDK's surface.
+
+---
+
+## Reference files
+
+### typescript — TypeScript SDK (`@mysten/sui` v2)
+**Path:** `typescript.md`
+**Load when:** writing, reviewing, or migrating TypeScript/JavaScript code that imports `@mysten/sui`, constructing PTBs in TS, choosing between `SuiGrpcClient` / `SuiJsonRpcClient` / `SuiGraphQLClient`, using the v2 Core API, or migrating from SDK v1 (`@mysten/sui.js`).
+**Covers:** install, imports, client classes and when to use each, v2 Core API, PTB construction, pure/object inputs, `coinWithBalance` intent, execution & status checking, `waitForTransaction`, keypairs, offline building, sponsored transactions, v1→v2 migration table, `$extend` pattern for kiosk/suins/deepbook/walrus/seal/zksend.
+
+### rust — Rust SDK (`sui-*` crates)
+**Path:** `rust.md`
+**Load when:** writing Rust code that interacts with Sui — CLI tools, backend services, validators, indexers. Also when choosing between the new modular crates and the legacy in-monorepo `sui-sdk` crate.
+**Covers:** the five crates (`sui-sdk-types`, `sui-crypto`, `sui-rpc`, `sui-graphql`, `sui-transaction-builder`), `TransactionBuilder` API with an end-to-end example, signing via `sui-crypto`, gRPC client from `sui-rpc`, relationship to the legacy `sui-sdk` crate, and the "intents" feature flag (high-level `Coin` / `Balance` intents).
+
+### community — Community SDKs (Python, Go, Dart, Kotlin, Swift, Vue)
+**Path:** `community.md`
+**Load when:** a user asks about or is using a non-TS-non-Rust SDK. Also when assessing risk for a language choice (maintainer responsiveness, feature gaps vs official SDKs).
+**Covers:** for each community SDK — repo, maintainer, install, what's supported/not, caveats, and a recommendation on whether to use it or call the Rust/TS SDK from an FFI wrapper instead.
+
+### mapping — Cross-SDK operation mapping
+**Path:** `mapping.md`
+**Load when:** porting code from one SDK to another, writing a polyglot reference, or answering "how do I do X in SDK Y".
+**Covers:** side-by-side tables mapping the 10-or-so core Sui operations (build PTB, split gas, moveCall, transfer, sign & execute, wait, query object / owned objects / balance, dry-run) across the TS and Rust SDKs, with syntactic parallels.
+
+### llm-docs — Using bundled docs from node_modules
+**Path:** `llm-docs.md`
+**Load when:** the agent needs authoritative, version-matched TypeScript API docs before writing code. Always check `node_modules/@mysten/*/docs/llms-index.md` first if it exists.
+**Covers:** the `docs/llms-index.md` convention, which `@mysten/*` packages ship it, how to read the index and target pages, how to wire it into `AGENTS.md` / `CLAUDE.md` for a project.
+
+## Routing guide
+
+| Task | Load |
+|------|------|
+| "Which SDK should I use?" | (this file) + mapping |
+| Writing TS/JS code against Sui | typescript + llm-docs |
+| Writing Rust code against Sui | rust |
+| Using pysui / ksui / suikit / sui-go / mofalabs/sui | community |
+| Porting between languages | mapping + (target SDK file) |
+| Migrating from `@mysten/sui.js` / SDK v1 | typescript |
+| Frontend / React integration | route to `frontend-apps` skill first, then typescript here |
+| PTB semantics deep dive | route to `ptbs` skill, then language-specific file here |
+| Data access patterns (gRPC vs GraphQL vs indexer) | route to `accessing-data` skill |
+| Full project setup | **all reference files** (or the SDK-specific one + llm-docs) |
+| Code review | **all reference files** |
+
+## Skill Content
+
+### Key concepts
+
+- **Two officially-supported SDKs.** TypeScript (`@mysten/sui`) and Rust (`sui-rust-sdk` crates). Both are maintained by Mysten Labs and updated alongside protocol changes.
+- **Everything else is community.** Python (`pysui`), Go (`block-vision/sui-go-sdk`), Dart (`mofalabs/sui`), Kotlin (`mcxross/ksui`), Swift (`opendive/suikit`), Vue (`SuiFansCN/suiue`). They typically lag protocol updates and feature coverage varies. Treat them as best-effort.
+- **The TS SDK has two client generations.** v1 used `SuiClient` + `@mysten/sui.js`. v2 uses `SuiGrpcClient` / `SuiJsonRpcClient` / `SuiGraphQLClient` from `@mysten/sui`. JSON-RPC is deprecated; gRPC is recommended for new code.
+- **The Rust SDK has two generations.** The new modular crates (`sui-sdk-types`, `sui-crypto`, `sui-rpc`, `sui-transaction-builder`) are the recommended surface. The "legacy Rust SDK" is the monolithic `sui-sdk` crate in the sui monorepo; it supports JSON-RPC with forward/backward compatibility and is still used by many existing projects, but is not the recommended target for new code.
+- **Every `@mysten/*` package ships LLM-ready docs.** Look for `node_modules/@mysten/sui/docs/llms-index.md` and follow its pointers before asking the user to clarify APIs. Matches the installed version exactly.
+- **Frameworks on top of SDKs.** `@mysten/dapp-kit` (React wallet integration), `@mysten/kiosk`, `@mysten/suins`, `@mysten/deepbook-v3`, `@mysten/walrus`, `@mysten/seal`, `@mysten/zksend`, `@mysten/enoki` — all are thin layers over `@mysten/sui` and integrate via the v2 `client.$extend(...)` pattern.
+
+### Rules
+
+1. **Default to TypeScript or Rust.** For any new Sui project, recommend TypeScript (`@mysten/sui`) or Rust (`sui-rust-sdk` crates) unless the user has a strict language constraint that forces a community SDK.
+2. **For TypeScript, always use `@mysten/sui`, never `@mysten/sui.js`.** The `.js`-suffixed package is frozen at v1 and will not receive updates. Legacy code using it should be migrated.
+3. **For TypeScript v2, use `SuiGrpcClient` by default.** `SuiJsonRpcClient` exists for legacy compatibility; `SuiGraphQLClient` is for specialized query flows. See `typescript.md` for the decision.
+4. **For Rust, prefer `sui-rust-sdk` crates over the legacy monorepo `sui-sdk`.** Import `sui-transaction-builder`, `sui-sdk-types`, `sui-crypto`, `sui-rpc` individually — pay only for what you use.
+5. **Check `node_modules/@mysten/*/docs/llms-index.md` before writing TS code.** If the project has `@mysten/sui` installed, those docs are the authoritative, version-matched source. Read the index, then the targeted page.
+6. **Do not mix v1 and v2 TS patterns.** Code that uses `SuiClient`, `TransactionBlock`, `getFullnodeUrl`, `options: { showEffects }`, `signAndExecuteTransactionBlock`, or `result.effects?.status?.status` is v1. Migrate wholesale or keep everything on v1 — a half-migrated file is a bug surface.
+7. **Community SDK caveat is mandatory.** When recommending or using a community SDK, mention that it's community-maintained and may lag protocol updates. Check the repo's last commit and latest Sui version support before relying on it.
+8. **Frameworks integrate via `$extend()` in v2.** `client.$extend(suins(), deepbook({ address }))` is the v2 pattern. Do not instantiate `SuinsClient` or `DeepBookClient` directly — that's the v1 style.
+9. **Cite the docs when unsure.** Official TS SDK docs live at `sdk.mystenlabs.com`. The inventory list lives at `docs.sui.io/references/sui-sdks`. Rust SDK docs live on `docs.rs` and `mystenlabs.github.io/sui-rust-sdk`.
+
+### Common mistakes
+
+- **Calling a community SDK "the Python SDK" or "the Go SDK" as if official.** There is no official Python or Go SDK. Name the specific package (`pysui`, `block-vision/sui-go-sdk`) and flag it as community.
+- **Telling users `SuiClient` is the recommended client.** That was v1. v2 uses `SuiGrpcClient` (or `SuiJsonRpcClient` for legacy flows).
+- **Recommending `@mysten/sui.js`.** Deprecated package name. Always `@mysten/sui`.
+- **Confusing the two Rust SDKs.** The new `sui-rust-sdk` crates (on `crates.io` as separate crates like `sui-sdk-types` / `sui-transaction-builder` / `sui-rpc`) are distinct from the legacy `sui-sdk` crate in the sui monorepo. New code should use the former.
+- **Fetching TS docs from the web when they're installed locally.** If the project has `@mysten/sui` installed, read `node_modules/@mysten/sui/docs/llms-index.md` instead — it matches the installed version.
+- **Hardcoding a specific SDK version.** SDK APIs evolve. Prefer "install the latest `@mysten/sui`" and then consult the bundled docs, rather than pinning advice to a version.
+- **Recommending `@mysten/dapp-kit` for backend code.** dApp Kit is a React-oriented frontend framework. Backend or CLI code should use `@mysten/sui` directly. (Route to the `frontend-apps` skill for dApp Kit.)
+- **Using JSON-RPC as the default for any client.** JSON-RPC is deprecated for the TS SDK; the legacy Rust SDK supports it but the new Rust SDK does not. Default to gRPC.

--- a/sui-sdks/community.md
+++ b/sui-sdks/community.md
@@ -1,0 +1,94 @@
+# Community Sui SDKs
+
+**None of these are maintained by Mysten Labs.** They are community-supported and may lag protocol updates. Always check the repo's last commit and whether the latest Sui protocol is supported before relying on one.
+
+Canonical inventory: https://docs.sui.io/references/sui-sdks
+
+## Python — `pysui`
+
+| | |
+|---|---|
+| Repo | https://github.com/FrankC01/pysui |
+| Install | `pip install pysui` · upgrade: `pip install -U --upgrade-strategy eager pysui` |
+| Maintainer | Community (FrankC01) |
+| Protocols | JSON-RPC, GraphQL, gRPC |
+| Supports PTBs | Yes — via `transaction()` with `build()`, `build_and_sign()`, `transaction_data()` |
+
+Most mature community SDK. Sync and async clients. Supports PTB construction and execution.
+
+```python
+from pysui import SuiConfig, SyncClient
+from pysui.sui.sui_txn import SyncTransaction
+
+cfg = SuiConfig.default_config()
+client = SyncClient(cfg)
+txn = SyncTransaction(client=client)
+txn.split_coin(coin=txn.gas, amounts=[1_000_000])
+txn.transfer_objects(transfers=[...], recipient='0x...')
+result = txn.execute(gas_budget='10000000')
+```
+
+Check `docs` directory and `pypi` page for current API — the surface evolves.
+
+## Go — `block-vision/sui-go-sdk`
+
+| | |
+|---|---|
+| Repo | https://github.com/block-vision/sui-go-sdk |
+| Install | `go get github.com/block-vision/sui-go-sdk` |
+| Maintainer | Community (BlockVision) |
+| Protocols | Primarily JSON-RPC |
+
+Other Go SDKs exist (SuiVision, Pattonkan). `block-vision` is the one listed on docs.sui.io; assess staleness before use.
+
+## Dart — `mofalabs/sui`
+
+| | |
+|---|---|
+| Repo | https://github.com/mofalabs/sui |
+| Install | `dart pub add sui` or Flutter `flutter pub add sui` |
+| Maintainer | Community (mofalabs) |
+| Use case | Cross-platform Flutter apps, mobile & web |
+
+## Kotlin — `ksui` (`mcxross/ksui`)
+
+| | |
+|---|---|
+| Repo | https://github.com/mcxross/ksui |
+| Maintainer | Community (mcxross) |
+| Use case | Kotlin Multiplatform; JSON-RPC wrapper + crypto utilities |
+
+## Swift — `SuiKit` (`opendive/suikit`)
+
+| | |
+|---|---|
+| Repo | https://github.com/opendive/suikit |
+| Maintainer | Community (OpenDive) |
+| Use case | Native iOS / macOS apps |
+
+## Vue/TS — `SuiFansCN/suiue`
+
+| | |
+|---|---|
+| Repo | https://github.com/SuiFansCN/suiue |
+| Maintainer | Community |
+| Use case | Vue-based dApp Kit equivalent |
+
+For React, use `@mysten/dapp-kit` instead (official, covered in the `frontend-apps` skill).
+
+## Risk checklist before choosing a community SDK
+
+1. **Last commit date** — more than a few months old is a yellow flag.
+2. **Protocol version compatibility** — does it support the latest Sui release?
+3. **Feature coverage** — PTBs, sponsored tx, object queries, event subscription. Many community SDKs are query-only or lack newer features (e.g., gRPC, intents).
+4. **Issue tracker health** — open issues, responsive maintainer.
+5. **FFI alternative** — if the language constraint is hard and the community SDK is stale, consider wrapping the Rust SDK via FFI (uniffi / pyo3 / napi) rather than relying on an unmaintained library.
+
+## Recommendation decision tree
+
+1. **Can you use TypeScript or Rust?** If yes — stop here, use the official SDK.
+2. **Is Python / Go / Swift / Kotlin / Dart a hard requirement?** Check the relevant community SDK for recent commits + protocol support.
+3. **Is the community SDK stale?** Consider FFI-wrapping the Rust SDK (`sui-rust-sdk`) in your target language.
+4. **Still stuck?** Use the community SDK but flag the staleness risk to the user and be prepared to fall back to JSON-RPC / raw BCS construction.
+
+Always tell the user when they're relying on a community SDK. They may prefer to switch languages for an official SDK.

--- a/sui-sdks/evals/evals.json
+++ b/sui-sdks/evals/evals.json
@@ -1,0 +1,149 @@
+[
+  {
+    "id": "sui-sdks-choose-sdk",
+    "prompt": "I'm building a high-throughput indexer service that reads Sui transactions in near-real-time and writes them into a Postgres database. My team uses Go. What SDK should I use?",
+    "sources": [
+      "https://docs.sui.io/references/sui-sdks",
+      "https://github.com/MystenLabs/sui-rust-sdk",
+      "https://github.com/block-vision/sui-go-sdk"
+    ],
+    "expected_output": "Explains there is no official Go SDK — only the community block-vision/sui-go-sdk is listed on docs.sui.io. Recommends either (a) using the official Rust SDK (sui-rust-sdk crates) behind a Go↔Rust FFI boundary for protocol-accurate access, or (b) using block-vision/sui-go-sdk with a warning about community-maintained staleness risk. Notes that for raw throughput, gRPC via the sui-rpc crate (Rust) is the performance ceiling; JSON-RPC via a community Go SDK is lower-ceiling.",
+    "expectations": [
+      "Correctly states there is NO official Go SDK maintained by Mysten Labs",
+      "Names block-vision/sui-go-sdk as the canonical community Go SDK (matches docs.sui.io listing)",
+      "Mentions the Rust SDK (sui-rust-sdk) as the performance-maximizing alternative, usable via FFI",
+      "Flags community-SDK risk: may lag protocol updates, check last commit",
+      "Does NOT claim the Go SDK is official or maintained by Mysten",
+      "Does NOT recommend the TypeScript SDK for a Go service"
+    ]
+  },
+  {
+    "id": "sui-sdks-ts-client-choice",
+    "prompt": "I'm starting a new Node.js backend that submits transactions and queries state on Sui mainnet. Which TypeScript client class should I use and how do I instantiate it?",
+    "sources": [
+      "https://sdk.mystenlabs.com/sui/clients",
+      "https://sdk.mystenlabs.com/sui"
+    ],
+    "expected_output": "Recommends SuiGrpcClient from '@mysten/sui/grpc' as the default for new code. Shows instantiation with both network and baseUrl parameters, pointing to https://fullnode.mainnet.sui.io:443. Explains SuiJsonRpcClient is legacy (JSON-RPC deprecated) and SuiGraphQLClient is for specialized relational queries. Notes all three share the client.core.* data access API.",
+    "expectations": [
+      "Imports SuiGrpcClient from '@mysten/sui/grpc' (not SuiClient from '@mysten/sui/client')",
+      "Passes BOTH network: 'mainnet' AND baseUrl to the constructor",
+      "Uses the correct mainnet gRPC URL: https://fullnode.mainnet.sui.io:443",
+      "Explicitly labels SuiJsonRpcClient as legacy / JSON-RPC deprecated",
+      "Does NOT use getFullnodeUrl (v1 helper) — that's for v1 SuiClient which was removed",
+      "Does NOT recommend @mysten/sui.js (deprecated package)"
+    ]
+  },
+  {
+    "id": "sui-sdks-bundled-llm-docs",
+    "prompt": "I'm about to write some code against @mysten/sui in my project. Before I do, is there a way to make sure I'm using the exact API for the version I have installed, not a newer or older version?",
+    "sources": [
+      "https://sdk.mystenlabs.com/sui/llm-docs"
+    ],
+    "expected_output": "Explains that every @mysten/* package ships a docs/ directory in node_modules containing llms-index.md (a routing index) plus topic markdown files, and that these match the installed version exactly. Recommends the agent check node_modules/@mysten/sui/docs/llms-index.md first, read the index, then read the targeted page. Suggests wiring this into AGENTS.md or CLAUDE.md so it becomes automatic per-project. Mentions this is more reliable than fetching docs from sdk.mystenlabs.com.",
+    "expectations": [
+      "Mentions the 'docs/llms-index.md' file convention",
+      "Specifies the correct path: node_modules/@mysten/sui/docs/llms-index.md (or equivalent node_modules/@mysten/<pkg>/docs/)",
+      "Explains that these docs match the installed version (not latest web docs)",
+      "Recommends reading llms-index.md first, then targeted page",
+      "Suggests adding guidance to AGENTS.md / CLAUDE.md / .cursorrules",
+      "Does NOT invent a non-existent CLI command or separate npm package for docs"
+    ]
+  },
+  {
+    "id": "sui-sdks-rust-ptb-minimal",
+    "prompt": "Show me a minimal Rust example that builds a PTB transferring 1 SUI from the gas coin to a recipient address, using the new sui-rust-sdk crates (not the legacy monorepo sui-sdk crate). Just the build — no execution.",
+    "sources": [
+      "https://github.com/MystenLabs/sui-rust-sdk",
+      "https://docs.rs/sui-transaction-builder"
+    ],
+    "expected_output": "A Rust snippet importing from sui_sdk_types, sui_transaction_builder. Creates TransactionBuilder::new(), uses tx.pure(&amount_u64), tx.gas(), tx.split_coins(gas, vec![amount]), tx.transfer_objects(coins, recipient_pure), sets sender/gas_budget/gas_price, adds a gas object via ObjectInput::owned, and calls try_build(). Matches the documented minimal example.",
+    "expectations": [
+      "Imports from sui_sdk_types and sui_transaction_builder — NOT from the legacy sui-sdk crate",
+      "Uses TransactionBuilder::new() (not SuiClientBuilder or similar)",
+      "Calls tx.pure(&amount) and tx.gas() — not tx.pure.u64() (which is TypeScript syntax)",
+      "Uses tx.split_coins(gas, vec![amount]) — snake_case, not camelCase",
+      "Calls tx.transfer_objects(coins, recipient) with recipient as a pure input",
+      "Calls tx.set_sender, tx.set_gas_budget, tx.set_gas_price, tx.add_gas_objects",
+      "Uses ObjectInput::owned for the gas coin object ref",
+      "Calls tx.try_build() at the end (offline build)",
+      "Does NOT use sui_sdk::SuiClientBuilder or similar legacy SDK types"
+    ]
+  },
+  {
+    "id": "sui-sdks-v1-to-v2-migration",
+    "prompt": "Migrate this legacy TS code to the current @mysten/sui v2:\n\n```ts\nimport { SuiClient, getFullnodeUrl } from '@mysten/sui.js/client';\nimport { TransactionBlock } from '@mysten/sui.js/transactions';\n\nconst client = new SuiClient({ url: getFullnodeUrl('mainnet') });\nconst txb = new TransactionBlock();\nconst [coin] = txb.splitCoins(txb.gas, [txb.pure(1_000_000)]);\ntxb.transferObjects([coin], txb.pure('0xrecipient'));\n\nconst result = await client.signAndExecuteTransactionBlock({\n  signer: keypair,\n  transactionBlock: txb,\n  options: { showEffects: true },\n});\n\nif (result.effects?.status?.status === 'success') { /* ... */ }\nawait client.waitForTransactionBlock({ digest: result.digest });\n```",
+    "sources": [
+      "https://sdk.mystenlabs.com/sui/migrations/sui-2.0/llms.txt",
+      "https://sdk.mystenlabs.com/sui"
+    ],
+    "expected_output": "The fully migrated v2 file: imports from @mysten/sui (not @mysten/sui.js), uses SuiGrpcClient (or SuiJsonRpcClient) with network + baseUrl (or getJsonRpcFullnodeUrl), Transaction instead of TransactionBlock, typed tx.pure.u64(), tx.pure.address(), signAndExecuteTransaction, transaction: (not transactionBlock:), include: { effects: true }, result.$kind === 'FailedTransaction' check, waitForTransaction.",
+    "expectations": [
+      "All imports from @mysten/sui (subpaths like '@mysten/sui/grpc', '@mysten/sui/transactions') — NO @mysten/sui.js remaining",
+      "TransactionBlock replaced with Transaction everywhere",
+      "SuiClient + getFullnodeUrl replaced with SuiGrpcClient + baseUrl (or SuiJsonRpcClient + getJsonRpcFullnodeUrl)",
+      "Client constructor has the network parameter",
+      "txb.pure(1_000_000) replaced with tx.pure.u64(1_000_000) or tx.pure.u64(1_000_000n)",
+      "txb.pure('0xrecipient') replaced with tx.pure.address('0xrecipient')",
+      "signAndExecuteTransactionBlock replaced with signAndExecuteTransaction",
+      "transactionBlock parameter replaced with transaction",
+      "options: { showEffects: true } replaced with include: { effects: true }",
+      "result.effects?.status?.status === 'success' replaced with $kind-based check (result.$kind !== 'FailedTransaction' or equivalent)",
+      "waitForTransactionBlock replaced with waitForTransaction",
+      "Does NOT leave any v1 patterns in the output"
+    ]
+  },
+  {
+    "id": "sui-sdks-cross-sdk-port",
+    "prompt": "I have this TypeScript code that splits a coin and transfers it. Port it to Rust using the new sui-rust-sdk crates.\n\n```ts\nconst tx = new Transaction();\nconst [coin] = tx.splitCoins(tx.gas, [tx.pure.u64(1_000_000n)]);\ntx.transferObjects([coin], tx.pure.address('0xabc'));\n```",
+    "sources": [
+      "https://docs.rs/sui-transaction-builder",
+      "https://github.com/MystenLabs/sui-rust-sdk"
+    ],
+    "expected_output": "Rust equivalent using sui_transaction_builder::TransactionBuilder, tx.split_coins(tx.gas(), vec![tx.pure(&1_000_000u64)]), tx.transfer_objects(coins, tx.pure(&recipient_address)). Notes the differences: pure uses generic BCS serialization (not a typed helper chain), gas() is a method not a property, method names are snake_case.",
+    "expectations": [
+      "Uses TransactionBuilder::new()",
+      "Uses tx.split_coins (snake_case) not tx.splitCoins",
+      "Uses tx.gas() as a method call, not tx.gas as a field",
+      "Uses tx.pure(&value) with generic BCS — not tx.pure.u64(value) which is TS syntax",
+      "Wraps vec![amount] for the amounts argument",
+      "Calls tx.transfer_objects with the coins result and a pure recipient",
+      "Casts or types the amount as u64 (e.g., 1_000_000u64)",
+      "Points out the API differences (snake_case, generic pure, method gas())"
+    ]
+  },
+  {
+    "id": "sui-sdks-community-caveat",
+    "prompt": "Can I use the Python SDK for Sui? How do I install it?",
+    "sources": [
+      "https://docs.sui.io/references/sui-sdks",
+      "https://github.com/FrankC01/pysui"
+    ],
+    "expected_output": "Clarifies there is no official Python SDK. pysui is the community-maintained Python client for Sui, installed via 'pip install pysui'. Recommends checking repo activity before relying on it. Notes what pysui supports (PTBs, JSON-RPC/GraphQL/gRPC, sync and async clients). Suggests the Rust SDK via a Python FFI wrapper as an alternative if pysui is stale or missing a feature.",
+    "expectations": [
+      "States that there is NO official Python SDK from Mysten Labs",
+      "Names pysui as the community SDK and correctly attributes it to FrankC01",
+      "Gives the correct install command: pip install pysui",
+      "Mentions pysui supports PTBs and execution",
+      "Flags the community-maintained status as a risk factor",
+      "Does NOT claim pysui is official or maintained by Mysten Labs"
+    ]
+  },
+  {
+    "id": "sui-sdks-frontend-boundary",
+    "prompt": "I'm building a React frontend that lets users connect their wallet and submit a transaction. Should I use @mysten/sui, @mysten/dapp-kit, or both?",
+    "sources": [
+      "https://sdk.mystenlabs.com/dapp-kit",
+      "https://sdk.mystenlabs.com/sui"
+    ],
+    "expected_output": "Explains both are needed. @mysten/dapp-kit handles wallet connection, React hooks (useCurrentAccount, useSignAndExecuteTransaction, useSuiClient), and UI components. The underlying Transaction construction uses @mysten/sui's Transaction class — dapp-kit wraps submission. The pattern: build the Transaction with @mysten/sui, hand it to a dapp-kit hook for wallet signing. Notes that dapp-kit is the React-specific layer; for Vue use SuiFansCN/suiue (community); for vanilla JS the core-package handles everything.",
+    "expectations": [
+      "Recommends BOTH @mysten/sui (transaction construction) AND @mysten/dapp-kit (wallet + hooks)",
+      "Mentions specific dapp-kit hooks like useCurrentAccount, useSignAndExecuteTransaction, useSuiClient",
+      "Explains the role separation: @mysten/sui for Transaction/client, dapp-kit for wallet + React bindings",
+      "Notes that dapp-kit wraps submission, it doesn't replace @mysten/sui's Transaction",
+      "Does NOT tell the user they can pick one or the other (both are needed for React wallet flow)",
+      "Does NOT confuse dapp-kit with @mysten/sui as if they were alternatives"
+    ]
+  }
+]

--- a/sui-sdks/llm-docs.md
+++ b/sui-sdks/llm-docs.md
@@ -1,0 +1,89 @@
+# Using bundled LLM docs from `@mysten/*` packages
+
+Source: https://sdk.mystenlabs.com/sui/llm-docs
+
+Every `@mysten/*` npm package ships markdown documentation alongside its compiled code, designed for AI coding agents to read at runtime. These docs live in `node_modules` and match the installed version exactly — no staleness, no hallucination about a newer or older API than what's actually installed.
+
+## The convention
+
+When you install `@mysten/sui`, the package contains:
+
+```
+node_modules/@mysten/sui/
+├── docs/
+│   ├── llms-index.md       # routing index with page descriptions
+│   ├── transactions.md     # topic-specific references
+│   ├── client.md
+│   └── ...
+├── dist/                   # compiled code
+└── package.json
+```
+
+From the official docs: *"When you install an SDK package, you automatically get accurate, up-to-date documentation that coding agents (Claude Code, Cursor, Copilot, and others) can read directly."*
+
+## How to use them
+
+**Step 1: Check for the index.**
+
+Before answering a TypeScript API question, check whether the project has `@mysten/sui` (or other `@mysten/*` packages) installed:
+
+```bash
+ls node_modules/@mysten/
+cat node_modules/@mysten/sui/docs/llms-index.md
+```
+
+**Step 2: Read the index, then the targeted page.**
+
+`llms-index.md` is a routing guide — it tells you which page covers which topic. Read that first, then load only the specific page(s) you need.
+
+**Step 3: Cite the local path if referring to docs.**
+
+When recommending a pattern, mention you verified it against `node_modules/@mysten/sui/docs/<page>.md` so the user knows the answer is version-matched.
+
+## Which packages ship docs
+
+All modern `@mysten/*` packages, including:
+- `@mysten/sui` — core SDK
+- `@mysten/dapp-kit` — React wallet integration
+- `@mysten/kiosk`
+- `@mysten/suins`
+- `@mysten/deepbook-v3`
+- `@mysten/walrus`
+- `@mysten/seal`
+- `@mysten/zksend`
+- `@mysten/enoki`
+
+Check each package's `node_modules/@mysten/<name>/docs/` for its `llms-index.md`.
+
+## Wiring it into a project's agent config
+
+The official recommendation is to add a guidance snippet to `AGENTS.md`, `CLAUDE.md`, or `.cursorrules` in the project root:
+
+```markdown
+When working with @mysten/* packages, find relevant docs by looking for
+`docs/llms-index.md` files inside `node_modules/@mysten/*/`. Read the index
+first to find the page you need, then read that page for details.
+```
+
+This way, any agent opened in the project will know to consult the bundled docs before answering.
+
+## Why this matters
+
+- **Version accuracy.** SDK APIs evolve. A file on `sdk.mystenlabs.com/sui` shows the latest; the project's `node_modules` shows what's installed. If the user is on `@mysten/sui@2.3`, the web docs may describe `@mysten/sui@2.5` features that don't exist in their install.
+- **No round trip.** No need to `WebFetch` — faster, and works offline.
+- **Canonical source.** The bundled docs are the docs the SDK authors ship; they won't conflict with the code.
+
+## When to use the web docs instead
+
+- The user isn't in a project with `@mysten/sui` installed (e.g., they're designing a new app and asking general questions).
+- The project has an old `@mysten/sui.js` and you need the new v2 API for a migration answer.
+- The bundled docs don't cover the specific topic (rare).
+
+## Fallback: the public URL
+
+If bundled docs aren't available, the authoritative web source is:
+- https://sdk.mystenlabs.com/sui — v2 API reference
+- https://sdk.mystenlabs.com/sui/llms.txt — aggregated LLM-friendly text file
+- https://sdk.mystenlabs.com/sui/migrations/sui-2.0/llms.txt — full v1→v2 migration
+
+Prefer the bundled docs when they exist.

--- a/sui-sdks/mapping.md
+++ b/sui-sdks/mapping.md
@@ -1,0 +1,164 @@
+# Cross-SDK Mapping
+
+Side-by-side mapping of common Sui operations across the two officially-supported SDKs (TypeScript and Rust) and the most-used community SDK (Python). Use this when porting code or answering "how do I do X in SDK Y".
+
+All examples assume a signer is available.
+
+## Install
+
+| SDK | Install |
+|---|---|
+| TypeScript (official) | `npm install @mysten/sui` |
+| Rust (official, new) | `cargo add sui-sdk-types sui-transaction-builder sui-crypto sui-rpc` |
+| Rust (legacy) | Depend on `sui-sdk` from `MystenLabs/sui` monorepo |
+| Python (community, pysui) | `pip install pysui` |
+
+## Client initialization
+
+| Op | TypeScript | Rust (new) |
+|---|---|---|
+| gRPC client | `new SuiGrpcClient({ network, baseUrl })` | `sui_rpc::client::Client::new(url)` |
+| JSON-RPC client | `new SuiJsonRpcClient({ network, url: getJsonRpcFullnodeUrl(n) })` | use legacy `sui-sdk` crate |
+| GraphQL client | `new SuiGraphQLClient({ network, url })` | `sui_graphql::client::Client::new(url)` |
+
+## Build a PTB
+
+### TypeScript
+
+```ts
+import { Transaction } from '@mysten/sui/transactions';
+const tx = new Transaction();
+```
+
+### Rust
+
+```rust
+use sui_transaction_builder::TransactionBuilder;
+let mut tx = TransactionBuilder::new();
+```
+
+### Python (pysui)
+
+```python
+from pysui.sui.sui_txn import SyncTransaction
+txn = SyncTransaction(client=client)
+```
+
+## Core operations
+
+### Split from gas
+
+| TS | `const [coin] = tx.splitCoins(tx.gas, [1_000_000]);` |
+|---|---|
+| Rust | `let coin = tx.split_coins(tx.gas(), vec![tx.pure(&1_000_000u64)]);` |
+| Python | `coin = txn.split_coin(coin=txn.gas, amounts=[1_000_000])` |
+
+### Move call
+
+| TS | `tx.moveCall({ target: 'pkg::m::f', arguments: [a, b], typeArguments: ['0x2::sui::SUI'] });` |
+|---|---|
+| Rust | `tx.move_call(Function::new(pkg, "m", "f", vec![type_arg]), vec![a, b]);` |
+| Python | `txn.move_call(target='pkg::m::f', arguments=[a, b], type_arguments=['0x2::sui::SUI'])` |
+
+### Transfer objects
+
+| TS | `tx.transferObjects([obj], tx.pure.address(to));` |
+|---|---|
+| Rust | `tx.transfer_objects(vec![obj], tx.pure(&to));` |
+| Python | `txn.transfer_objects(transfers=[obj], recipient=to)` |
+
+### Pure inputs
+
+| TS | `tx.pure.u64(100n)` / `tx.pure.address('0x..')` / `tx.pure.string('s')` |
+|---|---|
+| Rust | `tx.pure(&100u64)` / `tx.pure(&address)` / `tx.pure(&"s".to_string())` |
+| Python | `SuiU64(100)` / `SuiAddress('0x..')` / `SuiString('s')` (passed as arguments) |
+
+### Object input
+
+| TS | `tx.object('0x...')` (SDK resolves) |
+|---|---|
+| Rust | `tx.input(ObjectInput::owned(id, version, digest))` (you supply ref) |
+| Python | `ObjectID('0x...')` passed as an argument |
+
+### Sign & execute
+
+| TS | `const result = await client.signAndExecuteTransaction({ signer, transaction: tx });` |
+|---|---|
+| Rust | build → sign with `sui-crypto` → `client.transaction_execution_service().execute_transaction(tx, vec![sig]).await` |
+| Python | `result = txn.execute(gas_budget='10000000')` |
+
+### Wait for indexing
+
+| TS | `await client.waitForTransaction({ digest });` |
+|---|---|
+| Rust | Poll `ledger_service().get_transaction(digest)` until finalized |
+| Python | `client.wait_for_transaction(digest)` |
+
+### Dry run / simulate
+
+| TS | `await client.core.simulateTransaction({ transaction: tx, sender });` |
+|---|---|
+| Rust | `client.transaction_execution_service().dry_run_transaction(...).await` |
+| Python | `txn.inspect_for_result()` / `txn.inspect_all()` |
+
+## Data access
+
+### Get one object
+
+| TS | `await client.core.getObject({ objectId, include: { content: true } });` |
+|---|---|
+| Rust | `client.ledger_service().get_object(ObjectId, read_mask).await` |
+| Python | `client.get_object('0x...')` |
+
+### List owned objects (paginated)
+
+| TS | `await client.core.listOwnedObjects({ owner });` |
+|---|---|
+| Rust | `client.ledger_service().list_owned_objects(...).await` |
+| Python | `client.get_owned_objects(owner='0x...')` |
+
+### List balances
+
+| TS | `await client.core.listBalances({ owner });` |
+|---|---|
+| Rust | `client.ledger_service().list_balances(owner).await` |
+| Python | `client.get_all_balances(owner='0x...')` |
+
+### Get transaction
+
+| TS | `await client.core.getTransaction({ digest, include: { effects: true } });` |
+|---|---|
+| Rust | `client.ledger_service().get_transaction(digest).await` |
+| Python | `client.get_transaction(digest=...)` |
+
+## Error / status shape
+
+| TS | `if (result.$kind === 'FailedTransaction') { ... }` |
+|---|---|
+| Rust | Check `response.effects.status` — `TransactionStatus::Success` vs `::Failure(err)` |
+| Python | Check `result.is_ok()` and inspect `result.result_data` |
+
+## Feature matrix
+
+| Feature | TS (official) | Rust (new) | Python (pysui) |
+|---|---|---|---|
+| PTB construction | ✅ | ✅ | ✅ |
+| gRPC | ✅ (`SuiGrpcClient`) | ✅ (`sui-rpc`) | ✅ |
+| JSON-RPC | ✅ (`SuiJsonRpcClient`, deprecated) | ❌ (use legacy `sui-sdk`) | ✅ |
+| GraphQL | ✅ (`SuiGraphQLClient`) | ✅ (`sui-graphql`) | ✅ |
+| Coin intents | ✅ (`coinWithBalance`) | ✅ (`Coin`, `Balance` intents) | partial |
+| MVR name resolution | ✅ (automatic v2) | depends on crate | ❌ |
+| Sponsored transactions | ✅ | ✅ | ✅ |
+| Multi-sig | ✅ | ✅ | ✅ |
+| zkLogin | ✅ | ✅ | partial |
+| Ecosystem extensions (suins, deepbook, etc.) | ✅ (`$extend`) | manual / none | manual |
+| wasm build | ✅ | ✅ (designed for it) | N/A |
+
+## Porting gotchas
+
+- **Object input**: TS resolves versions automatically (`tx.object('0x..')`); Rust requires you to supply the `ObjectInput` ref. When porting TS → Rust, insert a preparatory `client.ledger_service().get_object(...)` to fetch the ref first.
+- **Pure typing**: TS uses typed helpers (`tx.pure.u64`); Rust uses generic BCS serialization (`tx.pure(&value)`). The Python SDK passes typed wrapper classes (`SuiU64`).
+- **Async model**: Rust is explicitly async (`.await` everywhere); TS is async but the builder is sync until `.build` or `.sign`; pysui has both sync and async clients — don't mix in the same program.
+- **Gas config defaults**: TS auto-resolves gas via dry-run; Rust's offline `try_build` does not — you must set budget/price or use the `intents` feature with `build(client).await`.
+- **Response shape**: TS uses `$kind` discriminant; Rust returns typed enum variants; pysui wraps in a result object. Don't assume shape parity.

--- a/sui-sdks/mapping.md
+++ b/sui-sdks/mapping.md
@@ -113,9 +113,9 @@ txn = SyncTransaction(client=client)
 
 ### List owned objects (paginated)
 
-| TS | `await client.core.listOwnedObjects({ owner });` |
+| TS | `await client.core.listOwnedObjects({ owner, filter: { StructType }, limit: 50 });` |
 |---|---|
-| Rust | `client.ledger_service().list_owned_objects(...).await` |
+| Rust | `client.state_service().list_owned_objects(owner, object_type).await` |
 | Python | `client.get_owned_objects(owner='0x...')` |
 
 ### List balances

--- a/sui-sdks/rust.md
+++ b/sui-sdks/rust.md
@@ -1,0 +1,192 @@
+# Sui Rust SDK
+
+Source: https://github.com/MystenLabs/sui-rust-sdk · https://docs.rs/sui-transaction-builder · https://mystenlabs.github.io/sui-rust-sdk/
+
+## Which Rust SDK
+
+There are two. They serve different projects:
+
+- **Recommended: `sui-rust-sdk` family of crates** (this page). Modular, published on `crates.io` as independent crates. Pay only for what you use, wasm-compatible where possible.
+- **Legacy: the `sui-sdk` crate in the `MystenLabs/sui` monorepo.** Monolithic, JSON-RPC-based, forward/backward-compatible. Still used by many existing projects but not the recommended target for new code. Docs: https://docs.sui.io/references/rust-sdk.
+
+New code → use the modular crates. Existing code on the legacy `sui-sdk` crate → can stay there; migrate if you need gRPC or want to drop JSON-RPC.
+
+## Crates
+
+From https://github.com/MystenLabs/sui-rust-sdk:
+
+| Crate | Purpose |
+|---|---|
+| `sui-sdk-types` | Core types: `Address`, `Transaction`, `ObjectId`, `Digest`, `Identifier`, etc. Required by all other crates. |
+| `sui-crypto` | Keypair types, signing, signature verification. Ed25519, Secp256k1, Secp256r1. |
+| `sui-transaction-builder` | `TransactionBuilder` — the PTB builder. Mirrors the TS SDK's `Transaction` class. |
+| `sui-rpc` | gRPC client for interacting with a fullnode. |
+| `sui-graphql` | GraphQL client. |
+| `sui-graphql-macros` | Macros supporting `sui-graphql`. |
+| `proto-build` | Internal build helpers for protobuf compilation. |
+
+Design goals (from the repo README):
+- **Modular** — only pay for what you use.
+- **Light** — minimal dependency footprint.
+- **wasm-friendly** where possible.
+
+## Minimum viable `Cargo.toml`
+
+For a CLI that builds, signs, and submits a PTB via gRPC:
+
+```toml
+[dependencies]
+sui-sdk-types = "..."
+sui-transaction-builder = "..."
+sui-crypto = "..."
+sui-rpc = "..."
+```
+
+Pin versions from `crates.io` — the crates version independently. Check [docs.rs](https://docs.rs/sui-transaction-builder) for the latest.
+
+## `TransactionBuilder` — core PTB API
+
+The canonical minimal example, from the `sui-transaction-builder` crate docs:
+
+```rust
+use sui_sdk_types::Address;
+use sui_sdk_types::Digest;
+use sui_transaction_builder::ObjectInput;
+use sui_transaction_builder::TransactionBuilder;
+
+let mut tx = TransactionBuilder::new();
+
+// Split 1 SUI from the gas coin
+let amount = tx.pure(&1_000_000_000u64);
+let gas = tx.gas();
+let coins = tx.split_coins(gas, vec![amount]);
+
+// Transfer to recipient
+let recipient = tx.pure(&Address::ZERO);
+tx.transfer_objects(coins, recipient);
+
+// Metadata
+tx.set_sender(Address::ZERO);
+tx.set_gas_budget(500_000_000);
+tx.set_gas_price(1000);
+tx.add_gas_objects([ObjectInput::owned(Address::ZERO, 1, Digest::ZERO)]);
+
+let transaction = tx.try_build().expect("build should succeed");
+```
+
+### Method mapping (TypeScript ↔ Rust)
+
+| TypeScript | Rust |
+|---|---|
+| `new Transaction()` | `TransactionBuilder::new()` |
+| `tx.pure.u64(n)` / `tx.pure('u64', n)` | `tx.pure(&n)` (generic over `BCS`-serializable) |
+| `tx.object('0x...')` | `tx.input(ObjectInput::owned(...))` / `ObjectInput::shared(...)` / `ObjectInput::receiving(...)` |
+| `tx.gas` | `tx.gas()` |
+| `tx.splitCoins(coin, amounts)` | `tx.split_coins(coin, vec![amounts])` |
+| `tx.mergeCoins(dest, srcs)` | `tx.merge_coins(dest, srcs)` |
+| `tx.transferObjects(objs, addr)` | `tx.transfer_objects(objs, addr)` |
+| `tx.moveCall({ target, arguments, typeArguments })` | `tx.move_call(Function::new(pkg, module, name, type_args), args)` |
+| `tx.makeMoveVec({ type, elements })` | `tx.make_move_vec(Some(type), elements)` |
+| `tx.publish({ modules, dependencies })` | `tx.publish(modules, dependencies)` |
+| `tx.upgrade({ modules, dependencies, packageId, ticket })` | `tx.upgrade(modules, deps, pkg_id, ticket)` |
+| `tx.setSender(addr)` | `tx.set_sender(addr)` |
+| `tx.setGasBudget(n)` | `tx.set_gas_budget(n)` |
+| `tx.setGasPrice(n)` | `tx.set_gas_price(n)` |
+| `tx.setGasPayment([refs])` | `tx.add_gas_objects(refs)` |
+
+### Build methods
+
+- `tx.try_build()` — offline build; fails if intents or missing metadata remain.
+- `tx.build(client).await` — async build that resolves intents and auto-fills gas via an RPC client. Requires the `intents` feature flag (**enabled by default**).
+
+## Intents (`intents` feature)
+
+Analogous to the TS SDK's `coinWithBalance`:
+
+```rust
+use sui_transaction_builder::intent::{Coin, Balance};
+```
+
+Two high-level intents:
+- `Coin` — produces a coin with a specified balance, handling selection/merge/split automatically.
+- `Balance` — abstract balance manipulation.
+
+Resolved by `tx.build(client).await`.
+
+Disable via `default-features = false` if you don't want the runtime / client dependency:
+
+```toml
+sui-transaction-builder = { version = "...", default-features = false }
+```
+
+## Signing (`sui-crypto`)
+
+```rust
+use sui_crypto::ed25519::Ed25519PrivateKey;
+use sui_crypto::SuiKeyPair;
+
+let kp = SuiKeyPair::Ed25519(Ed25519PrivateKey::generate(&mut rng));
+let address = kp.public().derive_address();
+let signature = kp.sign_transaction(&transaction)?;
+```
+
+(Exact API evolves — consult `docs.rs/sui-crypto` for the current surface.)
+
+## Execution (`sui-rpc`)
+
+The `sui-rpc` crate is the gRPC client. Pattern:
+
+```rust
+use sui_rpc::client::Client;
+
+let client = Client::new("https://fullnode.mainnet.sui.io:443")?;
+let response = client
+    .transaction_execution_service()
+    .execute_transaction(transaction, vec![signature])
+    .await?;
+```
+
+Services mirror the TS SDK's service clients:
+- `transaction_execution_service`
+- `ledger_service` — object reads, transaction reads
+- `move_package_service` — package / function introspection
+- `name_service` — SuiNS
+
+## Querying with GraphQL
+
+Use `sui-graphql` when gRPC doesn't cover a relational query (e.g., "all NFTs of type X owned by address Y with field Z > N"):
+
+```rust
+use sui_graphql::client::Client;
+
+let gql = Client::new("https://graphql.mainnet.sui.io/graphql")?;
+```
+
+Typed queries are built with `sui-graphql-macros`.
+
+## Legacy `sui-sdk` crate (older monolithic)
+
+Lives in `MystenLabs/sui/crates/sui-sdk`. Monolithic, JSON-RPC-based.
+
+```rust
+use sui_sdk::SuiClientBuilder;
+
+let client = SuiClientBuilder::default().build("https://fullnode.mainnet.sui.io:443").await?;
+let owned = client.read_api().get_owned_objects(address, None, None, None).await?;
+```
+
+When to use:
+- Existing codebase already uses it.
+- You need JSON-RPC compatibility with older fullnodes.
+
+Otherwise: migrate to the new modular crates.
+
+Legacy docs: https://docs.sui.io/references/rust-sdk
+
+## Common mistakes
+
+- **Using both `sui-sdk` (legacy) and `sui-rust-sdk` crates in the same project.** Type conflicts. Pick one.
+- **Skipping `set_sender` / `set_gas_budget` / `set_gas_price` on offline builds.** `try_build` will fail. For online builds with the `intents` feature, `build(client).await` auto-fills gas.
+- **Using `tx.pure(&value)` for an object argument.** Object inputs go through `tx.input(ObjectInput::...)`. Pure is only for BCS-encodable value types.
+- **Assuming the Rust SDK tracks the TS SDK's API shape exactly.** Method names are similar (`split_coins` vs `splitCoins`) but the argument types and async-ness differ. Check `docs.rs` for the exact signature.
+- **Forgetting `.await` on `tx.build(client)`.** Offline `try_build()` is sync and returns `Result<Transaction>`; `build(client)` is async.

--- a/sui-sdks/rust.md
+++ b/sui-sdks/rust.md
@@ -1,6 +1,6 @@
 # Sui Rust SDK
 
-Source: https://github.com/MystenLabs/sui-rust-sdk · https://docs.rs/sui-transaction-builder · https://mystenlabs.github.io/sui-rust-sdk/
+Source: https://github.com/MystenLabs/sui-rust-sdk · https://docs.rs/sui-transaction-builder · https://mystenlabs.github.io/sui-rust-sdk/sui_transaction_builder/
 
 ## Which Rust SDK
 

--- a/sui-sdks/typescript.md
+++ b/sui-sdks/typescript.md
@@ -142,18 +142,27 @@ All common data access methods live under `client.core`:
 ```ts
 await client.core.getObject({ objectId, include: { content: true } });
 await client.core.getObjects({ objectIds: [...], include: { content: true } });
-await client.core.listOwnedObjects({ owner });           // paginated
-await client.core.listCoins({ owner, coinType });        // paginated
+await client.core.listOwnedObjects({
+  owner,
+  filter: { StructType: '0xpkg::nft::NFT' },   // type filter goes under `filter`
+  limit: 50,
+});
+await client.core.listCoins({ owner, coinType, limit: 50 });
 await client.core.listBalances({ owner });
-await client.core.listDynamicFields({ parent });         // paginated
-await client.core.getDynamicField({ parent, name });
+await client.core.listDynamicFields({ parentId, limit: 50 });   // parentId, not parent
+await client.core.getDynamicField({ parentId, name });
+await client.core.getCoinMetadata({ coinType });
 await client.core.getTransaction({ digest, include: {...} });
-await client.core.simulateTransaction({ transaction: tx, sender });
+await client.core.simulateTransaction({ transaction: tx });
 await client.core.executeTransaction({ transaction: bytes, signatures: [...], include: {...} });
 ```
 
-**Include options** (replaces v1's `options: { show*: true }`):
-`effects`, `events`, `balanceChanges`, `objectTypes`, `transaction`, `bcs`, `content`.
+Pagination: core `list*` methods return a single nullable `cursor`. Iterate while non-null, passing it back as the next call's `cursor`.
+
+**Include options** (replaces v1's `options: { show*: true }`). Keys differ by method:
+- Object reads (`getObject`, `getObjects`, `listOwnedObjects`): `content`, `previousTransaction`, `json`, `objectBcs`, `display`.
+- Transaction reads (`getTransaction`, `waitForTransaction`): `effects`, `events`, `balanceChanges`, `transaction`, `bcs`.
+- Simulation (`simulateTransaction`): adds `commandResults`.
 
 ## Execution
 

--- a/sui-sdks/typescript.md
+++ b/sui-sdks/typescript.md
@@ -1,0 +1,290 @@
+# Sui TypeScript SDK (`@mysten/sui` v2)
+
+Source: https://sdk.mystenlabs.com/sui · https://sdk.mystenlabs.com/typescript
+
+Install:
+```bash
+npm install @mysten/sui
+```
+
+**Never** `npm install @mysten/sui.js` — frozen at v1.
+
+All imports use subpath exports:
+```ts
+import { Transaction } from '@mysten/sui/transactions';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+```
+
+## Clients (v2)
+
+Three client classes, all requiring explicit `network`:
+
+```ts
+// Recommended — gRPC, best performance, typed protobuf
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+const client = new SuiGrpcClient({
+  network: 'mainnet',
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
+});
+
+// Legacy — JSON-RPC, still widely deployed
+import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
+const client = new SuiJsonRpcClient({
+  network: 'mainnet',
+  url: getJsonRpcFullnodeUrl('mainnet'),
+});
+
+// Specialized — GraphQL queries
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
+const gql = new SuiGraphQLClient({
+  network: 'mainnet',
+  url: 'https://graphql.mainnet.sui.io/graphql',
+});
+```
+
+### Network URLs
+
+| Network | gRPC | GraphQL | JSON-RPC helper |
+|---|---|---|---|
+| Mainnet | `https://fullnode.mainnet.sui.io:443` | `https://graphql.mainnet.sui.io/graphql` | `getJsonRpcFullnodeUrl('mainnet')` |
+| Testnet | `https://fullnode.testnet.sui.io:443` | `https://graphql.testnet.sui.io/graphql` | `getJsonRpcFullnodeUrl('testnet')` |
+| Devnet | `https://fullnode.devnet.sui.io:443` | `https://graphql.devnet.sui.io/graphql` | `getJsonRpcFullnodeUrl('devnet')` |
+
+### Which client to use
+
+- **New code**: `SuiGrpcClient`. Typed protobuf, best throughput, active surface.
+- **Existing v1 migration / JSON-RPC-only infra**: `SuiJsonRpcClient`.
+- **Complex relational queries**: `SuiGraphQLClient` alongside one of the above.
+- **All clients share the v2 `client.core.*` API** for common data access.
+
+### gRPC service clients (low-level)
+
+`SuiGrpcClient` exposes typed services:
+
+```ts
+await client.transactionExecutionService.executeTransaction({ ... });
+await client.ledgerService.getObject({ objectId: '0x...' });
+await client.movePackageService.getFunction({
+  packageId: '0x2', moduleName: 'coin', name: 'transfer',
+});
+await client.nameService.reverseLookupName({ address: '0x...' });
+```
+
+## Transactions
+
+```ts
+import { Transaction } from '@mysten/sui/transactions';
+const tx = new Transaction();
+```
+
+Pure inputs — always typed:
+```ts
+tx.pure.u8(255); tx.pure.u16(n); tx.pure.u32(n); tx.pure.u64(n);
+tx.pure.u128(n); tx.pure.u256(n);
+tx.pure.bool(true); tx.pure.string('hello');
+tx.pure.address('0x...'); tx.pure.id('0x...');
+tx.pure.vector('u64', [100n, 200n]);
+tx.pure.option('u64', 42n);  // null for None
+```
+
+Objects — let the SDK resolve versions:
+```ts
+tx.object('0x...');
+tx.object.system();    // 0x5
+tx.object.clock();     // 0x6
+tx.object.random();    // 0x8
+tx.object.denyList();  // 0x403
+tx.object.option({ type: '0xpkg::m::T', value: '0x...' });
+```
+
+Commands:
+```ts
+const [coin] = tx.splitCoins(tx.gas, [1000]);
+tx.mergeCoins(tx.object('0xDest'), [tx.object('0xSrc')]);
+tx.transferObjects([coin], '0x...');
+tx.moveCall({
+  target: '0xpkg::module::fn',
+  arguments: [tx.object(poolId), coin, tx.pure.string('x')],
+  typeArguments: ['0x2::sui::SUI'],
+});
+const vec = tx.makeMoveVec({ type: '0xpkg::m::T', elements: [tx.object('0xA')] });
+const [upgradeCap] = tx.publish({ modules, dependencies });
+```
+
+For deeper PTB semantics (equivocation, hot-potato cliques, sponsored), load the `ptbs` skill.
+
+### `coinWithBalance` intent (non-SUI coins)
+
+Manually selecting / merging / splitting non-SUI coins is verbose. Use the intent:
+
+```ts
+import { coinWithBalance, Transaction } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+tx.setSender(keypair.toSuiAddress()); // REQUIRED for non-SUI
+
+tx.transferObjects(
+  [
+    coinWithBalance({ balance: 1_000_000 }),  // SUI — splits from gas
+    coinWithBalance({ balance: 500_000, type: '0xpkg::token::TOKEN' }),
+  ],
+  recipient,
+);
+```
+
+`setSender` is mandatory for non-SUI types — the SDK needs the sender to resolve owned coins during build.
+
+## v2 Core API (data access)
+
+All common data access methods live under `client.core`:
+
+```ts
+await client.core.getObject({ objectId, include: { content: true } });
+await client.core.getObjects({ objectIds: [...], include: { content: true } });
+await client.core.listOwnedObjects({ owner });           // paginated
+await client.core.listCoins({ owner, coinType });        // paginated
+await client.core.listBalances({ owner });
+await client.core.listDynamicFields({ parent });         // paginated
+await client.core.getDynamicField({ parent, name });
+await client.core.getTransaction({ digest, include: {...} });
+await client.core.simulateTransaction({ transaction: tx, sender });
+await client.core.executeTransaction({ transaction: bytes, signatures: [...], include: {...} });
+```
+
+**Include options** (replaces v1's `options: { show*: true }`):
+`effects`, `events`, `balanceChanges`, `objectTypes`, `transaction`, `bcs`, `content`.
+
+## Execution
+
+```ts
+const result = await client.signAndExecuteTransaction({
+  signer: keypair,
+  transaction: tx,
+});
+
+if (result.$kind === 'FailedTransaction') {
+  throw new Error(`Failed: ${result.FailedTransaction.status.error?.message}`);
+}
+
+await client.waitForTransaction({ digest: result.digest });
+// safe to query updated state now
+```
+
+Execution response shape uses a `$kind` discriminant: `'Transaction' | 'FailedTransaction'`. **Do not** rely on v1's `result.effects?.status?.status`.
+
+For sponsored or multi-sig, split sign and execute:
+
+```ts
+const { bytes, signature } = await tx.sign({ client, signer: keypair });
+const result = await client.core.executeTransaction({
+  transaction: bytes,
+  signatures: [signature],
+  include: { effects: true },
+});
+```
+
+## Keypairs
+
+```ts
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { Secp256k1Keypair } from '@mysten/sui/keypairs/secp256k1';
+import { Secp256r1Keypair } from '@mysten/sui/keypairs/secp256r1';
+
+const kp = new Ed25519Keypair();
+const kp2 = Ed25519Keypair.deriveKeypair('mnemonic words ...');
+const kp3 = Ed25519Keypair.fromSecretKey(secretKeyBytes);
+const addr = kp.toSuiAddress();
+```
+
+## Extensions — `client.$extend(...)` (v2)
+
+Ecosystem packages integrate via `$extend`:
+
+```ts
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { suins } from '@mysten/suins';
+import { deepbook } from '@mysten/deepbook-v3';
+
+const client = new SuiGrpcClient({
+  network: 'mainnet',
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
+}).$extend(suins(), deepbook({ address: myAddress }));
+
+await client.suins.getNameRecord('example.sui');
+await client.deepbook.checkManagerBalance(manager, asset);
+```
+
+Known extensions: `@mysten/suins`, `@mysten/deepbook-v3`, `@mysten/kiosk`, `@mysten/walrus`, `@mysten/seal`, `@mysten/zksend`.
+
+**Not** an extension: `@mysten/dapp-kit` (React-only frontend framework — see `frontend-apps` skill).
+
+## Offline building
+
+```ts
+import { Transaction, Inputs } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+tx.object(Inputs.ObjectRef({ objectId, version, digest }));
+tx.object(Inputs.SharedObjectRef({ objectId, initialSharedVersion, mutable: true }));
+tx.object(Inputs.ReceivingRef({ objectId, version, digest }));
+
+tx.setSender('0x...');
+tx.setGasPrice(1000);
+tx.setGasBudget(10_000_000);
+tx.setGasPayment([{ objectId, version, digest }]);
+
+const bytes = await tx.build();
+```
+
+## v1 → v2 migration (abridged)
+
+Full migration guide: fetch `https://sdk.mystenlabs.com/sui/migrations/sui-2.0/llms.txt` for the complete list.
+
+| v1 | v2 |
+|---|---|
+| `@mysten/sui.js` | `@mysten/sui` |
+| `TransactionBlock` | `Transaction` |
+| `SuiClient` + `getFullnodeUrl` | `SuiGrpcClient` + `baseUrl` (or `SuiJsonRpcClient` + `getJsonRpcFullnodeUrl`) |
+| `client.getObject({ id, options: {...} })` | `client.core.getObject({ objectId, include: {...} })` |
+| `client.getOwnedObjects` | `client.core.listOwnedObjects` |
+| `client.getCoins` | `client.core.listCoins` |
+| `client.getDynamicFields` | `client.core.listDynamicFields` |
+| `client.signAndExecuteTransactionBlock` | `client.signAndExecuteTransaction` |
+| `client.waitForTransactionBlock` | `client.waitForTransaction` |
+| `client.devInspectTransactionBlock` | `client.core.simulateTransaction` |
+| `client.executeTransactionBlock` | `client.core.executeTransaction` |
+| `options: { showEffects: true }` | `include: { effects: true }` |
+| `result.effects?.status?.status === 'success'` | `result.$kind !== 'FailedTransaction'` |
+| `txb.pure(value)` untyped | `tx.pure.u64(value)` / typed helpers |
+| `tx.serialize()` | `await tx.toJSON()` |
+| `namedPackagesPlugin` | built-in (MVR auto-resolution) |
+| direct `new SuinsClient(...)` | `client.$extend(suins())` |
+| `Commands` | `TransactionCommands` |
+| `graphql/schemas/latest` | `graphql/schema` |
+
+### ESM required
+
+All `@mysten/*` packages are ESM-only:
+```json
+// package.json
+{ "type": "module" }
+
+// tsconfig.json
+{ "compilerOptions": { "moduleResolution": "NodeNext", "module": "NodeNext" } }
+```
+
+## Common mistakes — v1 holdovers
+
+| Wrong | Right |
+|---|---|
+| `import { ... } from '@mysten/sui.js'` | `import { ... } from '@mysten/sui'` |
+| `new TransactionBlock()` | `new Transaction()` |
+| `client.signAndExecuteTransactionBlock(...)` | `client.signAndExecuteTransaction(...)` |
+| `SuiClient` | `SuiGrpcClient` (or `SuiJsonRpcClient`) |
+| Hardcoding `tx.object(Inputs.ObjectRef({ version, digest }))` for online code | `tx.object('0x...')` — let SDK resolve |
+| `tx.pure(100)` untyped | `tx.pure.u64(100)` |
+| Not checking `result.$kind` | Always check for `'FailedTransaction'` |
+| Querying state immediately after execution | `await client.waitForTransaction({ digest })` first |
+| Using `tx.gas` by value in `splitCoins` for sponsored tx (sponsor rejects) | Use `coinWithBalance({ balance })` |
+| `coinWithBalance(type=non-SUI)` without `tx.setSender` | Always call `tx.setSender(addr)` first for non-SUI |

--- a/sui-sdks/typescript.md
+++ b/sui-sdks/typescript.md
@@ -250,6 +250,8 @@ const bytes = await tx.build();
 
 Full migration guide: fetch `https://sdk.mystenlabs.com/sui/migrations/sui-2.0/llms.txt` for the complete list.
 
+**Migration rule:** when migrating a v1 snippet, do not migrate only the lines visible. v1 codebases almost always also use the execution / waiting / status APIs even if not shown. Surface the full set of likely-related migrations (signing, waiting, status check, options→include) alongside the migrated snippet so the user can update the rest of their file in one pass. A "complete" migration that leaves `signAndExecuteTransactionBlock` or `result.effects?.status?.status` intact elsewhere in the project is a half-migration that will break.
+
 | v1 | v2 |
 |---|---|
 | `@mysten/sui.js` | `@mysten/sui` |


### PR DESCRIPTION
## Summary
- Adds a `sui-sdks/` skill that disambiguates the Sui SDK landscape — which SDK to pick, how they relate, and how to install each.
- Builds on the existing `~/sui-dev-skills/sui-ts-sdk` starting point; `typescript.md` carries forward the v1→v2 migration table, `coinWithBalance`, and the `client.\$extend(...)` composition pattern.
- Adds coverage the old skill didn't have: the Rust SDK (new modular crates vs legacy monorepo `sui-sdk`), every community SDK (pysui / sui-go-sdk / mofalabs / ksui / SuiKit / suiue) with maintainer and install info, and a cross-SDK mapping table for the common operations.
- Documents the \`docs/llms-index.md\` convention: every `@mysten/*` package ships version-matched markdown docs in `node_modules`, and agents should read those before answering TS questions.

## Skill rules worth highlighting
- Only TypeScript (`@mysten/sui`) and Rust (`sui-rust-sdk` crates) are official. Everything else is community.
- `@mysten/sui.js` is frozen at v1; always recommend `@mysten/sui`.
- For v2, default to `SuiGrpcClient`; `SuiJsonRpcClient` is legacy.
- For Rust, prefer the modular `sui-rust-sdk` crates over the legacy monorepo `sui-sdk` crate.
- Check `node_modules/@mysten/*/docs/llms-index.md` before writing TS — those docs match the installed version.
- Ecosystem packages integrate via `client.\$extend(...)` in v2, not direct instantiation.

## Test plan
- [ ] Evals cover: picking an SDK for Go, choosing a v2 client, using bundled LLM docs, minimal Rust PTB, v1→v2 migration, TS→Rust porting, community SDK caveat (Python), and React frontend boundary (`@mysten/sui` + `@mysten/dapp-kit`).
- [ ] Each eval has explicit `expectations` asserting what patterns must appear and which pitfalls to avoid.
- [ ] Sources field on each eval points to the canonical docs page used to verify output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)