### PR TITLE
Add frontend-apps skill

### DIFF
--- a/frontend-apps/SKILL.md
+++ b/frontend-apps/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: frontend-apps
+description: >
+  Sui frontend / dApp development with @mysten/dapp-kit-react (React) and
+  @mysten/dapp-kit-core (Vue, vanilla JS, Svelte, other frameworks). Use when
+  building browser apps that connect Sui wallets, query on-chain state, or
+  submit transactions. Covers wallet connection, network switching, transaction
+  execution, query patterns with TanStack React Query, and the specific
+  pitfalls of browser + wallet + async-indexer environments. Pair with the
+  `sui-sdks` skill for @mysten/sui Transaction construction patterns and the
+  `ptbs` skill for PTB semantics.
+---
+
+# Sui Frontend / dApp Kit
+
+Browser Sui apps fail for a consistent set of reasons:
+
+1. **Wrong package.** `@mysten/dapp-kit` (no suffix) is the legacy JSON-RPC-only package — **deprecated**. New code uses `@mysten/dapp-kit-react` or `@mysten/dapp-kit-core`.
+2. **Wrong client.** dApp Kit takes a `SuiGrpcClient` (recommended) in `createDAppKit`'s `createClient`. Passing a `SuiJsonRpcClient` defeats the point of the new package.
+3. **Old provider stack.** Code often tries the v1 pattern: `QueryClientProvider` → `SuiClientProvider` → `WalletProvider`. That's gone. New pattern: `createDAppKit` factory + `DAppKitProvider` (or a non-React equivalent).
+4. **Dead hooks.** `useSuiClientQuery`, `useSuiClientInfiniteQuery`, `useSignAndExecuteTransaction` (mutation hook), `useConnectWallet`, `useDisconnectWallet`, `useSuiClient`, `useSuiClientContext` — **removed**. Replaced by `useCurrentClient` / `useCurrentNetwork` / `useDAppKit()` (imperative methods) + your own TanStack Query wrappers.
+5. **Skipping `waitForTransaction` between execute and refetch.** Fullnodes index transactions asynchronously — invalidating TanStack caches immediately after `signAndExecuteTransaction` refetches stale data.
+6. **Building PTBs in app code with `tx.build()` before handing to the wallet.** Defeats the wallet's gas selection. Always pass the `Transaction` instance (or `tx.serialize()`) to the wallet.
+
+All patterns in this skill are derived from:
+- https://sdk.mystenlabs.com/dapp-kit (landing)
+- https://sdk.mystenlabs.com/dapp-kit/getting-started/react
+- https://sdk.mystenlabs.com/dapp-kit/getting-started/next-js
+- https://sdk.mystenlabs.com/dapp-kit/getting-started/vue
+- https://docs.sui.io/standards/wallet-standard
+
+If unsure about any API, fetch from the relevant page — do not extrapolate from the legacy `@mysten/dapp-kit` or the pre-v2 hook surface. Many outdated tutorials exist.
+
+---
+
+## Reference files
+
+### setup — Install, factory, provider
+**Path:** `setup.md`
+**Load when:** starting a new dApp project, scaffolding React/Next.js/Vue setup, or migrating from the old three-provider pattern. Covers package choice, `createDAppKit({ networks, createClient })`, `DAppKitProvider` (React), and the `declare module` TypeScript augmentation.
+
+### react — React hooks & patterns
+**Path:** `react.md`
+**Load when:** writing React components. Covers every current hook (`useCurrentAccount`, `useCurrentWallet`, `useCurrentNetwork`, `useCurrentClient`, `useDAppKit`, `useWallets`, `useWalletConnection`), standard components (`ConnectButton`), and wallet-gated UI idioms.
+
+### non-react — Vue, vanilla JS, Web Components
+**Path:** `non-react.md`
+**Load when:** building Vue / Svelte / vanilla JS dApps. Covers `@mysten/dapp-kit-core`, nanostores reactive state (`dAppKit.stores.$connection` etc.), Web Components registration, Vue bindings via `@nanostores/vue`.
+
+### queries — TanStack Query patterns
+**Path:** `queries.md`
+**Load when:** fetching on-chain data (balances, owned objects, coins, dynamic fields, transactions) in a dApp. Covers `useQuery` + `useCurrentClient`, `useInfiniteQuery` for paginated results, `enabled` guards, and cache invalidation after writes.
+
+### transactions — Signing and executing
+**Path:** `transactions.md`
+**Load when:** submitting any transaction from a dApp. Covers `dAppKit.signAndExecuteTransaction`, the `$kind`-based result discriminant, `signTransaction` (wallet signs but doesn't execute — for sponsored flows), `signPersonalMessage`, the `waitForTransaction` + `invalidateQueries` sequence, and common wallet UX failures.
+
+### limitations — What frontends can't or shouldn't do
+**Path:** `limitations.md`
+**Load when:** a user is designing something that feels like it crosses a browser-environment boundary. Covers: no backend-only features (gas station internals, validator keys), browser/SSR caveats, auto-connect reliability, JSON-RPC-specific features that don't have gRPC equivalents yet, and the "don't put secrets in the browser" rules.
+
+## Routing guide
+
+| Task | Load |
+|------|------|
+| New React dApp from scratch | setup + react + queries + transactions |
+| New Vue / vanilla / Svelte dApp | setup + non-react |
+| "How do I connect a wallet?" | react (or non-react) |
+| "How do I query a balance / owned objects?" | queries |
+| "How do I send a transaction?" | transactions + (sui-sdks for PTB construction) |
+| Sponsored tx flow | transactions (front-end side) + ptbs (PTB side) |
+| Migrating from `@mysten/dapp-kit` (no suffix) | setup + limitations + all as needed |
+| Why is my UI stale after a tx? | transactions + queries |
+| Dealing with SSR / Next.js | setup + limitations |
+| Full code review of a dApp | **all reference files** |
+
+## Skill Content
+
+### Key concepts
+
+- **Two packages, one API.** `@mysten/dapp-kit-react` wraps `@mysten/dapp-kit-core`. `createDAppKit` exists in both; actions (`signAndExecuteTransaction`, `signTransaction`, `switchNetwork`, `connectWallet`, `disconnectWallet`) are identical. What differs is how you read reactive state: React uses hooks; non-React reads nanostores stores.
+- **One instance, many networks.** `createDAppKit({ networks: [...], createClient })` creates one dApp Kit instance that knows about multiple networks. `dAppKit.switchNetwork(name)` changes the active one. The `createClient` factory is called once per network, lazily.
+- **gRPC by default.** The new dApp Kit is built for `SuiGrpcClient`. JSON-RPC is legacy; don't pass `SuiJsonRpcClient` to `createClient`.
+- **Wallets are browser-only.** Wallet detection uses `window.navigator.wallets` and CustomEvents. Any component that touches wallet state must be client-side rendered. In Next.js / SSR frameworks this means `'use client'` on wallet-aware components.
+- **The wallet owns gas.** Apps build the `Transaction` and pass it to the wallet. The wallet picks gas coins, sets budget (via dry-run), and signs. Never call `tx.build()` + pass bytes unless it's a sponsored flow — see `transactions.md`.
+- **Fullnodes are eventually consistent.** `signAndExecuteTransaction` returns a digest before the data is queryable. Always `waitForTransaction` before refetching.
+
+### Rules
+
+1. **Use `@mysten/dapp-kit-react` or `@mysten/dapp-kit-core`** — never the bare `@mysten/dapp-kit` in new code. That package is JSON-RPC-only and deprecated.
+2. **Use `SuiGrpcClient` in `createClient`.** Not `SuiJsonRpcClient`. Not `SuiClient` (v1 — removed).
+3. **Use `createDAppKit` + `DAppKitProvider`.** Not the three-provider stack (`QueryClientProvider` + `SuiClientProvider` + `WalletProvider`). You still wrap with `QueryClientProvider` if you use TanStack Query for data fetching, but dApp Kit itself doesn't need it.
+4. **Include the `declare module` TypeScript augmentation** so hooks get proper types without passing the instance manually.
+5. **Do not use the removed hooks.** `useSuiClientQuery` / `useSuiClientInfiniteQuery` / `useSuiClientContext` / `useSuiClient` / `useSignAndExecuteTransaction` (mutation hook) / `useConnectWallet` / `useDisconnectWallet` — gone. Use `useCurrentClient` + `useQuery`/`useInfiniteQuery` + `useDAppKit()` imperative methods.
+6. **Null-check the current account.** `useCurrentAccount()` returns `null` before connection. Always `if (!account) return` / gate with `enabled: !!account` in queries.
+7. **`waitForTransaction` before cache invalidation.** `await client.waitForTransaction({ digest: result.Transaction.digest })` then `queryClient.invalidateQueries(...)`. Reversing this fetches stale data.
+8. **Pass the `Transaction` instance (or `tx.serialize()`) to the wallet, not `await tx.build(...)` bytes.** The wallet needs to own gas selection. Exception: sponsored flows that use `tx.build({ client, onlyTransactionKind: true })` — see `ptbs` skill.
+9. **Check `result.$kind === 'FailedTransaction'` (or `result.FailedTransaction`).** Don't assume success. Don't use v1's `result.effects?.status?.status`.
+10. **Wallet-gated UI must client-render.** SSR without a client-side guard renders wallet buttons before wallets are detectable. Use `'use client'` / dynamic imports / effect-based hydration.
+
+### Common mistakes
+
+- **Using `@tanstack/react-query`'s `useQuery` without `enabled: !!account`** for queries that require a connected wallet. The query fires with undefined owner and errors.
+- **Returning a `Transaction` from a React-Query `queryFn`.** Transactions aren't queries — use them in mutations or event handlers via `useDAppKit()`.
+- **`dAppKit.signAndExecuteTransaction({ transactionBlock: tx })`.** It's `{ transaction: tx }` in the new API.
+- **Reading `result.digest` directly.** On success the digest is at `result.Transaction.digest`. On failure there's no digest — check `result.FailedTransaction` first.
+- **Invalidating queries before `waitForTransaction`.** Classic stale-UI bug. Always wait first.
+- **Calling `new SuiGrpcClient(...)` inside components.** Breaks network switching. Use `useCurrentClient()`.
+- **Instantiating `SuinsClient` / `DeepBookClient` directly.** Use `client.$extend(suins(), deepbook({ address }))` on the client returned from `createClient`.
+- **Leaving `autoConnect: true` with a confusing UX.** Auto-reconnect restores the last wallet on load. If the app handles permissions/nonces, account for the async nature of that restore (pending / reconnecting states).
+- **Hardcoding testnet / mainnet URLs in multiple places.** Keep them in a single `GRPC_URLS` map keyed by network name and reference from `createClient`.
+- **Using wallet-standard APIs directly.** dApp Kit wraps the wallet standard — don't call `window.navigator.wallets` yourself; use `useWallets()` / `dAppKit.stores.$wallets`.
+- **Storing private keys or secrets in the browser.** Never. dApps sign via wallets; backends hold keys.

--- a/frontend-apps/SKILL.md
+++ b/frontend-apps/SKILL.md
@@ -72,7 +72,8 @@ If unsure about any API, fetch from the relevant page — do not extrapolate fro
 | Migrating from `@mysten/dapp-kit` (no suffix) | setup + limitations + all as needed |
 | Why is my UI stale after a tx? | transactions + queries |
 | Dealing with SSR / Next.js | setup + limitations |
-| Full code review of a dApp | **all reference files** |
+| Full code review of a dApp | **all reference files** + the code-review checklist below |
+| "Review this code" / "what's wrong with this snippet" | the code-review checklist below + relevant reference files |
 
 ## Skill Content
 
@@ -97,6 +98,44 @@ If unsure about any API, fetch from the relevant page — do not extrapolate fro
 8. **Pass the `Transaction` instance (or `tx.serialize()`) to the wallet, not `await tx.build(...)` bytes.** The wallet needs to own gas selection. Exception: sponsored flows that use `tx.build({ client, onlyTransactionKind: true })` — see `ptbs` skill.
 9. **Check `result.$kind === 'FailedTransaction'` (or `result.FailedTransaction`).** Don't assume success. Don't use v1's `result.effects?.status?.status`.
 10. **Wallet-gated UI must client-render.** SSR without a client-side guard renders wallet buttons before wallets are detectable. Use `'use client'` / dynamic imports / effect-based hydration.
+
+### Code-review checklist
+
+When the user asks you to review a code snippet, do not stop at the first 2–3 issues you spot. Walk this checklist explicitly and call out **every** match. Browser Sui code typically has 5–10 issues stacked in a single component because it was copied from a v1 tutorial.
+
+**Imports / packages**
+- `@mysten/sui.js` (anywhere) — frozen v1 package; replace with `@mysten/sui`.
+- `@mysten/dapp-kit` (no suffix) — deprecated JSON-RPC-only package; replace with `@mysten/dapp-kit-react` (React) or `@mysten/dapp-kit-core` (other frameworks).
+- `import { SuiClient }` — v1 client; replace with `SuiGrpcClient` from `@mysten/sui/grpc` (or `useCurrentClient()` inside components).
+- `import { TransactionBlock }` — renamed to `Transaction` in v2.
+
+**Removed hooks (any of these = bug)**
+- `useSuiClientQuery`, `useSuiClientInfiniteQuery`, `useSuiClientContext`, `useSuiClient` — replace with `useCurrentClient()` + TanStack `useQuery` / `useInfiniteQuery`.
+- `useSignAndExecuteTransaction` (mutation hook) — replace with `useDAppKit().signAndExecuteTransaction(...)` called imperatively in event handlers.
+- `useConnectWallet`, `useDisconnectWallet` — replace with `useDAppKit().connectWallet()` / `disconnectWallet()`.
+
+**Provider stack**
+- `SuiClientProvider` + `WalletProvider` (the v1 three-provider stack) — replace with `createDAppKit(...)` + `<DAppKitProvider>`. `QueryClientProvider` from TanStack is still allowed.
+
+**Client construction inside components**
+- `new SuiClient(...)` / `new SuiGrpcClient(...)` inside a component body — breaks network switching and re-creates a client per render. Use `useCurrentClient()`.
+- Missing `enabled: !!account` on queries that need a connected wallet — fires on undefined owner and errors.
+
+**Transaction construction**
+- `tx.pure(value)` (untyped) — replace with the typed helper matching the Move type: `tx.pure.u64(n)`, `tx.pure.address(addr)`, `tx.pure.string(s)`, etc.
+- `tx.build()` before handing to the wallet — defeats wallet gas selection. Pass the `Transaction` instance (or `tx.serialize()`).
+
+**Execute / wait / status**
+- `signAndExecuteTransactionBlock(...)` (v1 method) — replace with `signAndExecuteTransaction(...)`.
+- `{ transactionBlock: tx }` parameter shape — replace with `{ transaction: tx }`.
+- `result.effects?.status?.status === 'success'` — v1 shape; replace with `result.$kind !== 'FailedTransaction'` (or check `result.FailedTransaction`).
+- `result.digest` direct access — on success the digest is at `result.Transaction.digest`; on failure there's no digest.
+- Cache invalidation immediately after execute — must `await client.waitForTransaction({ digest })` first, then `queryClient.invalidateQueries(...)`.
+
+**SSR / Next.js**
+- Wallet-aware component without `'use client'` — wallet detection uses browser-only APIs.
+
+After walking the list, count the distinct issues you found. If it's fewer than 5 on a typical multi-line snippet pulled from an outdated tutorial, re-read the snippet — you almost certainly missed something.
 
 ### Common mistakes
 

--- a/frontend-apps/evals/evals.json
+++ b/frontend-apps/evals/evals.json
@@ -1,0 +1,157 @@
+[
+  {
+    "id": "frontend-apps-react-setup",
+    "prompt": "Help me set up a new Vite + React app to integrate with Sui. I want users to connect a wallet and see their SUI balance. Give me the complete setup code: package installs, dapp-kit.ts instance, provider wrapping, and a simple Balance component that reads from the current network.",
+    "sources": [
+      "https://sdk.mystenlabs.com/dapp-kit/getting-started/react",
+      "https://sdk.mystenlabs.com/sui/clients"
+    ],
+    "expected_output": "A full setup: npm install @mysten/dapp-kit-react @mysten/sui @tanstack/react-query; a dapp-kit.ts file that imports createDAppKit from '@mysten/dapp-kit-react' and SuiGrpcClient from '@mysten/sui/grpc', creates the instance with networks + defaultNetwork + createClient, and includes the `declare module` augmentation; an App.tsx that wraps with QueryClientProvider and DAppKitProvider; a Balance component using useCurrentAccount + useCurrentClient + useQuery with enabled: !!account and the correct client.core.listBalances call.",
+    "expectations": [
+      "Installs @mysten/dapp-kit-react (NOT the bare @mysten/dapp-kit)",
+      "Installs @mysten/sui and @tanstack/react-query",
+      "Creates the dApp Kit instance via createDAppKit from '@mysten/dapp-kit-react'",
+      "Passes SuiGrpcClient (from '@mysten/sui/grpc') to createClient, NOT SuiJsonRpcClient or SuiClient",
+      "Wraps with DAppKitProvider (NOT the old three-provider SuiClientProvider + WalletProvider + QueryClientProvider stack for dApp Kit)",
+      "Uses QueryClientProvider for TanStack Query",
+      "Includes the `declare module '@mysten/dapp-kit-react'` TypeScript augmentation",
+      "Uses useCurrentAccount and useCurrentClient (NOT useSuiClient)",
+      "Uses useQuery with enabled: !!account to gate the balance query",
+      "Calls client.core.listBalances (v2 API) not client.getBalance or client.getAllBalances directly",
+      "Does NOT use any removed hook: useSuiClientQuery, useSignAndExecuteTransaction (mutation), useSuiClient, useConnectWallet",
+      "Does NOT use deprecated @mysten/dapp-kit (no suffix) or @mysten/sui.js"
+    ]
+  },
+  {
+    "id": "frontend-apps-transaction-flow",
+    "prompt": "Write a React button that transfers 0.5 SUI to a hardcoded recipient when the user clicks it. Show the full transaction flow including error handling, waiting for indexing, and refreshing the balance query afterward.",
+    "sources": [
+      "https://sdk.mystenlabs.com/dapp-kit/getting-started/react",
+      "https://sdk.mystenlabs.com/sui"
+    ],
+    "expected_output": "A React component using useDAppKit, useCurrentClient, useCurrentAccount, useQueryClient. Builds a Transaction with tx.splitCoins(tx.gas, [tx.pure.u64(500_000_000n)]) and tx.transferObjects([coin], tx.pure.address(recipient)). Calls dAppKit.signAndExecuteTransaction({ transaction: tx }) — passing the Transaction instance directly, NOT pre-built bytes. Checks result.$kind === 'FailedTransaction' (or equivalent) for failure. Awaits client.waitForTransaction({ digest: result.Transaction.digest }). Then invalidates the balance query. Manages loading state via useState since there's no built-in mutation hook.",
+    "expectations": [
+      "Uses useDAppKit() to get the instance and calls instance.signAndExecuteTransaction (NOT the removed useSignAndExecuteTransaction hook)",
+      "Passes { transaction: tx } to signAndExecuteTransaction (NOT transactionBlock:)",
+      "Passes the Transaction instance directly — does NOT call tx.build() in the app code first",
+      "Builds the PTB with tx.splitCoins(tx.gas, [tx.pure.u64(500_000_000n)]) — uses typed pure helper",
+      "Uses tx.pure.address(recipient) for the recipient — not a raw string",
+      "Checks for failure via result.$kind or result.FailedTransaction discriminant (NOT result.effects?.status?.status)",
+      "On success, awaits client.waitForTransaction({ digest }) BEFORE invalidating queries",
+      "Calls queryClient.invalidateQueries AFTER waitForTransaction, not before",
+      "Manages isPending / error via useState (no built-in mutation hook)",
+      "Does NOT set tx.setGasBudget / tx.setGasPrice / tx.setGasPayment in app code (leaves gas to the wallet)",
+      "Does NOT use removed hooks"
+    ]
+  },
+  {
+    "id": "frontend-apps-owned-nfts-paginated",
+    "prompt": "Show me how to list all NFTs of type 0xPKG::nft::NFT owned by the connected user, with a 'Load more' button for pagination.",
+    "sources": [
+      "https://sdk.mystenlabs.com/dapp-kit/getting-started/react",
+      "https://sdk.mystenlabs.com/sui"
+    ],
+    "expected_output": "A React component using useCurrentClient + useCurrentAccount + useInfiniteQuery from @tanstack/react-query. queryFn calls client.core.listOwnedObjects with owner, cursor from pageParam, and type filter. getNextPageParam returns lastPage.nextCursor when hasNextPage. Uses enabled: !!account. Flattens pages to render. Load more button calls fetchNextPage.",
+    "expectations": [
+      "Uses useInfiniteQuery from @tanstack/react-query (NOT useSuiClientInfiniteQuery which is removed)",
+      "Uses useCurrentClient (NOT useSuiClient)",
+      "Calls client.core.listOwnedObjects (v2 Core API), NOT client.getOwnedObjects",
+      "Passes the type filter to listOwnedObjects",
+      "Uses cursor / pageParam pattern with initialPageParam and getNextPageParam",
+      "getNextPageParam returns lastPage.nextCursor when hasNextPage is true, undefined otherwise",
+      "enabled: !!account guards the query until wallet is connected",
+      "Flattens data.pages to render the full list",
+      "Load more button calls fetchNextPage and disables when isFetchingNextPage"
+    ]
+  },
+  {
+    "id": "frontend-apps-deprecated-package-check",
+    "prompt": "I found a tutorial that says to `npm install @mysten/dapp-kit` and shows SuiClientProvider, WalletProvider, QueryClientProvider nested together plus a useSuiClientQuery hook. Is this current?",
+    "sources": [
+      "https://sdk.mystenlabs.com/dapp-kit"
+    ],
+    "expected_output": "Explains that @mysten/dapp-kit (no suffix) is the legacy JSON-RPC-only package and is deprecated. The tutorial shows the old three-provider pattern and a removed hook. The current setup uses @mysten/dapp-kit-react (React) or @mysten/dapp-kit-core (Vue/vanilla) with createDAppKit + DAppKitProvider. useSuiClientQuery was removed — use useCurrentClient + @tanstack/react-query's useQuery. Recommends using the getting-started React guide at sdk.mystenlabs.com/dapp-kit/getting-started/react.",
+    "expectations": [
+      "Identifies @mysten/dapp-kit (no suffix) as the deprecated / legacy package",
+      "Explicitly states the new packages are @mysten/dapp-kit-react and @mysten/dapp-kit-core",
+      "Notes the three-provider pattern (SuiClientProvider + WalletProvider + QueryClientProvider for dApp Kit) is replaced by createDAppKit + DAppKitProvider",
+      "Identifies useSuiClientQuery as a removed hook",
+      "Suggests useCurrentClient + @tanstack/react-query useQuery as the replacement",
+      "Does NOT claim the old pattern still works",
+      "Points to the current getting-started docs"
+    ]
+  },
+  {
+    "id": "frontend-apps-sponsored-sign-only",
+    "prompt": "I want the wallet to sign a transaction but have my backend sponsor the gas and submit it. Show the frontend React code that signs without executing, then POSTs the signed bytes and signature to /api/sponsor.",
+    "sources": [
+      "https://sdk.mystenlabs.com/dapp-kit/getting-started/react"
+    ],
+    "expected_output": "Uses dAppKit.signTransaction({ transaction: tx }) (not signAndExecuteTransaction) to get { bytes, signature }. POSTs these to /api/sponsor. Explains that the backend is responsible for filling gas data (setSender from the user, setGasOwner to the sponsor, setGasPayment with sponsor coins), attaching the sponsor signature, and submitting. After the backend returns a digest, the frontend calls client.waitForTransaction.",
+    "expectations": [
+      "Uses dAppKit.signTransaction({ transaction }) — NOT signAndExecuteTransaction",
+      "Destructures { bytes, signature } from the result",
+      "POSTs bytes and signature to the backend (JSON body or multipart)",
+      "Mentions that the backend is responsible for setting gas owner / payment / sponsor signature / submission",
+      "After the backend responds with a digest, calls client.waitForTransaction for UI consistency",
+      "Does NOT try to call tx.build({ onlyTransactionKind: true }) in the frontend (that pattern is backend-facing in the sponsored flow where the app builds kind-only bytes for the sponsor — but if the user's prompt says 'wallet signs, backend sponsors', using signTransaction is the right primitive)",
+      "Does NOT try to set gas budget / gas owner / gas payment on the frontend"
+    ]
+  },
+  {
+    "id": "frontend-apps-vue-setup",
+    "prompt": "Set up @mysten/dapp-kit-core for a Vue 3 project. Show the dapp-kit.ts, main.ts, and a Vue component that shows the connect button and the connected account's address.",
+    "sources": [
+      "https://sdk.mystenlabs.com/dapp-kit/getting-started/vue"
+    ],
+    "expected_output": "dapp-kit.ts imports createDAppKit from '@mysten/dapp-kit-core' (NOT -react) and SuiGrpcClient from '@mysten/sui/grpc', creates the instance. main.ts registers Web Components with `import '@mysten/dapp-kit-core/web'`. A .vue component uses useStore from @nanostores/vue on dAppKit.stores.$connection, renders <mysten-dapp-kit-connect-button :instance=\"dAppKit\" />, and shows the address from connection.value.account?.address.",
+    "expectations": [
+      "Imports createDAppKit from '@mysten/dapp-kit-core' (NOT @mysten/dapp-kit-react)",
+      "Imports SuiGrpcClient from '@mysten/sui/grpc'",
+      "Registers Web Components once at app entry with `import '@mysten/dapp-kit-core/web'`",
+      "Uses @nanostores/vue's useStore on dAppKit.stores.$connection",
+      "Renders the Web Component <mysten-dapp-kit-connect-button> with :instance property binding (NOT as an HTML string attribute)",
+      "Reads connection.value.account (Vue reactive ref) — not connection.account directly",
+      "Does NOT include the `declare module` TypeScript augmentation (that's React-only)",
+      "Does NOT import from @mysten/dapp-kit-react"
+    ]
+  },
+  {
+    "id": "frontend-apps-avoid-bad-pattern",
+    "prompt": "Review this code for problems:\n\n```tsx\nimport { SuiClient, getFullnodeUrl } from '@mysten/sui/client';\nimport { useSuiClientQuery, useSignAndExecuteTransaction } from '@mysten/dapp-kit';\nimport { TransactionBlock } from '@mysten/sui.js/transactions';\n\nfunction Mint() {\n  const { mutate: sign } = useSignAndExecuteTransaction();\n  const { data: balance } = useSuiClientQuery('getBalance', { owner: '...' });\n\n  const handleMint = () => {\n    const tx = new TransactionBlock();\n    tx.moveCall({ target: '...', arguments: [tx.pure('n')] });\n    sign({ transactionBlock: tx }, {\n      onSuccess: (result) => {\n        if (result.effects?.status?.status === 'success') {\n          queryClient.invalidateQueries(['getBalance']);\n        }\n      },\n    });\n  };\n}\n```",
+    "sources": [
+      "https://sdk.mystenlabs.com/dapp-kit",
+      "https://sdk.mystenlabs.com/sui"
+    ],
+    "expected_output": "Identifies multiple outdated patterns: imports from deprecated @mysten/sui.js and @mysten/dapp-kit (no suffix); uses removed useSuiClientQuery and useSignAndExecuteTransaction hooks; uses removed TransactionBlock class and SuiClient; uses untyped tx.pure('n'); uses old transactionBlock parameter name; uses v1 result.effects?.status?.status check; invalidates queries without waitForTransaction first. Suggests the full migration: import from @mysten/sui/transactions and @mysten/dapp-kit-react, use Transaction, useDAppKit().signAndExecuteTransaction, tx.pure.u64/string/address, { transaction: tx }, check result.$kind, add waitForTransaction before invalidate.",
+    "expectations": [
+      "Flags @mysten/sui.js as deprecated; recommends @mysten/sui",
+      "Flags @mysten/dapp-kit (no suffix) as deprecated; recommends @mysten/dapp-kit-react",
+      "Flags useSuiClientQuery as removed",
+      "Flags useSignAndExecuteTransaction (mutation hook) as removed",
+      "Flags TransactionBlock as renamed to Transaction",
+      "Flags SuiClient as removed; recommends SuiGrpcClient",
+      "Flags tx.pure('n') as untyped; recommends typed helper like tx.pure.string('n') or tx.pure.u64(n)",
+      "Flags transactionBlock: parameter; recommends transaction:",
+      "Flags result.effects?.status?.status check; recommends $kind discriminant",
+      "Flags missing waitForTransaction before invalidateQueries",
+      "Identifies at least 6 distinct issues"
+    ]
+  },
+  {
+    "id": "frontend-apps-ssr-nextjs",
+    "prompt": "I'm using Next.js App Router. Where do I put the DAppKitProvider? Do I need 'use client'?",
+    "sources": [
+      "https://sdk.mystenlabs.com/dapp-kit/getting-started/next-js"
+    ],
+    "expected_output": "Explains that dApp Kit uses browser-only APIs (wallet detection via window.navigator.wallets) so components that touch wallet state must be client-rendered. Recommends a pattern: keep app/layout.tsx as a server component, extract providers into a separate app/providers.tsx file marked with 'use client', wrap the entire app in that. Any component that calls dApp Kit hooks must also be 'use client'.",
+    "expectations": [
+      "States that dApp Kit requires client-side rendering (wallet detection is browser-only)",
+      "Recommends keeping layout.tsx as a server component and a separate providers.tsx marked 'use client'",
+      "Shows 'use client' at the top of the providers file",
+      "Notes that leaf components using dApp Kit hooks also need 'use client'",
+      "Does NOT recommend marking the entire layout 'use client' (loses RSC benefits)",
+      "Does NOT recommend using @mysten/dapp-kit (the deprecated package)"
+    ]
+  }
+]

--- a/frontend-apps/limitations.md
+++ b/frontend-apps/limitations.md
@@ -1,0 +1,117 @@
+# Frontend limitations — what dApps can't or shouldn't do
+
+The browser is a hostile environment for some things that look tempting. This page is the "are you sure?" list.
+
+## Things the browser should never hold
+
+- **Private keys.** dApps sign via wallets. Never ask a user to paste a mnemonic or keypair into a form field. If your flow seems to require this, you're designing a wallet, not a dApp.
+- **API secrets that authorize signing.** RPC keys for paid endpoints are okay (they're rate-limited). Signing keys, sponsor keys, validator keys, admin keys — all backend-only.
+- **Gas station coins.** A gas station service sits server-side. The browser asks it for sponsored signatures via an authenticated endpoint.
+- **Indexer database credentials.** Queries go through a backend or a public GraphQL / gRPC endpoint.
+
+## Things that need a backend
+
+Any of these require a server component — a dApp alone cannot do them safely:
+
+- **Sponsored transaction gas selection** (the sponsor signs on a backend; the frontend only signs the user side with `signTransaction`).
+- **Rate-limited writes** (preventing one user from spamming a mint).
+- **Server-signed allowlists / merkle proofs** (generated server-side, verified on-chain).
+- **Signed-message nonces** for authentication (nonces issued + invalidated server-side; never client-issued).
+- **Webhooks / polling from external sources** (e.g., cross-chain bridges) that trigger on-chain actions.
+- **Operating a custom indexer** or querying an internal DB.
+
+If a user asks for a pure-frontend version of any of these, explain the constraint: a malicious browser client can lie about allowlist membership, replay nonces, or spam an endpoint.
+
+## Things the current dApp Kit does not support
+
+The new v2 dApp Kit is built around `SuiGrpcClient`. Some older JSON-RPC-only features don't have gRPC equivalents yet — or the mapping is still shifting. If a user asks for something specific and you can't find it in the v2 docs:
+
+- Check whether it's a JSON-RPC-only method and the user wants to stay on gRPC → may need to fall back to `SuiJsonRpcClient` alongside the dApp Kit client.
+- Check the `@mysten/dapp-kit-core` changelog for breaking changes.
+- If genuinely missing, document the gap to the user rather than fabricating an API.
+
+## Non-recommended patterns
+
+### Auto-connect without UX for reconnecting state
+
+`autoConnect: true` (default) restores the last wallet on page load. During that restore, `useWalletConnection().status === 'reconnecting'`. If your app shows `ConnectButton` whenever `account === null`, the user sees a connect button flash on every reload.
+
+Fix: branch on `status`, not just on `account`:
+
+```tsx
+const { status } = useWalletConnection();
+if (status === 'reconnecting') return <Spinner />;
+if (status === 'disconnected') return <ConnectButton />;
+```
+
+### Calling `tx.build()` in app code before `signAndExecuteTransaction`
+
+The wallet needs the raw `Transaction` so it can select gas coins and set budget. Pre-building locks those in and often breaks sponsored flows. Always pass the `Transaction` instance.
+
+Exception: sponsored flows that use `tx.build({ client, onlyTransactionKind: true })` and hand kind-only bytes to a backend sponsor service.
+
+### Hardcoding `setGasBudget`, `setGasPrice`, `setGasPayment` in app code
+
+The wallet computes these better than you can — gas price is network-variable, gas budget is dry-run-derived. Only set them for backend-signed flows.
+
+### Using `tx.gas` in `splitCoins` in a sponsored transaction
+
+Sponsors typically reject PTBs that consume the gas coin for non-gas purposes, because the sponsor's gas coin shouldn't be spent on app logic. Use `coinWithBalance` instead (see `sui-sdks` / `typescript.md`).
+
+### Instantiating `SuiGrpcClient` inside components
+
+```tsx
+// ❌ Wrong — loses network switching
+function Foo() {
+  const client = new SuiGrpcClient({ network: 'mainnet', baseUrl: '...' });
+}
+
+// ✅ Right
+function Foo() {
+  const client = useCurrentClient();
+}
+```
+
+### Using wallet-standard APIs directly
+
+```tsx
+// ❌ Don't
+const wallets = window.navigator.wallets;
+
+// ✅ Do
+const wallets = useWallets();
+```
+
+dApp Kit handles the wallet-standard event loop — reaching past it causes race conditions.
+
+### Querying immediately after execution
+
+Always `waitForTransaction` before the follow-up read / invalidate. Common omission.
+
+### Ignoring `FailedTransaction`
+
+A transaction that validators accepted can still fail at the Move layer (assertion, insufficient budget). `result.$kind === 'FailedTransaction'` is the failure signal. Don't treat a returned digest as proof of success.
+
+### Building infinite queries without `enabled: !!account`
+
+The query fires with `undefined` owner and errors. Always gate queries that require a connected wallet.
+
+### Invalidating with loose query keys
+
+`invalidateQueries({ queryKey: ['balance'] })` invalidates every balance-related query across every account the user has connected. Usually you want `['balance', account.address]`. Be specific.
+
+## SSR / Next.js
+
+- Wallet detection is browser-only. Any component that calls a dApp Kit hook or imports `@mysten/dapp-kit-react`/`-core` must be client-rendered.
+- In app-router Next.js: put providers in a `'use client'` file, wallet-aware leaf components in `'use client'` files.
+- Don't pre-render wallet UI on the server — it'll hydrate into a mismatch.
+- If you need server-side on-chain reads (e.g., for SEO), use a separate `SuiGrpcClient` on the server directly, not via dApp Kit. The server has no wallet concept.
+
+## Mobile webviews and in-app browsers
+
+- Many in-app browsers (Twitter, Discord, etc.) don't support wallet extensions. Detect and show a "Open in your browser" message.
+- Mobile wallets typically implement WalletConnect or deeplink flows. The wallet standard handles this via wallet adapters — no special handling in dApp Kit.
+
+## Caveat when adopting new SDK versions
+
+Both `@mysten/sui` and `@mysten/dapp-kit-*` evolve independently but must be compatible. Check the installed versions match the examples in their own `docs/llms-index.md` (see `sui-sdks` skill, `llm-docs.md`) before pulling patterns from web tutorials. Web tutorials go stale within months.

--- a/frontend-apps/non-react.md
+++ b/frontend-apps/non-react.md
@@ -1,0 +1,199 @@
+# Vue, Vanilla JS, Web Components
+
+Source: https://sdk.mystenlabs.com/dapp-kit/getting-started/vue
+
+`@mysten/dapp-kit-core` exposes the same `createDAppKit` factory and the same action methods (`signAndExecuteTransaction`, `signTransaction`, `signPersonalMessage`, `connectWallet`, `disconnectWallet`, `switchNetwork`, `switchAccount`) as the React package. What differs:
+
+- Reactive state is exposed via **nanostores** instead of React hooks.
+- UI components are **Web Components** (`<mysten-dapp-kit-connect-button>`, `<mysten-dapp-kit-connect-modal>`) instead of React components.
+
+## Setup (Vue)
+
+```ts
+// dapp-kit.ts
+import { createDAppKit } from '@mysten/dapp-kit-core';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const GRPC_URLS: Record<string, string> = {
+  mainnet: 'https://fullnode.mainnet.sui.io:443',
+  testnet: 'https://fullnode.testnet.sui.io:443',
+};
+
+export const dAppKit = createDAppKit({
+  networks: ['testnet', 'mainnet'],
+  defaultNetwork: 'testnet',
+  createClient: (network) => new SuiGrpcClient({ network, baseUrl: GRPC_URLS[network] }),
+});
+```
+
+```ts
+// main.ts
+import '@mysten/dapp-kit-core/web';    // registers Web Components globally
+import { createApp } from 'vue';
+import App from './App.vue';
+createApp(App).mount('#app');
+```
+
+## Web Components
+
+### Connect button
+
+```vue
+<template>
+  <mysten-dapp-kit-connect-button :instance="dAppKit" />
+</template>
+
+<script setup lang="ts">
+import { dAppKit } from './dapp-kit';
+</script>
+```
+
+**Important:** `instance` is a **DOM property**, not an HTML attribute. In vanilla HTML:
+```html
+<mysten-dapp-kit-connect-button></mysten-dapp-kit-connect-button>
+<script type="module">
+  import { dAppKit } from './dapp-kit.js';
+  document.querySelector('mysten-dapp-kit-connect-button').instance = dAppKit;
+</script>
+```
+
+In Vue, the `:instance` property binding handles this automatically.
+
+Accepts the same `modalOptions.filterFn` / `modalOptions.sortFn` as the React component:
+
+```vue
+<mysten-dapp-kit-connect-button
+  :instance="dAppKit"
+  :modal-options="{ filterFn: (w) => w.name !== 'Excluded' }"
+/>
+```
+
+### Connect modal (custom trigger)
+
+```html
+<mysten-dapp-kit-connect-modal></mysten-dapp-kit-connect-modal>
+<button id="open-btn">Connect</button>
+
+<script type="module">
+  const modal = document.querySelector('mysten-dapp-kit-connect-modal');
+  modal.instance = dAppKit;
+  document.getElementById('open-btn').onclick = () => modal.show();
+</script>
+```
+
+Events: `open`, `opened`, `close`, `closed`, `cancel`.
+
+## Reactive state (nanostores)
+
+`dAppKit.stores` exposes nanostores stores:
+
+| Store | Type | Contents |
+|---|---|---|
+| `$connection` | object | `{ wallet, account, status, isConnected, isConnecting, isReconnecting, isDisconnected }` |
+| `$currentNetwork` | string | active network |
+| `$currentClient` | `SuiGrpcClient` | client for active network |
+| `$wallets` | `UiWallet[]` | detected wallets |
+
+### Vanilla JS
+
+Read synchronously, or subscribe:
+
+```ts
+// Snapshot
+const conn = dAppKit.stores.$connection.get();
+if (conn.isConnected) console.log(conn.account?.address);
+
+// Subscribe (returns unsubscribe — always clean up)
+const unsub = dAppKit.stores.$connection.subscribe((c) => {
+  const el = document.getElementById('status');
+  if (!el) return;
+  el.textContent = c.isConnected
+    ? `${c.wallet?.name}: ${c.account?.address}`
+    : 'Not connected';
+});
+
+// Cleanup
+unsub();
+```
+
+### Vue (`@nanostores/vue`)
+
+```vue
+<script setup lang="ts">
+import { useStore } from '@nanostores/vue';
+import { Transaction } from '@mysten/sui/transactions';
+import { dAppKit } from './dapp-kit';
+
+const connection = useStore(dAppKit.stores.$connection);
+const network = useStore(dAppKit.stores.$currentNetwork);
+
+async function handleTransfer() {
+  if (!connection.value.account) return;
+
+  const tx = new Transaction();
+  // ... build PTB with @mysten/sui (see sui-sdks skill) ...
+
+  const result = await dAppKit.signAndExecuteTransaction({ transaction: tx });
+  if (result.$kind === 'FailedTransaction') {
+    throw new Error(result.FailedTransaction.status.error?.message ?? 'Failed');
+  }
+
+  const client = dAppKit.getClient();
+  await client.waitForTransaction({ digest: result.Transaction.digest });
+}
+</script>
+
+<template>
+  <mysten-dapp-kit-connect-button :instance="dAppKit" />
+  <div v-if="connection.account">
+    <p>{{ connection.wallet?.name }}: {{ connection.account.address }}</p>
+    <button @click="handleTransfer">Send</button>
+  </div>
+</template>
+```
+
+### Svelte
+
+```svelte
+<script lang="ts">
+  import { dAppKit } from './dapp-kit';
+  let connection = dAppKit.stores.$connection.get();
+  dAppKit.stores.$connection.subscribe((c) => connection = c);
+</script>
+```
+
+For idiomatic Svelte stores, nanostores has a `@nanostores/svelte` integration.
+
+## Accessing the client outside React
+
+```ts
+// Current network's client
+const client = dAppKit.getClient();
+// or equivalently:
+const client = dAppKit.stores.$currentClient.get();
+
+// Specific network (must be in the `networks` array)
+const mainnetClient = dAppKit.getClient('mainnet');
+```
+
+## Actions (identical to React side)
+
+All methods hang off the dApp Kit instance:
+
+```ts
+await dAppKit.signAndExecuteTransaction({ transaction });
+await dAppKit.signTransaction({ transaction });
+await dAppKit.signPersonalMessage({ message });
+await dAppKit.connectWallet({ wallet });
+await dAppKit.disconnectWallet();
+await dAppKit.switchNetwork('mainnet');
+await dAppKit.switchAccount({ account });
+```
+
+## Common mistakes
+
+- **Setting `instance` as an HTML attribute** (`<... instance="dAppKit">`) — doesn't work; it's a DOM property.
+- **Registering Web Components per component** — `import '@mysten/dapp-kit-core/web'` once at the app entry point.
+- **Reading store value without `.get()` in vanilla JS** — `dAppKit.stores.$connection` is a store, not its value.
+- **Forgetting to unsubscribe** — long-lived subscriptions leak memory.
+- **Using `@mysten/dapp-kit-react` bindings in Vue** — wrong package; use `-core`.

--- a/frontend-apps/queries.md
+++ b/frontend-apps/queries.md
@@ -1,0 +1,175 @@
+# Querying on-chain data in dApps
+
+TanStack React Query + `useCurrentClient`. `useSuiClientQuery` / `useSuiClientInfiniteQuery` are **removed** — don't look for them.
+
+## Basic query
+
+```tsx
+import { useCurrentClient, useCurrentAccount } from '@mysten/dapp-kit-react';
+import { useQuery } from '@tanstack/react-query';
+
+function Balance() {
+  const client = useCurrentClient();
+  const account = useCurrentAccount();
+
+  const { data, isPending, error } = useQuery({
+    queryKey: ['balance', account?.address, '0x2::sui::SUI'],
+    queryFn: () =>
+      client.core.listBalances({ owner: account!.address }),
+    enabled: !!account,          // ← crucial — skip until connected
+  });
+
+  if (isPending) return <Spinner />;
+  if (error) return <Error message={error.message} />;
+
+  const sui = data.find((b) => b.coinType === '0x2::sui::SUI');
+  return <p>{Number(sui?.totalBalance ?? 0n) / 1e9} SUI</p>;
+}
+```
+
+**Always `enabled: !!account`** for queries that require an owner. Without it, the query fires with `undefined` and errors.
+
+## Paginated queries
+
+`client.core.list*` methods return pages with `hasNextPage` + `nextCursor`. Use TanStack's `useInfiniteQuery`:
+
+```tsx
+import { useCurrentClient, useCurrentAccount } from '@mysten/dapp-kit-react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+function OwnedNFTs() {
+  const client = useCurrentClient();
+  const account = useCurrentAccount();
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+    queryKey: ['owned-nfts', account?.address],
+    queryFn: ({ pageParam }) =>
+      client.core.listOwnedObjects({
+        owner: account!.address,
+        cursor: pageParam,
+        type: '0xPKG::nft::NFT',
+        include: { content: true },
+      }),
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => (lastPage.hasNextPage ? lastPage.nextCursor : undefined),
+    enabled: !!account,
+  });
+
+  const all = data?.pages.flatMap((p) => p.data) ?? [];
+  return (
+    <>
+      {all.map((o) => <NFTCard key={o.objectId} object={o} />)}
+      {hasNextPage && (
+        <button onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
+          {isFetchingNextPage ? 'Loading…' : 'Load more'}
+        </button>
+      )}
+    </>
+  );
+}
+```
+
+## Core API methods (v2) — what you'll query
+
+All hang off `client.core`:
+
+| Method | Returns |
+|---|---|
+| `getObject({ objectId, include })` | single object |
+| `getObjects({ objectIds, include })` | multiple objects |
+| `listOwnedObjects({ owner, type?, cursor?, include? })` | paginated owned objects |
+| `listCoins({ owner, coinType?, cursor? })` | paginated coin objects |
+| `listBalances({ owner })` | array of per-coin-type balances |
+| `listDynamicFields({ parent, cursor? })` | paginated dynamic fields |
+| `getDynamicField({ parent, name })` | single dynamic field |
+| `getTransaction({ digest, include })` | single transaction |
+| `simulateTransaction({ transaction, sender })` | dry-run result |
+
+`include` flags replace v1's `show*`: `{ effects: true, events: true, balanceChanges: true, objectTypes: true, content: true, ... }`.
+
+## Cache invalidation after transactions
+
+```tsx
+import { useQueryClient } from '@tanstack/react-query';
+import { useDAppKit, useCurrentClient, useCurrentAccount } from '@mysten/dapp-kit-react';
+import { Transaction } from '@mysten/sui/transactions';
+
+function MintButton() {
+  const dAppKit = useDAppKit();
+  const client = useCurrentClient();
+  const account = useCurrentAccount();
+  const queryClient = useQueryClient();
+
+  async function handleMint() {
+    const tx = new Transaction();
+    // ... build PTB (see sui-sdks / ptbs) ...
+
+    const result = await dAppKit.signAndExecuteTransaction({ transaction: tx });
+    if (result.$kind === 'FailedTransaction') throw new Error('Mint failed');
+
+    // ✅ Wait for indexing BEFORE invalidating
+    await client.waitForTransaction({ digest: result.Transaction.digest });
+
+    await queryClient.invalidateQueries({ queryKey: ['balance', account?.address] });
+    await queryClient.invalidateQueries({ queryKey: ['owned-nfts', account?.address] });
+  }
+
+  return <button onClick={handleMint}>Mint</button>;
+}
+```
+
+Do **not** invalidate before `waitForTransaction` — the refetch will see stale data.
+
+## Query keys
+
+Include every input that can change the result:
+- owner address
+- coin type / object type filter
+- network (if the query reads across networks)
+- cursor / page params
+
+```ts
+queryKey: ['owned-nfts', account?.address, network, typeFilter]
+```
+
+Too loose a key causes cross-account data leakage when switching wallets. Too tight causes unnecessary refetches.
+
+## Stale-while-revalidate defaults
+
+TanStack Query aggressively refetches on window focus / reconnect. For rapidly-changing on-chain data (balances, orderbook state) this is often right. For immutable data (a specific tx digest, a past object version) it's wasteful — tune `staleTime`:
+
+```ts
+useQuery({
+  queryKey: ['tx', digest],
+  queryFn: () => client.core.getTransaction({ digest, include: { effects: true } }),
+  staleTime: Infinity,   // transactions don't change once finalized
+});
+```
+
+## Derivations
+
+Prefer to derive in the component, not in the query:
+
+```tsx
+const { data: balances } = useQuery({ queryKey: ['balances', addr], queryFn: ... });
+const sui = balances?.find((b) => b.coinType === '0x2::sui::SUI');  // derive here
+const suiAmount = Number(sui?.totalBalance ?? 0n) / 1e9;
+```
+
+Don't transform inside `queryFn` — TanStack's dedupe / cache works on the raw return, and double-transforming confuses invalidation.
+
+## Don't use `queryFn` to run transactions
+
+Queries should be pure reads. Transactions go in event handlers / mutations:
+
+```tsx
+// ❌ Don't do this
+useQuery({ queryFn: () => dAppKit.signAndExecuteTransaction(...) });
+
+// ✅ Do this — imperative in an event handler
+async function onClick() {
+  const result = await dAppKit.signAndExecuteTransaction(...);
+}
+```
+
+If you want a mutation hook pattern, use TanStack's `useMutation` + `dAppKit.signAndExecuteTransaction` — dApp Kit no longer exports its own mutation hook.

--- a/frontend-apps/queries.md
+++ b/frontend-apps/queries.md
@@ -31,7 +31,7 @@ function Balance() {
 
 ## Paginated queries
 
-`client.core.list*` methods return pages with `hasNextPage` + `nextCursor`. Use TanStack's `useInfiniteQuery`:
+`client.core.list*` methods return a single nullable `cursor` field — iterate while it's non-null. The response shape also contains the results under a method-specific key: `objects` for `listOwnedObjects`, `coins` for `listCoins`, `dynamicFields` for `listDynamicFields`, etc. Use TanStack's `useInfiniteQuery`:
 
 ```tsx
 import { useCurrentClient, useCurrentAccount } from '@mysten/dapp-kit-react';
@@ -47,15 +47,16 @@ function OwnedNFTs() {
       client.core.listOwnedObjects({
         owner: account!.address,
         cursor: pageParam,
-        type: '0xPKG::nft::NFT',
+        filter: { StructType: '0xPKG::nft::NFT' },   // type filter goes under `filter`
         include: { content: true },
+        limit: 50,
       }),
     initialPageParam: undefined,
-    getNextPageParam: (lastPage) => (lastPage.hasNextPage ? lastPage.nextCursor : undefined),
+    getNextPageParam: (lastPage) => lastPage.cursor ?? undefined,
     enabled: !!account,
   });
 
-  const all = data?.pages.flatMap((p) => p.data) ?? [];
+  const all = data?.pages.flatMap((p) => p.objects) ?? [];
   return (
     <>
       {all.map((o) => <NFTCard key={o.objectId} object={o} />)}
@@ -75,17 +76,21 @@ All hang off `client.core`:
 
 | Method | Returns |
 |---|---|
-| `getObject({ objectId, include })` | single object |
-| `getObjects({ objectIds, include })` | multiple objects |
-| `listOwnedObjects({ owner, type?, cursor?, include? })` | paginated owned objects |
-| `listCoins({ owner, coinType?, cursor? })` | paginated coin objects |
-| `listBalances({ owner })` | array of per-coin-type balances |
-| `listDynamicFields({ parent, cursor? })` | paginated dynamic fields |
-| `getDynamicField({ parent, name })` | single dynamic field |
-| `getTransaction({ digest, include })` | single transaction |
-| `simulateTransaction({ transaction, sender })` | dry-run result |
+| `getObject({ objectId, include })` | `{ object }` |
+| `getObjects({ objectIds, include })` | `{ objects }` |
+| `listOwnedObjects({ owner, filter?, cursor?, limit?, include? })` | `{ objects, cursor }` |
+| `listCoins({ owner, coinType?, cursor?, limit? })` | `{ coins, cursor }` |
+| `listBalances({ owner })` | `{ balances }` |
+| `listDynamicFields({ parentId, cursor?, limit? })` | `{ dynamicFields, cursor }` |
+| `getDynamicField({ parentId, name })` | `{ dynamicField }` |
+| `getCoinMetadata({ coinType })` | `{ coinMetadata }` |
+| `getTransaction({ digest, include })` | `{ Transaction, FailedTransaction }` |
+| `simulateTransaction({ transaction, include })` | simulation result |
 
-`include` flags replace v1's `show*`: `{ effects: true, events: true, balanceChanges: true, objectTypes: true, content: true, ... }`.
+**Include options** — keys differ by method:
+- **Objects**: `content`, `previousTransaction`, `json`, `objectBcs`, `display`.
+- **Transactions**: `effects`, `events`, `balanceChanges`, `transaction`, `bcs`.
+- **Simulate**: adds `commandResults`.
 
 ## Cache invalidation after transactions
 

--- a/frontend-apps/react.md
+++ b/frontend-apps/react.md
@@ -1,0 +1,186 @@
+# React Hooks & Patterns
+
+Source: https://sdk.mystenlabs.com/dapp-kit/getting-started/react
+
+## Current hook inventory (v2 dApp Kit)
+
+| Hook | Returns | Use for |
+|---|---|---|
+| `useCurrentAccount()` | `UiWalletAccount \| null` | Connected address; null-check always required |
+| `useCurrentWallet()` | `UiWallet \| null` | Connected wallet (name, icon, accounts list) |
+| `useWalletConnection()` | `{ status, wallet, account, ... }` | Full connection state incl. `connecting` / `reconnecting` |
+| `useCurrentNetwork()` | active network string | Read current network |
+| `useCurrentClient()` | `SuiGrpcClient` for current network | Passing to TanStack Query / imperative calls |
+| `useDAppKit()` | the dApp Kit instance | Imperative actions: `signAndExecuteTransaction`, `connectWallet`, `switchNetwork`, etc. |
+| `useWallets()` | `UiWallet[]` | List detected wallets (custom wallet menu) |
+
+All of these pick up the typed instance automatically when the `declare module` augmentation is in place.
+
+## Removed hooks (do not use)
+
+| Removed | Replacement |
+|---|---|
+| `useSuiClient()` | `useCurrentClient()` |
+| `useSuiClientContext()` | `useCurrentNetwork()` (read) + `useDAppKit().switchNetwork(n)` (write) |
+| `useSuiClientQuery()` | `useCurrentClient()` + `useQuery()` (see `queries.md`) |
+| `useSuiClientInfiniteQuery()` | `useCurrentClient()` + `useInfiniteQuery()` |
+| `useSignAndExecuteTransaction()` (mutation hook) | `useDAppKit().signAndExecuteTransaction({ transaction })` |
+| `useSignTransaction()` (mutation hook) | `useDAppKit().signTransaction({ transaction })` |
+| `useSignPersonalMessage()` (mutation hook) | `useDAppKit().signPersonalMessage({ message })` |
+| `useConnectWallet()` | `useDAppKit().connectWallet({ wallet })` |
+| `useDisconnectWallet()` | `useDAppKit().disconnectWallet()` |
+
+If a tutorial or tool recommends any of the removed hooks, it's out of date.
+
+## `ConnectButton`
+
+Drop-in wallet connection button:
+
+```tsx
+import { ConnectButton } from '@mysten/dapp-kit-react';
+
+<ConnectButton />
+
+// With filtering
+<ConnectButton
+  modalOptions={{
+    filterFn: (wallet) => wallet.name !== 'ExcludedWallet',
+    sortFn: (a, b) => a.name.localeCompare(b.name),
+  }}
+/>
+```
+
+Wallet detection is browser-only. In SSR frameworks, ensure this renders client-side (`'use client'` in Next.js).
+
+## Custom wallet menu
+
+```tsx
+import { useWallets, useDAppKit, useCurrentWallet } from '@mysten/dapp-kit-react';
+
+function WalletMenu() {
+  const wallets = useWallets();
+  const dAppKit = useDAppKit();
+  const current = useCurrentWallet();
+
+  if (current) {
+    return (
+      <div>
+        <p>Connected: {current.name}</p>
+        <button onClick={() => dAppKit.disconnectWallet()}>Disconnect</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {wallets.map((wallet) => (
+        <button key={wallet.name} onClick={() => dAppKit.connectWallet({ wallet })}>
+          {wallet.name}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+## Connection state for UX
+
+`useWalletConnection` exposes the full state machine:
+
+```tsx
+import { useWalletConnection } from '@mysten/dapp-kit-react';
+
+function Status() {
+  const { status, wallet, account } = useWalletConnection();
+  // status: 'disconnected' | 'connecting' | 'reconnecting' | 'connected'
+
+  if (status === 'reconnecting') return <Spinner label="Reconnecting..." />;
+  if (status === 'connecting')  return <Spinner label="Connecting..." />;
+  if (status === 'connected')   return <p>{wallet?.name}: {account?.address}</p>;
+  return <ConnectButton />;
+}
+```
+
+`reconnecting` fires on page reload when `autoConnect: true` is restoring the last wallet. Design for it — don't treat it as `disconnected`.
+
+## Accessing the client
+
+```tsx
+import { useCurrentClient } from '@mysten/dapp-kit-react';
+
+function Component() {
+  const client = useCurrentClient();
+  // SuiGrpcClient for the current network; auto-updates on switchNetwork
+}
+```
+
+Never `new SuiGrpcClient(...)` inside a component — you'd lose network switching and duplicate connections.
+
+## Wallet-gated UI
+
+```tsx
+import { useCurrentAccount, ConnectButton } from '@mysten/dapp-kit-react';
+
+function ProtectedFeature() {
+  const account = useCurrentAccount();
+  if (!account) {
+    return (
+      <div>
+        <p>Connect your wallet to continue.</p>
+        <ConnectButton />
+      </div>
+    );
+  }
+  return <Feature address={account.address} />;
+}
+```
+
+Reusable guard:
+
+```tsx
+function WalletGuard({ children }: { children: React.ReactNode }) {
+  const account = useCurrentAccount();
+  if (!account) return <ConnectButton />;
+  return <>{children}</>;
+}
+```
+
+## Network switching
+
+```tsx
+import { useCurrentNetwork, useDAppKit } from '@mysten/dapp-kit-react';
+
+function NetworkSwitcher() {
+  const network = useCurrentNetwork();
+  const dAppKit = useDAppKit();
+
+  return (
+    <select value={network} onChange={(e) => dAppKit.switchNetwork(e.target.value)}>
+      <option value="mainnet">Mainnet</option>
+      <option value="testnet">Testnet</option>
+    </select>
+  );
+}
+```
+
+Only networks included in `createDAppKit`'s `networks` array are valid. `switchNetwork` updates the dApp's active client — it does not ask the wallet to switch.
+
+## Account details
+
+```tsx
+const account = useCurrentAccount();       // UiWalletAccount | null
+// account.address, account.label, account.chains, account.features
+```
+
+Always null-check:
+```tsx
+if (!account) return <ConnectButton />;
+```
+
+## Patterns to avoid
+
+- **Nested providers**: one `DAppKitProvider` only.
+- **Duplicate `createDAppKit`** calls: create the instance once in a module file, import everywhere.
+- **Accessing `window.navigator.wallets` directly**: use `useWallets()`.
+- **Reaching into the wallet's internals**: if a feature isn't exposed on the dApp Kit API, open an issue or fall back to `wallet.features['<name>']` — but this is rare.
+- **Using any removed hook**.

--- a/frontend-apps/setup.md
+++ b/frontend-apps/setup.md
@@ -1,0 +1,201 @@
+# Setup — install, factory, provider
+
+Source: https://sdk.mystenlabs.com/dapp-kit/getting-started/react · https://sdk.mystenlabs.com/dapp-kit/getting-started/next-js · https://sdk.mystenlabs.com/dapp-kit/getting-started/vue
+
+## Packages
+
+| Package | Use for |
+|---|---|
+| `@mysten/dapp-kit-react` | React / Next.js apps |
+| `@mysten/dapp-kit-core` | Vue, Svelte, Solid, vanilla JS, Web Components |
+| `@mysten/sui` | Sui TypeScript SDK — always a peer dep |
+| `@tanstack/react-query` | Declarative on-chain data fetching (React) |
+| `@nanostores/vue` | Vue reactive bindings to dApp Kit stores |
+
+Install (React):
+```bash
+npm install @mysten/dapp-kit-react @mysten/sui @tanstack/react-query
+```
+
+Install (Vue / vanilla):
+```bash
+npm install @mysten/dapp-kit-core @mysten/sui
+npm install @nanostores/vue      # if Vue
+```
+
+**Never install `@mysten/dapp-kit` (no suffix)** for new code — deprecated, JSON-RPC only.
+
+## React setup
+
+Create a single instance file:
+
+```ts
+// dapp-kit.ts
+import { createDAppKit } from '@mysten/dapp-kit-react';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const GRPC_URLS: Record<string, string> = {
+  mainnet: 'https://fullnode.mainnet.sui.io:443',
+  testnet: 'https://fullnode.testnet.sui.io:443',
+  devnet:  'https://fullnode.devnet.sui.io:443',
+};
+
+export const dAppKit = createDAppKit({
+  networks: ['testnet', 'mainnet'],
+  defaultNetwork: 'testnet',
+  createClient: (network) =>
+    new SuiGrpcClient({ network, baseUrl: GRPC_URLS[network] }),
+});
+
+// TypeScript augmentation — hooks pick up the instance type without explicit passing
+declare module '@mysten/dapp-kit-react' {
+  interface Register {
+    dAppKit: typeof dAppKit;
+  }
+}
+```
+
+Wrap the app:
+
+```tsx
+// App.tsx
+import { DAppKitProvider, ConnectButton } from '@mysten/dapp-kit-react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { dAppKit } from './dapp-kit';
+
+const queryClient = new QueryClient();
+
+export default function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <DAppKitProvider dAppKit={dAppKit}>
+        <ConnectButton />
+        <YourApp />
+      </DAppKitProvider>
+    </QueryClientProvider>
+  );
+}
+```
+
+Provider ordering between `QueryClientProvider` and `DAppKitProvider` doesn't matter — they don't share context.
+
+## Next.js setup
+
+The dApp Kit uses browser-only APIs (wallet detection). Mark wallet-aware components with `'use client'`:
+
+```tsx
+// app/layout.tsx (server component — no 'use client')
+import { Providers } from './providers';
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <html><body><Providers>{children}</Providers></body></html>;
+}
+```
+
+```tsx
+// app/providers.tsx
+'use client';
+import { DAppKitProvider } from '@mysten/dapp-kit-react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { dAppKit } from './dapp-kit';
+
+const queryClient = new QueryClient();
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <DAppKitProvider dAppKit={dAppKit}>{children}</DAppKitProvider>
+    </QueryClientProvider>
+  );
+}
+```
+
+Any component using dApp Kit hooks also needs `'use client'` at its top.
+
+## Vue setup
+
+```ts
+// dapp-kit.ts
+import { createDAppKit } from '@mysten/dapp-kit-core';   // ← core, not -react
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const GRPC_URLS: Record<string, string> = {
+  mainnet: 'https://fullnode.mainnet.sui.io:443',
+  testnet: 'https://fullnode.testnet.sui.io:443',
+};
+
+export const dAppKit = createDAppKit({
+  networks: ['testnet', 'mainnet'],
+  defaultNetwork: 'testnet',
+  createClient: (network) =>
+    new SuiGrpcClient({ network, baseUrl: GRPC_URLS[network] }),
+});
+```
+
+No `declare module` augmentation needed — that's React-only.
+
+Register Web Components once at app entry:
+```ts
+// main.ts
+import '@mysten/dapp-kit-core/web';
+```
+
+Then in any template:
+```vue
+<mysten-dapp-kit-connect-button :instance="dAppKit" />
+```
+
+See `non-react.md` for full Vue / Web Components / vanilla JS details.
+
+## Vanilla JS / Svelte / other
+
+Same as Vue: use `@mysten/dapp-kit-core`, create a single `dAppKit` instance, register `@mysten/dapp-kit-core/web` at app entry, bind the `instance` property on Web Components.
+
+For reactive UI, subscribe to `dAppKit.stores.$connection` etc. See `non-react.md`.
+
+## `createDAppKit` options
+
+```ts
+createDAppKit({
+  networks: ['testnet', 'mainnet'],   // supported networks; strings, used as keys
+  defaultNetwork: 'testnet',          // starts here
+  createClient: (network) => ...,     // called lazily per network, once
+  autoConnect: true,                  // default: true — restores last wallet on load
+  // autoConnect: false to require explicit connect each session
+});
+```
+
+`createClient` is called per network on first use. Cache of `SuiGrpcClient` instances is kept inside dApp Kit — don't create your own.
+
+## Migrating from the old three-provider stack
+
+```tsx
+// ❌ Old pattern (pre-createDAppKit)
+<QueryClientProvider client={queryClient}>
+  <SuiClientProvider networks={networks} defaultNetwork="testnet">
+    <WalletProvider autoConnect>
+      <App />
+    </WalletProvider>
+  </SuiClientProvider>
+</QueryClientProvider>
+
+// ✅ New pattern
+<QueryClientProvider client={queryClient}>
+  <DAppKitProvider dAppKit={dAppKit}>
+    <App />
+  </DAppKitProvider>
+</QueryClientProvider>
+```
+
+Also swap hooks — `useSuiClient` → `useCurrentClient`, `useSignAndExecuteTransaction` → `dAppKit.signAndExecuteTransaction` via `useDAppKit()`. See `react.md` for the full hook map.
+
+## Sanity check
+
+Before writing feature code, verify:
+
+- [ ] `package.json` includes `@mysten/dapp-kit-react` (or `-core`), **not** bare `@mysten/dapp-kit`.
+- [ ] `createClient` uses `SuiGrpcClient` (imported from `@mysten/sui/grpc`).
+- [ ] Each network in `networks` has a matching `baseUrl` entry in `GRPC_URLS`.
+- [ ] `declare module '@mysten/dapp-kit-react'` augmentation is present (React only).
+- [ ] Next.js: wallet-aware components have `'use client'`.
+- [ ] Only one `DAppKitProvider` in the component tree.
+- [ ] `QueryClientProvider` wraps (or is wrapped by) `DAppKitProvider` if TanStack Query is used.

--- a/frontend-apps/transactions.md
+++ b/frontend-apps/transactions.md
@@ -1,0 +1,201 @@
+# Signing and executing transactions in dApps
+
+Source: https://sdk.mystenlabs.com/dapp-kit/getting-started/react
+
+## Full pattern
+
+```tsx
+import { useDAppKit, useCurrentClient, useCurrentAccount } from '@mysten/dapp-kit-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Transaction } from '@mysten/sui/transactions';
+import { useState } from 'react';
+
+function ActionButton() {
+  const dAppKit = useDAppKit();
+  const client = useCurrentClient();
+  const account = useCurrentAccount();
+  const queryClient = useQueryClient();
+
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handle() {
+    if (!account) return;
+    setIsPending(true);
+    setError(null);
+
+    try {
+      // Build the PTB — see sui-sdks / ptbs skills for patterns
+      const tx = new Transaction();
+      const [coin] = tx.splitCoins(tx.gas, [tx.pure.u64(1_000_000n)]);
+      tx.transferObjects([coin], tx.pure.address('0xrecipient'));
+
+      // Hand the Transaction to the wallet — DO NOT call tx.build() first
+      const result = await dAppKit.signAndExecuteTransaction({ transaction: tx });
+
+      // Check failure
+      if (result.$kind === 'FailedTransaction') {
+        throw new Error(result.FailedTransaction.status.error?.message ?? 'Transaction failed');
+      }
+
+      // Wait for indexing, then invalidate caches
+      const digest = result.Transaction.digest;
+      await client.waitForTransaction({ digest });
+      await queryClient.invalidateQueries({ queryKey: ['balance', account.address] });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <>
+      <button onClick={handle} disabled={!account || isPending}>
+        {isPending ? 'Waiting for wallet…' : 'Submit'}
+      </button>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </>
+  );
+}
+```
+
+## Result shape
+
+`signAndExecuteTransaction` returns a discriminated union keyed on `$kind`:
+
+```ts
+type Result =
+  | { $kind: 'Transaction'; Transaction: { digest: string; /* ... */ } }
+  | { $kind: 'FailedTransaction'; FailedTransaction: { status: { error?: { message: string } } } };
+```
+
+Access patterns:
+
+```ts
+if (result.$kind === 'FailedTransaction') {
+  // result.FailedTransaction is populated
+  console.error(result.FailedTransaction.status.error?.message);
+  return;
+}
+// result.Transaction is populated
+const digest = result.Transaction.digest;
+```
+
+Do **not** use v1's `result.effects?.status?.status === 'success'` — that shape is gone.
+
+## Handing PTBs to the wallet
+
+**Pass the `Transaction` instance directly.** dApp Kit serializes it and forwards to the wallet, which selects gas coins and sets budget via dry-run.
+
+```tsx
+// ✅
+await dAppKit.signAndExecuteTransaction({ transaction: tx });
+
+// ❌ Do NOT build bytes in app code — wallet can't do gas selection
+const bytes = await tx.build({ client });
+await dAppKit.signAndExecuteTransaction({ transaction: bytes });
+```
+
+The one exception is sponsored transactions — see below.
+
+## Signing without executing (sponsored flow)
+
+When your backend pays for gas, the wallet signs but the app submits via your sponsor service:
+
+```tsx
+async function handleSponsored() {
+  const tx = new Transaction();
+  // ... build PTB ...
+
+  // Wallet signs but does not execute
+  const { bytes, signature } = await dAppKit.signTransaction({ transaction: tx });
+
+  // Hand off to your sponsor backend
+  const res = await fetch('/api/sponsor', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ bytes, signature }),
+  });
+  const { digest } = await res.json();
+
+  await client.waitForTransaction({ digest });
+}
+```
+
+For the backend side of the sponsored flow (setting gas owner, attaching sponsor signature, executing with both signatures), see the `ptbs` skill — the sponsor pattern with `tx.build({ onlyTransactionKind: true })` and `Transaction.fromKind`.
+
+## Personal message signing
+
+Use for wallet-based authentication (Sign-In-with-Sui / off-chain login):
+
+```tsx
+import { useDAppKit, useCurrentAccount } from '@mysten/dapp-kit-react';
+
+async function handleAuth() {
+  const dAppKit = useDAppKit();
+  const account = useCurrentAccount();
+  if (!account) return;
+
+  // Fetch a single-use nonce from your backend
+  const { nonce } = await fetch('/api/auth/nonce').then((r) => r.json());
+  const message = new TextEncoder().encode(`Sign in to MyApp: nonce=${nonce}`);
+
+  const { bytes, signature } = await dAppKit.signPersonalMessage({ message });
+
+  // Verify server-side, invalidate the nonce
+  await fetch('/api/auth/verify', {
+    method: 'POST',
+    body: JSON.stringify({ address: account.address, bytes, signature }),
+  });
+}
+```
+
+- **Message must be `Uint8Array`** — use `TextEncoder` on strings.
+- **Display the message clearly** — users see it in the wallet.
+- **Use a server-issued, single-use nonce** — client-side nonces are replayable.
+
+## The `waitForTransaction` + invalidate sequence
+
+This is the single most commonly missed pattern:
+
+```
+tx signed → wallet returns digest → fullnode finalizes (fast)
+                                          ↓
+                                  fullnode indexes (async, a few hundred ms)
+                                          ↓
+                              waitForTransaction resolves
+                                          ↓
+                           NOW safe to invalidate / refetch
+```
+
+```ts
+// ❌ Refetch fires before indexer has caught up — stale data
+await dAppKit.signAndExecuteTransaction(...);
+await queryClient.invalidateQueries(...);  // BAD
+
+// ✅ Wait first
+const result = await dAppKit.signAndExecuteTransaction(...);
+if (result.$kind === 'FailedTransaction') throw new Error(...);
+await client.waitForTransaction({ digest: result.Transaction.digest });
+await queryClient.invalidateQueries(...);  // GOOD
+```
+
+## Error handling — common wallet failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| User rejects in wallet | normal | Catch and show a "cancelled" state — not an error |
+| "Insufficient gas" | wallet has too little SUI | UX: surface the address and amount, suggest faucet (testnet) or exchange (mainnet) |
+| "Nothing to execute" | PTB has no effective commands | Check you actually added commands to `tx` before signing |
+| Tx executes but fails Move assertion | Move code aborted | Catch `result.FailedTransaction`, surface the error message verbatim |
+| Tx succeeds but UI doesn't update | missing `waitForTransaction` / `invalidateQueries` | Add both, in that order |
+| "Wallet not available" in dev | SSR rendered before hydration | `'use client'` in Next.js; guard render until wallet detected |
+
+## Don't fetch gas info before sending
+
+Leave gas budget / price / payment to the wallet. If you hardcode `setGasBudget` or `setGasPayment` in the app, the wallet can't adjust for fluctuating gas prices or replace gas coins. The one exception is sponsored flows, where a sponsor service fills gas data before the wallet signs.
+
+## PTB construction
+
+See the `ptbs` skill for command-by-command semantics and the `sui-sdks` skill (`typescript.md`) for the `Transaction` class API. This skill covers the *dApp-side* of the flow; building the PTB itself is the same in dApp, backend, or CLI code.


### PR DESCRIPTION
## Summary
- Adds a \`frontend-apps/\` skill for Sui dApp development with \`@mysten/dapp-kit-react\` (React) and \`@mysten/dapp-kit-core\` (Vue, vanilla, Web Components).
- Builds on the existing \`~/sui-dev-skills/sui-frontend\` starting point. The content is refined into a routed skill: SKILL.md carries the hard rules + removed-hook migration table; reference files cover setup, React hooks, non-React patterns, TanStack Query, transaction execution, and browser-environment limitations.
- Explicitly calls out the three most common dApp failure modes the skill exists to prevent: deprecated \`@mysten/dapp-kit\` package, wrong client class (\`SuiJsonRpcClient\` in \`createClient\`), and usage of removed hooks (\`useSuiClientQuery\`, \`useSignAndExecuteTransaction\`, \`useSuiClient\`, \`useConnectWallet\`, etc.).

## Skill rules worth highlighting
- Package: \`@mysten/dapp-kit-react\` or \`@mysten/dapp-kit-core\`. Never bare \`@mysten/dapp-kit\`.
- \`createClient\` must return a \`SuiGrpcClient\`. Not \`SuiJsonRpcClient\`, not \`SuiClient\` (v1, removed).
- Setup is \`createDAppKit\` + single \`DAppKitProvider\`. The v1 three-provider stack is gone.
- Always \`waitForTransaction\` before \`invalidateQueries\` after a write.
- Pass the \`Transaction\` instance (or \`tx.serialize()\`) to the wallet — never pre-built bytes, except in sponsored \`onlyTransactionKind\` flows.
- Check \`result.\$kind === 'FailedTransaction'\`, not v1's \`result.effects?.status?.status\`.
- SSR/Next.js: wallet-aware components need \`'use client'\`.

## Test plan
- [ ] Evals cover: React setup, transaction flow w/ waitForTransaction + invalidate, paginated owned-NFT query, deprecated package detection, sponsored sign-only flow, Vue setup, bad-code review with multiple outdated patterns, Next.js SSR handling.
- [ ] Each eval has explicit \`expectations\` asserting what must appear and what must not.
- [ ] Sources field points to the authoritative dapp-kit getting-started pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)