### PR TITLE
Add accessing-data skill

### DIFF
--- a/accessing-data/SKILL.md
+++ b/accessing-data/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: accessing-data
+description: >
+  How to read data from the Sui network. Use when choosing or implementing
+  a data access strategy — queries for on-chain state, indexing pipelines,
+  historical lookups, event subscriptions, cross-chain reads, or off-chain
+  blob storage. Covers the three live Sui APIs (gRPC, GraphQL RPC,
+  deprecated JSON-RPC), the Archival Store, the General-Purpose Indexer,
+  the `sui-indexer-alt` custom indexing framework, and Walrus for off-chain
+  blobs.
+---
+
+# Accessing Data on Sui
+
+"How do I read data from Sui?" is the most frequently mis-answered question in agent-written Sui code. The defaults have changed. This skill fixes it.
+
+**Key fact: JSON-RPC is deprecated.** From the official docs:
+
+> JSON-RPC is deprecated. Migrate to either gRPC or GraphQL RPC by July 2026.
+
+Any code — or tutorial — that uses JSON-RPC for new reads is wrong for mainnet past mid-2026.
+
+The four canonical data surfaces are:
+
+1. **gRPC** — low-latency, real-time, code-gen-friendly. Served by full nodes. Supports streaming/subscriptions. The default for transaction submission, live reads, and ingestion pipelines.
+2. **GraphQL RPC (beta)** — flexible relational queries over the General-Purpose Indexer's Postgres + full node + Archival Store. Best for frontends, dashboards, wallets. Lower latency bar than gRPC.
+3. **Archival Store (beta)** — long-term historical storage of transactions, checkpoints, and object states beyond full-node pruning. Accessed via gRPC or GraphQL RPC; not a separate API you call directly.
+4. **Custom indexer (`sui-indexer-alt`)** — build your own Postgres schema keyed on exactly the on-chain data your app needs. Ingests checkpoints from GCS (backfill) + full node gRPC (steady state).
+
+Off-chain blob data (images, audio, models, large JSON) belongs on **Walrus**, not on-chain. Sui stores blob metadata; the blobs themselves sit on Walrus storage nodes.
+
+All patterns in this skill are derived from:
+- https://docs.sui.io/concepts/data-access/data-serving (overview & deprecation notice)
+- https://docs.sui.io/concepts/data-access/graphql-rpc (GraphQL)
+- https://docs.sui.io/concepts/data-access/archival-store (archival)
+- https://docs.sui.io/guides/operator/indexer-stack-setup (general-purpose indexer)
+- https://docs.wal.app (Walrus)
+
+If unsure about an API, fetch from the relevant page before answering. Do not guess from Ethereum/Solana analogs — Sui's data surfaces are distinct.
+
+---
+
+## Reference files
+
+### grpc — gRPC API
+**Path:** `grpc.md`
+**Load when:** writing backend services, indexers, exchanges, market makers, real-time clients, or any high-throughput read path. Also when subscribing to effects streams or doing dry runs / transaction simulation.
+**Covers:** service surface (`ledger_service`, `transaction_execution_service`, `move_package_service`, `name_service`, `subscription_service`), endpoint URLs per network, the TypeScript (`SuiGrpcClient`) and Rust (`sui-rpc` crate) clients, streaming vs request-response, code-gen for arbitrary languages.
+
+### graphql — GraphQL RPC
+**Path:** `graphql.md`
+**Load when:** the app needs flexible, composable queries — e.g., a frontend that joins object data with owner metadata and event history in a single request, or historical queries with filters. Beta status — verify stability before building production-critical paths on top.
+**Covers:** GraphQL endpoint URLs, relationship to the General-Purpose Indexer + Archival Store, `SuiGraphQLClient` usage, typical query shapes, pagination patterns, rate limits, caveats of beta.
+
+### indexers — Custom indexing (`sui-indexer-alt`)
+**Path:** `indexers.md`
+**Load when:** a user asks "how do I track X event across history?", "how do I build an explorer / leaderboard / analytics pipeline?", or when a GraphQL or gRPC query is too slow / not filterable the way they need.
+**Covers:** the checkpoint-streaming pipeline model, backfill (GCS buckets like `gs://mysten-mainnet-checkpoints-use4`) vs steady-state (full node gRPC), writing a pipeline config (`events.toml`, `obj_versions.toml` patterns), concurrency tuning, and when to run the General-Purpose Indexer vs a custom one.
+
+### archival — Archival Store
+**Path:** `archival.md`
+**Load when:** the data you need has been pruned from full nodes — old transactions, old object versions, old checkpoints. Don't call it directly from app code; route via GraphQL RPC or gRPC clients that know how to fall back.
+**Covers:** what the Archival Store retains, why pruning exists, how it integrates under gRPC / GraphQL, use cases (compliance, dispute resolution, long-range analytics).
+
+### walrus — Off-chain blob storage
+**Path:** `walrus.md`
+**Load when:** the user wants to store a file (image, audio, model, document, large JSON, video) "on Sui" or is trying to put megabytes of data into a Move object. Route them to Walrus.
+**Covers:** why you don't put blobs on-chain (250 KB per-object cap, storage-fund economics), the Walrus model (erasure-coded blobs stored off-chain with on-chain availability certificates), blob lifecycle, and the `@mysten/walrus` client extension.
+
+### use-cases — Use case → method mapping
+**Path:** `use-cases.md`
+**Load when:** the user describes what they want to *do* and you need to pick the right surface. This is the first file to load for an unfamiliar data access request.
+**Covers:** table of common use cases (balance lookup, owned-object list, event subscription, historical point-in-time read, analytics dashboard, cross-table joins, blob storage) mapped to the right API with rationale.
+
+## Routing guide
+
+| Task | Load |
+|------|------|
+| "How do I read X from Sui?" (first-pass question) | use-cases |
+| Writing a backend/indexer read path | grpc + indexers |
+| Writing a frontend data query | graphql (+ frontend-apps skill for hook patterns) |
+| Building a custom analytics / explorer pipeline | indexers |
+| Looking up data older than full-node retention | archival + graphql |
+| Storing / retrieving a large file | walrus |
+| Migrating an existing JSON-RPC app | use-cases + grpc + graphql |
+| Designing a new app from scratch | use-cases + grpc |
+| Full code review of a data-heavy app | **all reference files** |
+
+## Skill Content
+
+### Key concepts
+
+- **JSON-RPC is deprecated.** Full deactivation targeted for **July 2026**. Any new code must default to gRPC or GraphQL RPC. Existing JSON-RPC code must be migrated.
+- **gRPC is the performance default.** Typed protobuf, streaming, low latency, polyglot client code gen (TS, Rust, Go, Python, etc.). Served directly by full nodes.
+- **GraphQL RPC is the flexibility default.** Reads from the General-Purpose Indexer's Postgres + full node + Archival Store. One request can span multiple entity types. Beta — tolerate some API churn.
+- **Archival Store is transparent.** You don't pick "the archival API." You call gRPC or GraphQL RPC and the service falls back to archival storage when the data has been pruned from full nodes.
+- **Custom indexers exist because no hosted API fits every query shape.** If you need filtered sorts over millions of rows with app-specific indexes, run your own `sui-indexer-alt` pipeline.
+- **On-chain storage is not general-purpose blob storage.** Max Move object size is 250 KB. Storage is paid once (storage fund redistributes returns to validators). Big files go to Walrus.
+- **The storage fund does not "hold your data."** It's an economic mechanism: a fraction of each write fee goes in; validators earn yield that pays for ongoing storage. It affects pricing, not where you store.
+
+### Rules
+
+1. **Absolutely no JSON-RPC for new code.** If a tutorial says `new SuiClient({ url: getFullnodeUrl(...) })`, replace with `new SuiGrpcClient({ network, baseUrl })`. If a user insists on JSON-RPC, name the deprecation + July 2026 sunset and offer `SuiJsonRpcClient` only as a migration stopgap.
+2. **Default to gRPC (`SuiGrpcClient` in TS, `sui-rpc` crate in Rust).** Only switch to GraphQL when you need multi-entity joins or historical filtered reads that gRPC services don't cover.
+3. **Don't reach for the Archival Store directly.** Use gRPC or GraphQL; the server-side stack falls back to archival automatically for pruned data.
+4. **Build a custom indexer only when hosted APIs don't fit.** Operating an indexer is ongoing work — Postgres, checkpoint ingestion, failure handling. Evaluate GraphQL RPC first.
+5. **Put large files on Walrus.** Never advise embedding images/audio/video in Move objects or in transaction inputs. If the user is trying to, route them to the `walrus` reference file.
+6. **Map use case → method correctly.** See `use-cases.md`:
+   - Live balance / owned-object / coin list → **gRPC `client.core.*`**.
+   - Flexible multi-entity query for a frontend → **GraphQL RPC**.
+   - Historical transaction > N days old → **GraphQL RPC (routes through archival)**.
+   - Custom leaderboard / analytics across all events → **custom indexer**.
+   - Transaction subscription / real-time effects feed → **gRPC streaming**.
+   - Large files → **Walrus**.
+7. **Waiting for indexing is separate from read API choice.** After `signAndExecuteTransaction`, call `client.waitForTransaction({ digest })` before the follow-up read. This applies to both gRPC and GraphQL paths.
+8. **Cite docs when unsure.** All sources listed above.
+
+### Common mistakes
+
+- **Using `client.getObject` / `client.getOwnedObjects` / `client.getCoins`** — these are v1 JSON-RPC method names. v2 is `client.core.getObject` / `client.core.listOwnedObjects` / `client.core.listCoins` on any of the v2 clients.
+- **Recommending "the Sui API" without specifying which.** "The Sui API" conflates three different interfaces with different use cases. Always name gRPC / GraphQL / JSON-RPC.
+- **Telling users to "use the indexer"** for a simple query that gRPC covers in one method. Only reach for a custom indexer when you've outgrown the hosted APIs.
+- **Storing images or large JSON "on Sui."** Sui's 250 KB object size limit and pricing model make this wrong. Use Walrus.
+- **Assuming all three APIs return the same shape.** gRPC is protobuf; GraphQL is typed GraphQL; JSON-RPC is JSON with v1-specific nesting. Response shapes differ; field names differ; pagination differs.
+- **Polling for events via JSON-RPC.** Use gRPC streaming / subscriptions instead. Polling is high-cost and high-latency.
+- **Reading from an RPC node and writing to a different one expecting read-after-write consistency.** Fullnodes are eventually consistent across the network. Read from the same node you wrote to, or `waitForTransaction` before cross-node reads.
+- **Conflating "storage fund" with "storage service."** The storage fund is a tokenomics mechanism. It is not an API you call.

