### PR TITLE
Fix faucet network restrictions, add MVR syntax and Move.lock guidance

### DIFF
--- a/sui-client/SKILL.md
+++ b/sui-client/SKILL.md
@@ -83,11 +83,13 @@ Development on Testnet and Devnet requires SUI tokens for gas. Tokens on these n
 
 | Method | How |
 |---|---|
-| CLI | `sui client faucet` (requests tokens for the active address on the active network) |
 | Web faucet | Visit `faucet.sui.io`, enter your address, select network, click Request SUI |
+| CLI (Devnet/Localnet only) | `sui client faucet` — works on Devnet and Localnet only, **not Testnet** |
 | TypeScript SDK | `requestSuiFromFaucetV2()` from `@mysten/sui/faucet` |
 | Discord | Join the Sui Discord, use `!faucet <ADDRESS>` in `#devnet-faucet` or `#testnet-faucet` |
 | Community faucets | N1Stake faucet, SuiLearn faucet (separate rate limits) |
+
+**IMPORTANT: `sui client faucet` only works on Devnet and Localnet. It does NOT work on Testnet. For Testnet tokens, use the web faucet at `faucet.sui.io` or another method above. NEVER suggest `sui client faucet` for Testnet.**
 
 Faucets are rate-limited. If you hit a limit, wait or try a different faucet.
 

--- a/sui-client/evals/evals.json
+++ b/sui-client/evals/evals.json
@@ -5,10 +5,10 @@
     {
       "id": 1,
       "prompt": "How do I get SUI tokens for testing? Where is the faucet?",
-      "expected_output": "Multiple faucet methods including web, CLI, Discord, and SDK, with the official URL.",
+      "expected_output": "Multiple faucet methods including web, CLI (Devnet/Localnet only), Discord, and SDK, with the official URL.",
       "expectations": [
         "The response provides the official faucet URL: faucet.sui.io",
-        "The response mentions the CLI method: sui client faucet",
+        "The response clarifies that sui client faucet only works on Devnet and Localnet, not Testnet",
         "The response mentions the Discord method: !faucet <ADDRESS> in #devnet-faucet or #testnet-faucet",
         "The response mentions the TypeScript SDK method: requestSuiFromFaucetV2",
         "The response states that Devnet and Testnet tokens are free and have no monetary value",
@@ -25,7 +25,7 @@
         "The response mentions that this creates a new key pair, address, and recovery phrase",
         "The response warns to save the recovery phrase immediately as it is only displayed once",
         "The response shows how to switch to devnet: sui client switch --env devnet",
-        "The response shows how to request tokens: sui client faucet",
+        "The response shows how to request tokens: sui client faucet (valid for devnet) or faucet.sui.io",
         "The response shows how to verify: sui client balance or sui client gas"
       ],
       "sources": [

--- a/sui-publish/SKILL.md
+++ b/sui-publish/SKILL.md
@@ -106,8 +106,9 @@ To publish to a different network (for example, from Testnet to Devnet), switch 
 
 Before publishing to a new network, ensure you have tokens for that network:
 
-- **Testnet / Devnet:** Free tokens through `sui client faucet`, the web faucet at `faucet.sui.io`, Discord (`!faucet <ADDRESS>` in `#testnet-faucet` or `#devnet-faucet`), or the TypeScript SDK (`requestSuiFromFaucetV2()`).
-- **Localnet:** Free tokens from the local faucet at `127.0.0.1:5003/gas` or `127.0.0.1:9123/gas` (started with `sui start --with-faucet`).
+- **Testnet:** Free tokens through the web faucet at `faucet.sui.io`, Discord (`!faucet <ADDRESS>` in `#testnet-faucet`), or the TypeScript SDK (`requestSuiFromFaucetV2()`). **`sui client faucet` does not work on Testnet.**
+- **Devnet:** Free tokens via `sui client faucet`, the web faucet at `faucet.sui.io`, Discord (`!faucet <ADDRESS>` in `#devnet-faucet`), or the TypeScript SDK.
+- **Localnet:** Free tokens via `sui client faucet` or the local faucet at `127.0.0.1:5003/gas` or `127.0.0.1:9123/gas` (started with `sui start --with-faucet`).
 - **Mainnet:** SUI tokens with real monetary value. Acquire through exchanges or transfers. No faucet available.
 
 ### Serializing for external signing


### PR DESCRIPTION
## Summary
- **sui-client, sui-publish:** Clarify that `sui client faucet` only works on Devnet and Localnet, not Testnet
- **sui-move-project:** Add actual MVR dependency syntax (`{ r.mvr = "@org/package" }`) and `mvr add` CLI command — previously only mentioned MVR exists without showing how to use it
- **sui-move-project:** Add Move.lock inspection section — structure explanation, example, and when to delete/regenerate
- Update evals to match

## Test plan
- [ ] Run sui-client evals and verify faucet expectations pass
- [ ] Run sui-move-project evals and verify dependency-related expectations pass
- [ ] Test prompt: "Inspect this Move package's Move.toml, Move.lock, and dependencies. Fix dependency declarations, prefer MVR where appropriate, and verify sui move build works." — confirm model uses correct `r.mvr` syntax and doesn't hallucinate Move.lock details

🤖 Generated with [Claude Code](https://claude.com/claude-code)