--- a/accessing-data/archival.md
+++ b/accessing-data/archival.md
@@ -1,0 +1,57 @@
+# Archival Store
+
+Source: https://docs.sui.io/concepts/data-access/archival-store
+
+**Beta.**
+
+## What it is
+
+From the docs:
+> The Archival Store provides "long-term storage and access to historical network data that might no longer be available on full nodes because of pruning."
+> Full nodes "enforce limited retention for scalability and performance," which is why this archival infrastructure exists — to preserve data after nodes discard it.
+
+It retains:
+- Old transactions.
+- Old checkpoints.
+- Old object versions (point-in-time state).
+
+## Why pruning exists
+
+Full nodes serve real-time queries. Retaining the entire history on every node would balloon storage and degrade query performance. Pruning lets full nodes stay fast by offloading older data to the archival backbone.
+
+## Access model — **don't call it directly**
+
+You don't point a client at the Archival Store. You call gRPC or GraphQL RPC as normal, and the server-side stack falls back to archival for data that's been pruned from the full node.
+
+From the docs:
+> The service is accessible via "gRPC-based" API calls, supporting both "GraphQL RPC" and direct "gRPC-based apps."
+
+So: your gRPC client or GraphQL client transparently benefits from archival when asking for old data. For most apps the Archival Store is invisible.
+
+## When it matters
+
+- **Compliance / audit** — proving on-chain activity from months or years ago.
+- **Dispute resolution** — "what did this object look like at checkpoint X?".
+- **Long-range analytics** — backfilling a custom indexer from deep history.
+- **Historical explorers** — letting users browse old transactions beyond the live full node retention.
+
+## Example: historical object version
+
+GraphQL RPC is the easiest way to request a specific past version:
+
+```graphql
+query { object(address: "0x...", version: 42) { ... } }
+```
+
+If version 42 has been pruned from the full node, GraphQL RPC pulls it from the archival backbone. No client-side logic needed.
+
+## For custom indexer backfills
+
+When seeding a custom `sui-indexer-alt` pipeline from history, point the backfill source at the checkpoint GCS bucket (e.g., `gs://mysten-mainnet-checkpoints-use4`) rather than the archival service — the buckets are the canonical historical source for checkpoint ingestion. The Archival Store is the **query-side** counterpart to this; the backfill side of a custom indexer reads checkpoints directly.
+
+## Common mistakes
+
+- **Assuming full nodes have the whole history.** They don't. Past the pruning horizon, the archival path kicks in — if your code bypasses it, you see "not found."
+- **Trying to call the Archival Store directly.** There's no public "archival API." Use gRPC or GraphQL.
+- **Skipping Archival coverage checks in beta.** Archival Store is in beta; some ranges may not yet be fully populated. Verify before building critical paths that depend on deep history.
+- **Confusing "Archival Store" with "checkpoint store."** Checkpoint store (GCS buckets) is the canonical checkpoint archive for backfill ingestion. Archival Store is the query-side service that serves pruned reads to gRPC/GraphQL clients. Related but distinct.

--- a/accessing-data/evals/evals.json
+++ b/accessing-data/evals/evals.json
@@ -1,0 +1,145 @@
+[
+  {
+    "id": "accessing-data-no-json-rpc",
+    "prompt": "I want to build a Node.js backend that reads a user's SUI balance and lists their owned NFTs. Which API should I use and how do I set up the client?",
+    "sources": [
+      "https://docs.sui.io/concepts/data-access/data-serving",
+      "https://sdk.mystenlabs.com/sui"
+    ],
+    "expected_output": "Recommends gRPC via SuiGrpcClient, imported from '@mysten/sui/grpc'. Shows client instantiation with network + baseUrl (https://fullnode.mainnet.sui.io:443). Uses client.core.listBalances and client.core.listOwnedObjects. Explicitly does NOT recommend JSON-RPC and notes it is deprecated with a July 2026 sunset.",
+    "expectations": [
+      "Recommends gRPC / SuiGrpcClient, NOT JSON-RPC / SuiClient / SuiJsonRpcClient",
+      "Imports SuiGrpcClient from '@mysten/sui/grpc'",
+      "Passes both network and baseUrl to the constructor",
+      "Uses client.core.listBalances (v2 Core API) for balance read",
+      "Uses client.core.listOwnedObjects for owned objects",
+      "Explicitly flags JSON-RPC as deprecated / names the July 2026 sunset date",
+      "Does NOT use client.getBalance / client.getOwnedObjects (v1 JSON-RPC method names)"
+    ]
+  },
+  {
+    "id": "accessing-data-use-case-mapping",
+    "prompt": "I'm building a wallet UI that needs to show: a balance for each coin type, recent transactions (with effects), owned NFTs filtered by type, and a dashboard combining all three. Which API should I use and why?",
+    "sources": [
+      "https://docs.sui.io/concepts/data-access/data-serving",
+      "https://docs.sui.io/concepts/data-access/graphql-rpc"
+    ],
+    "expected_output": "For a dashboard that combines multiple entity types in one view, GraphQL RPC is the best fit — it can return balances + transactions + owned objects in a single query, reducing round trips. Notes GraphQL RPC is beta. For individual per-entity reads (just a balance, just a tx), gRPC is still fine. Shows a sketch of a combined GraphQL query.",
+    "expectations": [
+      "Recommends GraphQL RPC for the multi-entity dashboard case",
+      "Explains the rationale: one request instead of multiple (reduced round trips, composable queries)",
+      "Flags GraphQL RPC as beta status",
+      "Shows a GraphQL query that fetches balances, transactions, and owned objects together",
+      "Does NOT recommend JSON-RPC",
+      "Does NOT recommend building a custom indexer for this use case (hosted APIs cover it)"
+    ]
+  },
+  {
+    "id": "accessing-data-custom-indexer-gate",
+    "prompt": "I need to show a leaderboard of the top 100 users by total trade volume on my marketplace over the last 30 days. What's the right approach?",
+    "sources": [
+      "https://docs.sui.io/guides/operator/indexer-stack-setup",
+      "https://docs.sui.io/concepts/data-access/graphql-rpc"
+    ],
+    "expected_output": "Recommends a custom indexer via sui-indexer-alt. Rationale: this is an app-specific aggregation (SUM by user) across a time range — not something gRPC point-lookups or general GraphQL answer efficiently. Describes the pipeline approach: subscribe to marketplace events via gRPC, write to a Postgres aggregation table, serve from your own query layer. Notes this is ongoing operational work — ensure the query isn't solvable with GraphQL RPC first.",
+    "expectations": [
+      "Recommends a custom indexer (sui-indexer-alt) for the leaderboard use case",
+      "Explains why: app-specific aggregation / SUM-by-user / time-range filtering is beyond gRPC's point-lookup surface and beyond the General-Purpose Indexer's schema",
+      "Mentions the pipeline model: checkpoint ingestion, Postgres tables, custom schema",
+      "Mentions GCS checkpoint buckets for backfill (e.g., gs://mysten-mainnet-checkpoints-use4)",
+      "Mentions full node gRPC for steady-state",
+      "Flags the operational cost of running an indexer",
+      "Does NOT recommend this workload be solved by polling JSON-RPC in app code"
+    ]
+  },
+  {
+    "id": "accessing-data-walrus-blob",
+    "prompt": "I'm minting NFTs where each NFT has a 2 MB image. Where should I store the image?",
+    "sources": [
+      "https://docs.wal.app",
+      "https://docs.sui.io/concepts/data-access/data-serving"
+    ],
+    "expected_output": "Recommends Walrus for the image bytes and a Sui Move object (the NFT) that stores the Walrus blob ID. Explains: Move objects are capped at 250 KB so 2 MB cannot fit on-chain; Walrus is the decentralized blob storage protocol designed for this. Shows a minimal pattern: upload to Walrus, get blobId, include blobId as a string field on the NFT. Discourages centralized CDN / IPFS as lesser alternatives for a decentralized app.",
+    "expectations": [
+      "Recommends Walrus for the image storage",
+      "States that the NFT Move object should store the Walrus blob ID (and possibly MIME type), NOT the bytes",
+      "Mentions the 250 KB Move object size limit as the reason bytes can't go on-chain",
+      "Mentions @mysten/walrus or the general Walrus access pattern",
+      "Explains that only the availability certificate + metadata goes on Sui, the blob itself is off-chain on Walrus storage nodes",
+      "Does NOT recommend storing 2 MB in a Move object",
+      "Does NOT recommend IPFS/S3/Pinata as the primary solution (may mention them as lesser alternatives)"
+    ]
+  },
+  {
+    "id": "accessing-data-migrate-json-rpc",
+    "prompt": "Here's some of my code. What's wrong and how do I update it?\n\n```ts\nimport { SuiClient, getFullnodeUrl } from '@mysten/sui/client';\nconst client = new SuiClient({ url: getFullnodeUrl('mainnet') });\nconst balance = await client.getBalance({ owner: addr });\nconst objs = await client.getOwnedObjects({ owner: addr, options: { showContent: true } });\nconst tx = await client.getTransactionBlock({ digest, options: { showEffects: true } });\n```",
+    "sources": [
+      "https://docs.sui.io/concepts/data-access/data-serving",
+      "https://sdk.mystenlabs.com/sui"
+    ],
+    "expected_output": "Identifies this as legacy JSON-RPC / v1 SDK code. Notes JSON-RPC is deprecated (July 2026 sunset). Migrates to SuiGrpcClient from '@mysten/sui/grpc' with network + baseUrl. Renames methods: getBalance → client.core.listBalances (or similar v2 Core API), getOwnedObjects → client.core.listOwnedObjects, getTransactionBlock → client.core.getTransaction. Replaces options: { show*: true } with include: { ... }. Does the full migration.",
+    "expectations": [
+      "Identifies the code as deprecated JSON-RPC / v1 SDK",
+      "States JSON-RPC is deprecated with a July 2026 sunset (or equivalent language)",
+      "Replaces SuiClient with SuiGrpcClient from '@mysten/sui/grpc'",
+      "Removes getFullnodeUrl (v1 helper) and passes baseUrl directly",
+      "Adds the network parameter",
+      "Renames client.getBalance to a v2 Core API method (client.core.listBalances or client.core.getBalance if that exists on Core)",
+      "Renames client.getOwnedObjects to client.core.listOwnedObjects",
+      "Renames client.getTransactionBlock to client.core.getTransaction",
+      "Replaces options: { showContent: true } with include: { content: true }",
+      "Replaces options: { showEffects: true } with include: { effects: true }",
+      "Does NOT leave any v1 method names in the final code"
+    ]
+  },
+  {
+    "id": "accessing-data-archival-historical",
+    "prompt": "I need to read the state of an object as it was 6 months ago. The object has been updated many times since. My gRPC call returns the current version — how do I get the historical version?",
+    "sources": [
+      "https://docs.sui.io/concepts/data-access/archival-store",
+      "https://docs.sui.io/concepts/data-access/graphql-rpc"
+    ],
+    "expected_output": "Explains that full nodes prune old object versions. The Archival Store retains them. Access is NOT via a direct archival API call — it's transparent: you query GraphQL RPC for the specific version, and the service routes to archival for pruned data. Shows a GraphQL query for object at a specific past version. Notes Archival Store is in beta.",
+    "expectations": [
+      "Correctly identifies that full nodes prune old object versions (retention is limited)",
+      "Identifies the Archival Store as the service that retains pruned history",
+      "States that the Archival Store is accessed transparently via gRPC or GraphQL RPC — NOT via a direct archival API",
+      "Shows a GraphQL query that requests a specific past object version (e.g., object(address: ..., version: ...))",
+      "Flags Archival Store as beta",
+      "Does NOT recommend a direct 'archival API' endpoint call"
+    ]
+  },
+  {
+    "id": "accessing-data-streaming-events",
+    "prompt": "I need to watch for new transactions that mint a specific NFT type and react in real time (<1s). What's the right approach?",
+    "sources": [
+      "https://docs.sui.io/concepts/data-access/data-serving"
+    ],
+    "expected_output": "Recommends gRPC streaming / subscription (client.subscriptionService or equivalent streaming RPC). Rationale: gRPC streams push events as they occur, whereas JSON-RPC / REST require polling and have higher latency. Shows a minimal example of iterating a server-stream. Discourages polling as wasteful and slow.",
+    "expectations": [
+      "Recommends gRPC streaming / subscription for real-time event ingestion",
+      "Mentions the SuiGrpcClient's subscription service (or equivalent streaming RPC path)",
+      "Explicitly discourages polling (getEvents / getTransactionBlocks in a loop) as the wrong pattern",
+      "Explains latency / cost tradeoff: streaming push vs polling pull",
+      "Does NOT recommend JSON-RPC",
+      "Does NOT recommend GraphQL RPC for this case (GraphQL is request/response, not streaming)"
+    ]
+  },
+  {
+    "id": "accessing-data-storage-fund-clarification",
+    "prompt": "What's the 'storage fund' in Sui? Can I use it to store my application data?",
+    "sources": [
+      "https://docs.sui.io/concepts/tokenomics",
+      "https://docs.sui.io/concepts/data-access/data-serving"
+    ],
+    "expected_output": "Clarifies that the storage fund is a tokenomics mechanism, NOT an API you call. Each on-chain transaction pays a storage fee into the fund; validators earn yield from the fund's stake to cover ongoing data storage. It affects pricing, not where you store. For application data storage: small structured data goes in Move objects (paid to the storage fund); large blobs go to Walrus. The storage fund is not a data storage service.",
+    "expectations": [
+      "Correctly identifies storage fund as an economic/tokenomics mechanism",
+      "States you cannot 'use the storage fund' as an API",
+      "Explains briefly how it works: transactions contribute storage fees, validators earn on the fund's stake",
+      "Directs the user to actual storage options: Move objects (small) or Walrus (large blobs)",
+      "Does NOT treat storage fund as a storage service or API",
+      "Does NOT conflate storage fund with Archival Store or Walrus"
+    ]
+  }
+]

--- a/accessing-data/graphql.md
+++ b/accessing-data/graphql.md
@@ -1,0 +1,186 @@
+# GraphQL RPC
+
+Source: https://docs.sui.io/concepts/data-access/graphql-rpc
+
+**Beta.** Official notice: *"Beta release of GraphQL RPC Server and General-purpose Indexer."* Expect occasional API churn.
+
+Reads from three backing stores:
+1. The **General-Purpose Indexer**'s Postgres (primary source — indexed, filterable).
+2. A **full node** (live tip-of-chain reads the indexer hasn't caught up to).
+3. The **Archival Store** (historical data pruned from full nodes).
+
+GraphQL RPC routes each query to whichever backing store is right. Clients don't pick.
+
+## When to use
+
+From the docs:
+> GraphQL RPC excels for applications requiring:
+> - Historical data with configurable retention or filtered queries
+> - Structured results for frontends (wallets, dashboards)
+> - Flexible, composable queries that reduce data overfetching
+> - Multiple data entities in single or consistent multi-request patterns
+
+Typical fit:
+- Frontend dashboards with several panels fetching related data.
+- Wallet history views (tx list + effects + balance changes in one query).
+- NFT marketplace explorers (filter + sort by type + traits).
+- Point-in-time historical reads ("what did object X look like at checkpoint Y?").
+
+## When not to use
+
+- Real-time / streaming. → gRPC.
+- Transaction submission. → gRPC (`transactionExecutionService`).
+- Ultra-low-latency trading. → gRPC.
+- App-specific analytics over millions of rows. → Custom indexer (`sui-indexer-alt`).
+
+## Endpoint URLs
+
+| Network | GraphQL URL |
+|---|---|
+| Mainnet | `https://graphql.mainnet.sui.io/graphql` |
+| Testnet | `https://graphql.testnet.sui.io/graphql` |
+| Devnet | `https://graphql.devnet.sui.io/graphql` |
+
+Verify current URLs at the source page — beta endpoints occasionally move.
+
+## TypeScript — `SuiGraphQLClient`
+
+```ts
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { graphql } from '@mysten/sui/graphql/schema';
+
+const client = new SuiGraphQLClient({
+  network: 'mainnet',
+  url: 'https://graphql.mainnet.sui.io/graphql',
+});
+
+const query = graphql(`
+  query GetOwnedNFTs($owner: SuiAddress!, $type: String!) {
+    address(address: $owner) {
+      objects(filter: { type: $type }) {
+        nodes {
+          address
+          version
+          asMoveObject {
+            contents {
+              json
+            }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+`);
+
+const result = await client.query({
+  query,
+  variables: { owner: '0x...', type: '0xpkg::nft::NFT' },
+});
+```
+
+The `graphql()` helper provides type inference from the schema. Old code imports from `@mysten/sui/graphql/schemas/latest` — v2 is `@mysten/sui/graphql/schema` (singular).
+
+## Rust — `sui-graphql` crate
+
+```rust
+use sui_graphql::client::Client;
+
+let gql = Client::new("https://graphql.mainnet.sui.io/graphql")?;
+// Queries are typed via sui-graphql-macros
+```
+
+## Query patterns
+
+### Single entity
+
+```graphql
+query {
+  object(address: "0x...") {
+    version
+    digest
+    owner { ... on AddressOwner { owner } }
+  }
+}
+```
+
+### Owned objects with filter + pagination
+
+```graphql
+query Owned($owner: SuiAddress!, $cursor: String) {
+  address(address: $owner) {
+    objects(first: 50, after: $cursor, filter: { type: "0xpkg::nft::NFT" }) {
+      nodes { address version }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}
+```
+
+### Multi-entity single-request (the GraphQL advantage)
+
+```graphql
+query Profile($addr: SuiAddress!) {
+  address(address: $addr) {
+    balances(first: 20) { nodes { coinType { repr } totalBalance } }
+    objects(first: 10, filter: { type: "0xpkg::nft::NFT" }) {
+      nodes { address asMoveObject { contents { json } } }
+    }
+    transactionBlocks(last: 10) {
+      nodes { digest effects { status } }
+    }
+  }
+}
+```
+
+One round trip, three related entity types.
+
+### Historical point-in-time
+
+```graphql
+query { object(address: "0x...", version: 42) { ... } }
+```
+
+For versions that full nodes have pruned, the server falls back to the Archival Store automatically.
+
+## Pagination — cursor-based
+
+Connection pattern (Relay-style):
+- `nodes: [...]`
+- `pageInfo: { hasNextPage, endCursor, hasPreviousPage, startCursor }`
+
+```ts
+let cursor: string | null = null;
+do {
+  const page = await client.query({
+    query,
+    variables: { cursor },
+  });
+  processPage(page.data.address.objects.nodes);
+  cursor = page.data.address.objects.pageInfo.hasNextPage
+    ? page.data.address.objects.pageInfo.endCursor
+    : null;
+} while (cursor);
+```
+
+## Beta caveats
+
+- Schema may change. Pin your client to a specific `@mysten/sui` version and check release notes when upgrading.
+- Some query shapes supported on gRPC are still being backported to GraphQL.
+- Rate limits on public endpoints can be tight. Run your own General-Purpose Indexer for production-scale traffic.
+
+## Relationship to the indexer
+
+GraphQL RPC doesn't exist without the General-Purpose Indexer. If you need a query that GraphQL doesn't support out of the box, two options:
+
+1. **Extend the General-Purpose Indexer** with an additional pipeline (see `indexers.md`), then query your new tables via GraphQL.
+2. **Run a custom indexer** with its own schema and query it however you like (Postgres SQL, GraphQL, your own REST).
+
+## Common mistakes
+
+- **Using GraphQL RPC for tx submission.** It's read-only. Submit via gRPC (`transactionExecutionService`).
+- **Using it for real-time.** GraphQL doesn't push. Use gRPC subscriptions.
+- **Importing from `@mysten/sui/graphql/schemas/latest`** — v1. v2 is `@mysten/sui/graphql/schema`.
+- **Treating pagination as offset-based.** GraphQL uses cursors. Don't pass integer offsets.
+- **Over-fetching by selecting every field.** GraphQL's whole point is "ask for only what you need." Trim queries to the fields actually used.
+- **Building production-critical flows on a beta endpoint without a fallback plan.** Have a migration path to gRPC or a custom indexer.

--- a/accessing-data/grpc.md
+++ b/accessing-data/grpc.md
@@ -35,11 +35,13 @@ The `SuiGrpcClient` exposes these typed services (protobuf-defined):
 
 | Service | Purpose |
 |---|---|
-| `ledgerService` | Object reads, transaction reads, checkpoint reads, balance/coin listings |
-| `transactionExecutionService` | Submit transactions, dry-run, simulate |
+| `ledgerService` | Transaction reads, epoch / checkpoint info |
+| `stateService` | Owned-objects listing, dynamic field listing, object state reads |
+| `transactionExecutionService` | Submit transactions |
 | `movePackageService` | Inspect published Move modules, functions, types |
-| `nameService` | SuiNS lookups |
-| `subscriptionService` | Streaming subscriptions (effects, events) |
+| `nameService` | SuiNS lookups (reverse / forward) |
+| `signatureVerificationService` | Verify a signature against a message |
+| `subscriptionService` | Streaming subscriptions (where available) |
 
 The **Core API** (`client.core.*`) is a higher-level facade that works identically across `SuiGrpcClient`, `SuiJsonRpcClient`, and `SuiGraphQLClient` for the common CRUD-ish reads.
 
@@ -55,26 +57,37 @@ const client = new SuiGrpcClient({
 
 // High-level Core API
 await client.core.getObject({ objectId: '0x...', include: { content: true } });
-await client.core.getObjects({ objectIds: [...] });
-await client.core.listOwnedObjects({ owner: '0x...', type: '0xpkg::nft::NFT' });
-await client.core.listCoins({ owner: '0x...', coinType: '0x2::sui::SUI' });
+await client.core.getObjects({ objectIds: [...], include: { content: true } });
+await client.core.listOwnedObjects({
+  owner: '0x...',
+  filter: { StructType: '0xpkg::nft::NFT' },   // type filter goes under filter
+  limit: 50,
+});
+await client.core.listCoins({ owner: '0x...', coinType: '0x2::sui::SUI', limit: 50 });
 await client.core.listBalances({ owner: '0x...' });
-await client.core.listDynamicFields({ parent: '0x...' });
-await client.core.getDynamicField({ parent: '0x...', name });
+await client.core.listDynamicFields({ parentId: '0x...', limit: 50 });   // parentId, not parent
+await client.core.getDynamicField({ parentId: '0x...', name });
 await client.core.getTransaction({ digest, include: { effects: true, events: true } });
-await client.core.simulateTransaction({ transaction: tx, sender });
+await client.core.simulateTransaction({ transaction: tx });
 await client.core.executeTransaction({ transaction: bytes, signatures: [...] });
 
 // Low-level services (when you need protobuf directly)
-await client.ledgerService.getObject({ objectId: '0x...' });
+await client.ledgerService.getTransaction({ digest: '0x...' });
+await client.stateService.listOwnedObjects({ owner: '0x...', objectType: '0x2::coin::Coin<0x2::sui::SUI>' });
+await client.stateService.listDynamicFields({ parent: '0x...' });
 await client.movePackageService.getFunction({
   packageId: '0x2', moduleName: 'coin', name: 'transfer',
 });
 await client.nameService.reverseLookupName({ address: '0x...' });
 ```
 
-`include` flags replace v1's `options: { show*: true }`:
-- `effects`, `events`, `balanceChanges`, `objectTypes`, `content`, `bcs`, `transaction`.
+`include` flags replace v1's `options: { show*: true }`. Flags differ by method:
+
+- **Object reads** (`getObject`, `getObjects`, `listOwnedObjects`): `content`, `previousTransaction`, `json`, `objectBcs`, `display`.
+- **Transaction reads** (`getTransaction`, `waitForTransaction`): `effects`, `events`, `balanceChanges`, `transaction`, `bcs`.
+- **Simulation** (`simulateTransaction`): adds `commandResults`.
+
+Default fields on every object response: `objectId`, `version`, `digest`, `owner`, `type`.
 
 ## Rust — `sui-rpc` crate
 
@@ -166,7 +179,7 @@ try {
 ## Performance tips
 
 - **Batch via `getObjects` when you have many IDs** rather than looping `getObject`.
-- **Paginate eagerly** — default page sizes are small. For bulk operations, iterate until `!hasNextPage`.
+- **Paginate eagerly** — core `list*` methods return `{ ..., cursor }`. Iterate while `cursor` is non-null, passing it back as the next request's `cursor`.
 - **Reuse the client.** Creating a new `SuiGrpcClient` per request opens a new connection.
 - **Dry-run before signing for gas budget.** Saves failed txs.
 - **Use subscriptions over polling** where possible.
@@ -174,7 +187,10 @@ try {
 ## Common mistakes
 
 - Using v1 method names: `client.getObject`, `client.getCoins`, `client.getOwnedObjects` — all v1 JSON-RPC. v2 is `client.core.getObject`, `client.core.listCoins`, `client.core.listOwnedObjects`.
-- Using `options: { showEffects: true }` — v1. v2 is `include: { effects: true }`.
+- Using `options: { showEffects: true }` — v1. v2 is `include: { effects: true }`. Note that `include` option keys differ by method — see the table above.
+- Passing `type: '0xpkg::m::T'` to `listOwnedObjects` — wrong. Type filters go under `filter: { StructType: '0xpkg::m::T' }`.
+- Passing `parent:` to `listDynamicFields` — wrong. It's `parentId:`.
+- Using `lastPage.hasNextPage` / `lastPage.nextCursor` on core API results — core `list*` methods return a single `cursor` field (null when done). `hasNextPage` / `pageInfo` is the GraphQL shape, not Core API.
 - Using `getFullnodeUrl` helper — v1 (only for JSON-RPC). For gRPC, pass the URL directly as `baseUrl`.
 - Instantiating `SuiClient` — removed in v2. Use `SuiGrpcClient`.
 - Checking `result.effects?.status?.status` — v1. v2 uses `$kind` discriminant.

--- a/accessing-data/grpc.md
+++ b/accessing-data/grpc.md
@@ -1,0 +1,181 @@
+# gRPC API
+
+Source: https://docs.sui.io/concepts/data-access/data-serving · https://sdk.mystenlabs.com/sui/clients
+
+The default data surface for new Sui code. Full nodes serve gRPC directly; no indexer in the path for most reads. Typed protobuf, streaming, code-gen for TS / Rust / Go / Python / any language with a gRPC toolchain.
+
+From the docs: *"gRPC has built-in support for code generation, allowing you to scaffold clients in TypeScript, Go, Rust, and more, making it ideal for scalable backend systems like indexers, blockchain explorers, and data-intensive decentralized apps."*
+
+## When to use
+
+- Backend services, indexers, validators, market makers, exchanges.
+- Live UI reads where low latency matters.
+- Real-time subscriptions via streaming RPCs.
+- Polyglot services (you need a client in a non-TS/Rust language — use gRPC code gen).
+- Transaction submission and dry-run / simulate.
+
+## When not to use
+
+- Multi-entity joins / historical filtered queries. → Use GraphQL RPC.
+- App-specific analytics over millions of events. → Use a custom indexer.
+
+## Endpoint URLs
+
+| Network | gRPC URL |
+|---|---|
+| Mainnet | `https://fullnode.mainnet.sui.io:443` |
+| Testnet | `https://fullnode.testnet.sui.io:443` |
+| Devnet | `https://fullnode.devnet.sui.io:443` |
+
+Run your own full node for production-critical traffic — public endpoints are rate-limited and shared.
+
+## Service surface
+
+The `SuiGrpcClient` exposes these typed services (protobuf-defined):
+
+| Service | Purpose |
+|---|---|
+| `ledgerService` | Object reads, transaction reads, checkpoint reads, balance/coin listings |
+| `transactionExecutionService` | Submit transactions, dry-run, simulate |
+| `movePackageService` | Inspect published Move modules, functions, types |
+| `nameService` | SuiNS lookups |
+| `subscriptionService` | Streaming subscriptions (effects, events) |
+
+The **Core API** (`client.core.*`) is a higher-level facade that works identically across `SuiGrpcClient`, `SuiJsonRpcClient`, and `SuiGraphQLClient` for the common CRUD-ish reads.
+
+## TypeScript — `SuiGrpcClient`
+
+```ts
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+  network: 'mainnet',
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
+});
+
+// High-level Core API
+await client.core.getObject({ objectId: '0x...', include: { content: true } });
+await client.core.getObjects({ objectIds: [...] });
+await client.core.listOwnedObjects({ owner: '0x...', type: '0xpkg::nft::NFT' });
+await client.core.listCoins({ owner: '0x...', coinType: '0x2::sui::SUI' });
+await client.core.listBalances({ owner: '0x...' });
+await client.core.listDynamicFields({ parent: '0x...' });
+await client.core.getDynamicField({ parent: '0x...', name });
+await client.core.getTransaction({ digest, include: { effects: true, events: true } });
+await client.core.simulateTransaction({ transaction: tx, sender });
+await client.core.executeTransaction({ transaction: bytes, signatures: [...] });
+
+// Low-level services (when you need protobuf directly)
+await client.ledgerService.getObject({ objectId: '0x...' });
+await client.movePackageService.getFunction({
+  packageId: '0x2', moduleName: 'coin', name: 'transfer',
+});
+await client.nameService.reverseLookupName({ address: '0x...' });
+```
+
+`include` flags replace v1's `options: { show*: true }`:
+- `effects`, `events`, `balanceChanges`, `objectTypes`, `content`, `bcs`, `transaction`.
+
+## Rust — `sui-rpc` crate
+
+```rust
+use sui_rpc::client::Client;
+
+let client = Client::new("https://fullnode.mainnet.sui.io:443")?;
+
+let response = client
+    .ledger_service()
+    .get_object(object_id, read_mask)
+    .await?;
+
+let result = client
+    .transaction_execution_service()
+    .execute_transaction(transaction, vec![signature])
+    .await?;
+```
+
+Services mirror the TS side: `ledger_service`, `transaction_execution_service`, `move_package_service`, `name_service`.
+
+## Streaming / subscriptions
+
+gRPC's big differentiator over HTTP: server-streaming RPCs for real-time feeds.
+
+```ts
+// TypeScript — subscription pattern (exact API on the client depends on version;
+// consult node_modules/@mysten/sui/docs/llms-index.md for the installed surface)
+for await (const event of client.subscriptionService.subscribeEvents({ filter })) {
+  processEvent(event);
+}
+```
+
+Rust uses `tokio::stream`. Both support cancellation via dropping the stream.
+
+Use streaming for:
+- Real-time event feeds.
+- Checkpoint ingestion into a custom indexer.
+- Order book updates / price feeds.
+- Cross-chain bridge observation.
+
+## Code gen for other languages
+
+gRPC + protobuf means you can generate a client in any language with a gRPC runtime:
+
+```bash
+# Example: generate Go client
+protoc --go_out=. --go-grpc_out=. sui.proto
+```
+
+Protobuf definitions live in the Sui monorepo under `crates/sui-rpc-api/proto/` (path may shift — grep for `.proto`).
+
+## Transaction submission
+
+```ts
+await client.signAndExecuteTransaction({ signer: keypair, transaction: tx });
+// or, if signing separately:
+await client.core.executeTransaction({
+  transaction: bytes,
+  signatures: [sig1, sig2],  // multi-sig or sponsored both fit this shape
+  include: { effects: true },
+});
+```
+
+## `waitForTransaction` — read-after-write consistency
+
+```ts
+const result = await client.signAndExecuteTransaction({ signer, transaction });
+await client.waitForTransaction({ digest: result.digest });
+// subsequent reads on the same client will see the new state
+```
+
+Cross-node reads after a write are not guaranteed immediately visible. Either (a) do the read on the same node, or (b) `waitForTransaction` before switching nodes.
+
+## Error handling
+
+gRPC uses typed error codes (`INVALID_ARGUMENT`, `NOT_FOUND`, `RESOURCE_EXHAUSTED`, etc.) plus details:
+
+```ts
+try {
+  await client.core.getObject({ objectId });
+} catch (err) {
+  // err has a grpc status code and message
+}
+```
+
+`RESOURCE_EXHAUSTED` typically means rate limiting — back off or switch to your own full node.
+
+## Performance tips
+
+- **Batch via `getObjects` when you have many IDs** rather than looping `getObject`.
+- **Paginate eagerly** — default page sizes are small. For bulk operations, iterate until `!hasNextPage`.
+- **Reuse the client.** Creating a new `SuiGrpcClient` per request opens a new connection.
+- **Dry-run before signing for gas budget.** Saves failed txs.
+- **Use subscriptions over polling** where possible.
+
+## Common mistakes
+
+- Using v1 method names: `client.getObject`, `client.getCoins`, `client.getOwnedObjects` — all v1 JSON-RPC. v2 is `client.core.getObject`, `client.core.listCoins`, `client.core.listOwnedObjects`.
+- Using `options: { showEffects: true }` — v1. v2 is `include: { effects: true }`.
+- Using `getFullnodeUrl` helper — v1 (only for JSON-RPC). For gRPC, pass the URL directly as `baseUrl`.
+- Instantiating `SuiClient` — removed in v2. Use `SuiGrpcClient`.
+- Checking `result.effects?.status?.status` — v1. v2 uses `$kind` discriminant.
+- Polling for events/effects — use streaming.

--- a/accessing-data/indexers.md
+++ b/accessing-data/indexers.md
@@ -1,0 +1,135 @@
+# Custom Indexers — `sui-indexer-alt`
+
+Source: https://docs.sui.io/guides/operator/indexer-stack-setup
+
+When to build one: the hosted gRPC and GraphQL APIs can't efficiently answer your query shape. Symptoms:
+- You need custom aggregations / leaderboards / analytics not supported by GraphQL.
+- Filter combinations cause full table scans on the General-Purpose Indexer.
+- You need to store app-computed derived state alongside on-chain state.
+- You need to retain data beyond the public services' retention policy.
+
+If you can answer your query with `client.core.*` or a GraphQL query, **don't** build an indexer. Operating one is ongoing work: Postgres, checkpoint ingestion, failure handling, backfills, migrations.
+
+## Architecture
+
+From the docs:
+> The indexer "consists of multiple pipelines that each read, transform, and write checkpoint data to various Postgres tables."
+
+```
+ Sui network                               Your infrastructure
+ ┌──────────┐        backfill GCS             ┌──────────────────────┐
+ │  Full    │        checkpoint bucket        │  sui-indexer-alt     │
+ │  nodes   │◀─────────────────────────────── │  pipelines           │
+ │  (gRPC)  │        steady state             │                      │
+ └──────────┘        (new checkpoints)        │  events.toml         │
+                                              │  obj_versions.toml   │
+                                              │  coin_transfers.toml │
+                                              └─────────┬────────────┘
+                                                        ▼
+                                              ┌──────────────────────┐
+                                              │  Postgres            │
+                                              │  your schema         │
+                                              └──────────────────────┘
+                                                        ▼
+                                              ┌──────────────────────┐
+                                              │  Your query layer    │
+                                              │  (REST / GraphQL /   │
+                                              │  raw SQL)            │
+                                              └──────────────────────┘
+```
+
+## Ingestion sources
+
+Two operational modes:
+
+| Mode | Source | URL pattern |
+|---|---|---|
+| **Backfill** (historical catch-up) | GCS checkpoint buckets | `gs://mysten-mainnet-checkpoints-use4` (mainnet), similar for testnet |
+| **Steady state** (tip of chain) | Full node gRPC | Same URL as your normal gRPC endpoint |
+
+The indexer automatically switches from GCS to gRPC when it catches up to tip.
+
+## Pipeline model
+
+Each pipeline:
+1. Defines a data source (checkpoint stream).
+2. Defines a transform (what to extract from each checkpoint — events, object changes, coin transfers, etc.).
+3. Defines a Postgres schema (target tables).
+4. Runs concurrently with other pipelines, each writing to its own tables.
+
+Config example (TOML, from the docs pattern):
+```toml
+# events.toml
+[source]
+kind = "remote_store"
+url = "gs://mysten-mainnet-checkpoints-use4"
+
+[pipeline.events]
+concurrency = { kind = "adaptive", initial = 200, min = 50, max = 2000 }
+
+[database]
+url = "postgres://localhost/sui_indexer"
+```
+
+Multiple pipelines can run in the same process, each targeting different tables. The General-Purpose Indexer is itself a collection of pipelines; yours can sit alongside it or stand alone.
+
+## Tuning
+
+Concurrency:
+```toml
+concurrency = { kind = "adaptive", initial = 200, min = 50, max = 2000 }
+```
+
+The adaptive strategy ramps up concurrency during backfill (GCS is cheap and parallel-friendly) and scales back for steady state. For simple workloads, a fixed concurrency is fine.
+
+Other knobs:
+- Batch size for DB writes.
+- Retry and backoff policy on transient failures.
+- Checkpoint retention (how far back to keep data).
+
+## When to use which
+
+| Scenario | Solution |
+|---|---|
+| Balance / owned / simple reads | **gRPC `client.core.*`** — no indexer |
+| Frontend dashboard with joins | **GraphQL RPC** — hosted |
+| Custom leaderboard / aggregations | **Custom indexer** |
+| Cross-table joins with app-specific filters | **Custom indexer** |
+| Event processing for a game / market | **Custom indexer** (or GraphQL for read-only) |
+| Long-term analytics (90+ days history) | **Custom indexer** (the hosted indexer's retention may be shorter) |
+
+## Running alongside the General-Purpose Indexer
+
+The General-Purpose Indexer is open-source and runnable locally. Teams often:
+
+1. Run the General-Purpose Indexer for general queries.
+2. Run additional custom pipelines for app-specific data.
+3. Point GraphQL RPC at the combined Postgres.
+
+This gives a hosted-style experience with app-specific extensions, without reinventing GraphQL resolvers.
+
+## Considerations
+
+- **Postgres operations.** Indexes, vacuum, backups, upgrades. It's ongoing.
+- **Checkpoint store egress.** GCS reads for backfill can be slow and bandwidth-heavy for huge histories. Budget accordingly.
+- **Sync lag.** Steady-state lag is typically seconds; during backfill it can be hours or days depending on concurrency and history depth.
+- **Schema migrations.** Changing a pipeline's schema often requires a backfill. Plan migrations carefully.
+- **Testing.** Run against testnet / a replay node before pointing at mainnet.
+
+## Alternatives before building your own
+
+Try in this order:
+1. **gRPC `client.core.*`** — zero ops cost.
+2. **GraphQL RPC hosted** — zero ops cost, more flexibility.
+3. **Run the General-Purpose Indexer locally** — you own the Postgres but the pipelines are prebuilt.
+4. **Custom pipelines via `sui-indexer-alt`** — you write the pipelines.
+
+Skip 4 if 1–3 solve your problem.
+
+## Common mistakes
+
+- **Building a custom indexer for a one-off query.** Ongoing ops cost > query value. Use GraphQL.
+- **Assuming the indexer provides transactional guarantees.** It's eventually consistent relative to the chain. For point-in-time accurate reads, reference the checkpoint sequence number.
+- **Running backfill without concurrency limits.** GCS egress caps or Postgres write throughput will bottleneck. Use adaptive concurrency.
+- **Storing on-chain-only data.** If it's already in a full node's gRPC response, you might not need a custom pipeline — just cache.
+- **Not retaining checkpoint sequence numbers alongside derived data.** Without them, you can't reconstruct or replay.

--- a/accessing-data/use-cases.md
+++ b/accessing-data/use-cases.md
@@ -17,7 +17,7 @@ First file to load when a user describes what they want to do. Pick the right da
 | Use case | Primary surface | Rationale |
 |---|---|---|
 | Show a user's SUI balance | gRPC (`client.core.listBalances`) | Single-entity read; built-in indexing |
-| Show a user's owned NFTs | gRPC (`client.core.listOwnedObjects`) with `type` filter | Paginated, type-indexed |
+| Show a user's owned NFTs | gRPC (`client.core.listOwnedObjects({ owner, filter: { StructType } })`) | Paginated, type-indexed |
 | Show details of a specific object | gRPC (`client.core.getObject`) | Point lookup |
 | Show recent transactions by an address | gRPC (list transactions) OR GraphQL | gRPC for simple, GraphQL if joining with object changes |
 | Wallet transaction history across time | GraphQL | Needs time-range filter + relational join to effects |

--- a/accessing-data/use-cases.md
+++ b/accessing-data/use-cases.md
@@ -1,0 +1,83 @@
+# Use Case → Method Mapping
+
+First file to load when a user describes what they want to do. Pick the right data surface before writing code.
+
+## Decision tree
+
+1. Do you need to **store / retrieve a large file** (image, audio, video, document, arbitrary blob)? → **Walrus** (`walrus.md`). Stop.
+2. Is this a **real-time / streaming subscription** (new transactions, new events, effects feed)? → **gRPC** (`grpc.md`).
+3. Is this a **single entity read** (one object, one balance, one transaction, one coin list)? → **gRPC** (`grpc.md`). Use `client.core.*` from any SDK.
+4. Does the query **join across entities** or filter historical data in a way a single gRPC method doesn't cover (e.g., "all NFTs owned by X minted after date Y with field Z > N")? → **GraphQL RPC** (`graphql.md`).
+5. Is this **app-specific analytics** that neither gRPC nor GraphQL covers efficiently (leaderboards, custom aggregations, complex filters over millions of rows)? → **Custom indexer** (`indexers.md`).
+6. Is the data **older than full-node retention** and you're hitting "not found"? → Use **GraphQL RPC** (routes through Archival Store). See `archival.md`.
+7. None of the above? Start with **gRPC**.
+
+## Common use cases
+
+| Use case | Primary surface | Rationale |
+|---|---|---|
+| Show a user's SUI balance | gRPC (`client.core.listBalances`) | Single-entity read; built-in indexing |
+| Show a user's owned NFTs | gRPC (`client.core.listOwnedObjects`) with `type` filter | Paginated, type-indexed |
+| Show details of a specific object | gRPC (`client.core.getObject`) | Point lookup |
+| Show recent transactions by an address | gRPC (list transactions) OR GraphQL | gRPC for simple, GraphQL if joining with object changes |
+| Wallet transaction history across time | GraphQL | Needs time-range filter + relational join to effects |
+| NFT marketplace listings page | GraphQL | Filter + sort across types, pagination, join with prices |
+| Leaderboard / custom analytics | Custom indexer | App-specific schema, custom indexes |
+| Live feed of new mints of type T | gRPC streaming / subscription | Push, not pull |
+| "When did this object last change?" | GraphQL OR custom indexer | Historical versioning is the indexer's job |
+| Proof-of-ownership at a past epoch | GraphQL (routes to archival) | Pruned from live full node |
+| Bridge / cross-chain state sync | gRPC streaming | Needs low-latency push |
+| Storing a 10 MB image referenced by an NFT | Walrus (store) + Sui (reference) | 250 KB object cap |
+| Storing application JSON state > 250 KB | Walrus | Object size cap |
+| Storing small structured data (< few KB) in an object | Sui (on-chain) | Fine within object size |
+| Sending a transaction and then reading the result | gRPC + `waitForTransaction` then read | Eventually-consistent indexer |
+| Dashboard with 20 panels of varying data | GraphQL | One request > many round-trips |
+
+## Anti-patterns
+
+| Don't | Do |
+|---|---|
+| `client.getCoins(...)` (v1 JSON-RPC method) | `client.core.listCoins(...)` (v2 Core API) on `SuiGrpcClient` |
+| Polling `getOwnedObjects` every second for changes | gRPC subscription / streaming |
+| Building a custom indexer for a one-off query | Use GraphQL RPC first; indexer is ongoing ops |
+| Storing file bytes in a Move object | Walrus; reference the blob ID on-chain |
+| Hitting a different full node for the read than the write | Same node, or `waitForTransaction` first |
+| Trusting an unofficial public gRPC endpoint for production | Run a full node or use a reputable RPC provider |
+| Inferring block finality from the wallet's returned digest | `client.waitForTransaction({ digest })` |
+
+## "Which SDK" vs "which API"
+
+They're independent axes:
+
+- **API** = gRPC / GraphQL / JSON-RPC (legacy) / custom indexer / Walrus.
+- **SDK / language** = TypeScript, Rust, Python, etc.
+
+Each official SDK exposes gRPC, GraphQL, and JSON-RPC clients. Pick the API for your use case first, then pick the SDK for your language.
+
+| API | TS | Rust |
+|---|---|---|
+| gRPC | `SuiGrpcClient` (`@mysten/sui/grpc`) | `sui-rpc` crate |
+| GraphQL | `SuiGraphQLClient` (`@mysten/sui/graphql`) | `sui-graphql` crate |
+| JSON-RPC (legacy) | `SuiJsonRpcClient` (`@mysten/sui/jsonRpc`) | legacy monorepo `sui-sdk` crate |
+| Custom indexer | `@mysten/sui/graphql` + your own Postgres | `sui-indexer-alt` + your own Postgres |
+| Walrus | `@mysten/walrus` extension | TBD / community |
+
+For mappings across SDKs per operation, see the `sui-sdks` skill (`mapping.md`).
+
+## Migrating from JSON-RPC
+
+If you're staring at a codebase calling `client.getObject` / `getOwnedObjects` / `getCoins` / `getBalance` / etc.:
+
+1. Replace the client: `SuiClient` → `SuiGrpcClient` (imports from `@mysten/sui/grpc` instead of `@mysten/sui/client`).
+2. Rename methods: all data access moves under `client.core.*` and is renamed (see `sui-sdks` / `typescript.md` for the full table).
+3. Replace `options: { show*: true }` with `include: { ... }`.
+4. Replace result shape checks (`result.effects?.status?.status`) with `$kind` discriminant.
+
+Full mapping lives in the `sui-sdks` skill's `typescript.md` file (v1 → v2 table).
+
+## Sunset timeline
+
+- **JSON-RPC deprecated**: September–October 2025 (already in effect).
+- **Full JSON-RPC deactivation target**: July 2026.
+
+New code should not be built on JSON-RPC. Existing code needs a migration plan.

--- a/accessing-data/walrus.md
+++ b/accessing-data/walrus.md
@@ -1,0 +1,107 @@
+# Walrus — off-chain blob storage
+
+Source: https://docs.wal.app
+
+Walrus is the decentralized storage protocol built on Sui for files too big to live on-chain. When a user asks how to store an image, audio, video, large JSON, ML model, or any arbitrary blob "on Sui" — the answer is **Walrus**, with an on-chain reference to the blob ID.
+
+## Why not store files on-chain
+
+- **250 KB max object size.** Move objects are capped; no single object can hold a megabyte file.
+- **Storage fund economics.** Every on-chain byte pays into the storage fund, which distributes yield to validators to cover ongoing storage. It's designed for small, long-lived structured data, not file storage.
+- **Read performance.** Full nodes aren't CDNs. Large reads would punish gRPC latency and rate-limit budgets.
+- **Redundancy model.** Sui's validator set replicates every byte of state. Storing a video on every validator is wasteful.
+
+Walrus is designed to fill this gap: erasure-coded storage across a distributed network, with on-chain availability certificates.
+
+## Architecture at a glance
+
+From the Walrus docs:
+
+> Metadata is the only blob element ever exposed to Sui or its validators, as the content of blobs is always stored off-chain on Walrus storage nodes and caches.
+
+> After uploading blob data off-chain, availability is certified on Sui:
+> 1. Upload blob slivers to storage nodes off-chain.
+> 2. Storage nodes provide an availability certificate.
+> 3. Upload the certificate on-chain.
+
+So the on-chain state is small (certificate + blob ID + metadata). The blob itself is off-chain, erasure-coded, and retrievable from storage nodes.
+
+## Typical integration
+
+A Move object (NFT, profile, marketplace listing, etc.) stores the **blob ID** and possibly metadata (MIME type, size). The frontend fetches the blob from Walrus using the ID.
+
+```move
+public struct NFT has key, store {
+  id: UID,
+  name: String,
+  walrus_blob_id: String,   // reference to Walrus
+  mime_type: String,
+}
+```
+
+```ts
+// TypeScript — via the @mysten/walrus extension
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { walrus } from '@mysten/walrus';
+
+const client = new SuiGrpcClient({
+  network: 'mainnet',
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
+}).$extend(walrus({ /* config */ }));
+
+// Upload (write blob + commit on-chain certificate)
+const { blobId } = await client.walrus.writeBlob({
+  blob: fileBytes,
+  deletable: false,      // permanent vs re-claimable
+  epochs: 200,           // storage duration in epochs
+});
+
+// Read
+const bytes = await client.walrus.readBlob({ blobId });
+```
+
+(Exact API names track the `@mysten/walrus` package version — consult `node_modules/@mysten/walrus/docs/llms-index.md` if installed. See the `sui-sdks` skill's `llm-docs.md`.)
+
+## Blob lifecycle
+
+- **Stored for a configurable duration** (in epochs). Expires if not renewed.
+- **Deletable vs permanent.** Deletable blobs can be reclaimed; permanent blobs are locked for their full duration.
+- **Availability certificate** on Sui proves the blob was uploaded and stored correctly by enough storage nodes.
+- **Renewal** extends the storage duration without re-uploading.
+
+## What goes on-chain
+
+| Thing | Sui | Walrus |
+|---|---|---|
+| Ownership record | ✅ on-chain |  |
+| Structured metadata (name, description, traits) | ✅ on-chain (under 250 KB) |  |
+| Blob ID / Walrus reference | ✅ on-chain (small string) |  |
+| Image / audio / video / large JSON |  | ✅ on Walrus |
+| Availability certificate | ✅ on-chain (proof) |  |
+
+## Cost model
+
+- **Sui write**: storage fund contribution for the small on-chain object holding the blob reference.
+- **Walrus write**: payment for N epochs of blob storage, paid in WAL tokens.
+- **Reads**: free at the protocol level from storage nodes; actual cost depends on the client you use to fetch.
+
+## Use cases
+
+- **NFT media** — images, animations, audio.
+- **Profile data** — large avatars, bios, off-chain attestations.
+- **Gaming** — maps, skins, saved states too large for a Move object.
+- **App state** — large JSON blobs that exceed the 250 KB cap.
+- **Data availability** — rollup-style or oracle data that needs verifiable availability without on-chain bytes.
+
+## Not for
+
+- **Highly-interactive structured state** — if Move needs to read and reason about the data, it has to fit in an object. Walrus blobs are opaque bytes from Move's perspective.
+- **Tiny metadata.** A 1 KB string belongs in a Move object. Walrus has per-blob overhead.
+
+## Common mistakes
+
+- **"Put the image in the NFT."** NFTs should hold the *blob ID*, not the image bytes. Images go to Walrus; the Move object references them.
+- **Using a centralized CDN for "decentralized" apps.** Walrus is the decentralized equivalent. Using S3 / IPFS gateway / Pinata undermines the decentralization story.
+- **Forgetting to renew blobs.** Blobs expire. If your app's NFTs reference blobs past their storage duration, the references break. Set renewal logic or use permanent blobs with long durations.
+- **Conflating Walrus with IPFS.** IPFS is content-addressed but has no built-in economic guarantee of persistence. Walrus pairs content-addressing with paid storage + availability proofs on Sui.
+- **Assuming Walrus replaces Sui.** Walrus is *additive*: Sui for logic/ownership/reference, Walrus for bytes.


### PR DESCRIPTION
## Summary
- Adds an \`accessing-data/\` skill covering every way to read data from Sui: gRPC (default), GraphQL RPC (beta), Archival Store (beta, transparent fallback), custom indexers via \`sui-indexer-alt\`, and Walrus for off-chain blobs.
- \`SKILL.md\` enforces the hard rules: JSON-RPC is deprecated with a July 2026 sunset, default to gRPC, reach for GraphQL only for multi-entity / historical queries, build a custom indexer only when hosted APIs can't express the query, and large files go to Walrus (not on-chain).
- \`use-cases.md\` is a decision tree mapping common use cases (balance lookup, owned objects, event subscription, leaderboard, historical read, blob storage) to the right surface — load this first for any "how do I read X" question.

## Skill rules worth highlighting
- **Absolutely no JSON-RPC in new code.** If a user insists, flag the deprecation and July 2026 sunset.
- Default to \`SuiGrpcClient\` / \`sui-rpc\` crate.
- Never call the Archival Store directly — it's transparent under gRPC/GraphQL.
- Build custom indexers only after gRPC and GraphQL RPC are exhausted.
- Blobs go to Walrus; Sui object holds the blob ID.
- "Storage fund" is tokenomics, not an API.
- Use v2 Core API method names (\`client.core.listBalances\`, \`client.core.listOwnedObjects\`, \`client.core.getTransaction\`) — not v1 JSON-RPC names.

## Test plan
- [ ] Evals cover: no-JSON-RPC enforcement, use-case routing (multi-entity dashboard → GraphQL), custom indexer gating (leaderboard), Walrus for 2 MB NFT image, JSON-RPC → gRPC migration, historical object read (archival transparency), real-time event streaming, storage-fund clarification.
- [ ] Each eval has explicit \`expectations\` asserting what must appear and what must NOT (e.g., "does NOT recommend JSON-RPC").
- [ ] Sources field points to canonical docs.sui.io / docs.wal.app pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)