### PR TITLE
Add mainnet launch checklist, UpgradeCap lookup, and upgrade compatibility rules

### DIFF
--- a/accessing-data/walrus.md
+++ b/accessing-data/walrus.md
@@ -127,6 +127,48 @@ const bytes = await client.walrus.readBlob({ blobId });
 - **Highly-interactive structured state** — if Move needs to read and reason about the data, it has to fit in an object. Walrus blobs are opaque bytes from Move's perspective.
 - **Tiny metadata.** A 1 KB string belongs in a Move object. Walrus has per-blob overhead.
 
+## Wiring Walrus blob IDs into Object Display
+
+Store the blob ID in a struct field, then use the Walrus aggregator URL in the Display template to make wallets and explorers render the image directly:
+
+```move
+use sui::display_registry;
+
+public struct NFT has key, store {
+    id: UID,
+    name: String,
+    walrus_blob_id: String,
+}
+
+fun init(otw: MY_NFT, ctx: &mut TxContext) {
+    let publisher = package::claim(otw, ctx);
+
+    let (mut d, cap) = display_registry::new_with_publisher<NFT>(
+        &mut display_registry::borrow_mut(),
+        &mut publisher,
+        ctx,
+    );
+    display_registry::set(&mut d, &cap,
+        b"name".to_string(), b"{name}".to_string());
+    display_registry::set(&mut d, &cap,
+        b"image_url".to_string(),
+        b"https://aggregator.walrus-testnet.walrus.space/v1/blobs/{walrus_blob_id}".to_string());
+    display_registry::share(d);
+
+    transfer::public_transfer(cap, ctx.sender());
+    transfer::public_transfer(publisher, ctx.sender());
+}
+```
+
+The `{walrus_blob_id}` placeholder is replaced at display time with the object's field value, producing a full aggregator URL that wallets fetch directly.
+
+For mainnet, use the mainnet aggregator URL. The aggregator endpoint is read-only and free — no authentication or WAL tokens needed for reads.
+
+The end-to-end flow:
+1. Upload media to Walrus (HTTP API or `@mysten/walrus` SDK) → get `blobId`
+2. Mint the NFT with `walrus_blob_id` set to the returned `blobId`
+3. Display template resolves `{walrus_blob_id}` → aggregator serves the image
+
 ## Common mistakes
 
 - **"Put the image in the NFT."** NFTs should hold the *blob ID*, not the image bytes. Images go to Walrus; the Move object references them.

--- a/frontend-apps/setup.md
+++ b/frontend-apps/setup.md
@@ -42,6 +42,18 @@ const GRPC_URLS: Record<string, string> = {
   devnet:  'https://fullnode.devnet.sui.io:443',
 };
 
+// Package IDs per network — update after each publish/upgrade
+export const PACKAGE_IDS: Record<string, string> = {
+  testnet: '0x...', // from sui client publish on testnet
+  mainnet: '0x...', // from sui client publish on mainnet
+};
+
+// For type queries after upgrades, keep the original package ID
+export const ORIGINAL_PACKAGE_IDS: Record<string, string> = {
+  testnet: '0x...', // first publish ID (never changes)
+  mainnet: '0x...',
+};
+
 export const dAppKit = createDAppKit({
   networks: ['testnet', 'mainnet'],
   defaultNetwork: 'testnet',

--- a/frontend-apps/transactions.md
+++ b/frontend-apps/transactions.md
@@ -84,6 +84,43 @@ const digest = result.Transaction.digest;
 
 Do **not** use v1's `result.effects?.status?.status === 'success'` — that shape is gone.
 
+## Using package IDs in transactions
+
+Import `PACKAGE_IDS` and `ORIGINAL_PACKAGE_IDS` from your setup file (see `setup.md`) and use them with the current network:
+
+```tsx
+import { useCurrentNetwork } from '@mysten/dapp-kit-react';
+import { PACKAGE_IDS, ORIGINAL_PACKAGE_IDS } from './dapp-kit';
+
+function MintButton() {
+  const dAppKit = useDAppKit();
+  const network = useCurrentNetwork();
+
+  async function handleMint() {
+    const packageId = PACKAGE_IDS[network];
+    const tx = new Transaction();
+    tx.moveCall({
+      target: `${packageId}::nft::mint`,
+      arguments: [tx.pure.string('My NFT')],
+    });
+    await dAppKit.signAndExecuteTransaction({ transaction: tx });
+  }
+  // ...
+}
+```
+
+For type-filtered queries after a package upgrade, use `ORIGINAL_PACKAGE_IDS`:
+
+```ts
+const originalId = ORIGINAL_PACKAGE_IDS[network];
+const objects = await client.core.listOwnedObjects({
+  owner: account.address,
+  filter: { StructType: `${originalId}::nft::NFT` },
+});
+```
+
+See `sui-publish` skill → "Type anchoring after upgrades" for why the original ID is needed for type queries.
+
 ## Handing PTBs to the wallet
 
 **Pass the `Transaction` instance directly.** dApp Kit serializes it and forwards to the wallet, which selects gas coins and sets budget via dry-run.

--- a/modern-move-syntax/SKILL.md
+++ b/modern-move-syntax/SKILL.md
@@ -58,16 +58,21 @@ id.delete();
 
 ## String Literals
 
-Use byte string method syntax, not `std::string::utf8()`.
+Use quoted string literals directly, not `std::string::utf8()` or byte-string conversion.
 
 ```move
 // WRONG
 use std::string;
 let s = string::utf8(b"hello");
 
-// CORRECT
+// ALSO WRONG — unnecessary conversion
 let s = b"hello".to_string();
-let ascii = b"hello".to_ascii_string();
+
+// CORRECT — direct string literals (2024 edition)
+let s = "hello";                    // String (UTF-8)
+let ascii = "hello";                // also works for ASCII strings
+let s = b"hello".to_string();      // still valid but prefer quoted form
+let ascii = b"hello".to_ascii_string(); // explicit ASCII when needed
 ```
 
 ## Vector Literals and Methods
@@ -133,8 +138,20 @@ while (i < 32) {
     i = i + 1;
 };
 
-// CORRECT
+// CORRECT — do! macro
 32u8.do!(|_| do_action());
+```
+
+### Range-based loops
+
+```move
+// Iterate over a numeric range
+let mut sum = 0;
+10u64.do!(|i| { sum = sum + i });  // i goes 0..9
+
+// With index for more complex logic
+let mut results = vector[];
+5u64.do!(|i| results.push_back(i * i));  // [0, 1, 4, 9, 16]
 ```
 
 ### Vector iteration
@@ -197,6 +214,60 @@ dynamic_field::exists_(&id, key)
 dynamic_field::exists(&id, key)
 ```
 
+## Positional Fields (Tuple Structs)
+
+Structs can use positional fields instead of named fields:
+
+```move
+// Named fields (traditional)
+public struct Wrapper has copy, drop, store { value: u64 }
+
+// Positional fields (2024 edition)
+public struct Wrapper(u64) has copy, drop, store;
+
+// Access by position
+let w = Wrapper(42);
+let val = w.0;
+```
+
+Positional structs are useful for newtype wrappers and dynamic field keys (see `naming-conventions` skill).
+
+## Public Structs
+
+The `public` keyword on structs controls visibility of the struct's fields. Without `public`, fields are module-private — only the defining module can construct or destructure the struct.
+
+```move
+// Fields visible only within this module
+struct Config has key { id: UID, admin: address }
+
+// Fields visible to other modules
+public struct Token has key, store { id: UID, value: u64 }
+```
+
+Use `public` when other modules need to read fields or construct/destructure the struct. Omit it for encapsulation.
+
+## Enums
+
+Move 2024 supports enum types:
+
+```move
+public enum Color {
+    Red,
+    Green,
+    Blue,
+    Custom(u8, u8, u8),
+}
+
+public fun is_red(c: &Color): bool {
+    match (c) {
+        Color::Red => true,
+        _ => false,
+    }
+}
+```
+
+Enums can have variants with positional fields, named fields, or no fields. Use `match` expressions for exhaustive pattern matching. Enums cannot have the `key` ability — they cannot be objects directly, but they can be stored as fields inside objects.
+
 ## Quick Reference
 
 | Legacy Pattern | Modern 2024 Syntax |
@@ -207,7 +278,7 @@ dynamic_field::exists(&id, key)
 | `balance::split(&mut b, n)` | `b.split(n)` |
 | `tx_context::sender(ctx)` | `ctx.sender()` |
 | `object::delete(id)` | `id.delete()` |
-| `string::utf8(b"x")` | `b"x".to_string()` |
+| `string::utf8(b"x")` | `"x"` (or `b"x".to_string()`) |
 | `vector::empty()` | `vector[]` |
 | `vector::push_back(&mut v, x)` | `v.push_back(x)` |
 | `vector::length(&v)` | `v.length()` |

--- a/move-unit-testing/SKILL.md
+++ b/move-unit-testing/SKILL.md
@@ -160,6 +160,104 @@ fun mint_returns_correct_value() {
 
 **When to use `tx_context::dummy()`:** pure function tests, single-operation tests, anything that just needs a ctx to create objects.
 
+## `test_scenario` for Multi-Transaction and Authorization Tests
+
+Use `test_scenario` when you need to simulate multiple transactions, different senders, shared objects, or test `init` functions. The core API:
+
+| Function | Purpose |
+|---|---|
+| `test_scenario::begin(@addr)` | Start a scenario with `@addr` as the first sender |
+| `scenario.next_tx(@addr)` | Advance to a new transaction with `@addr` as sender |
+| `scenario.take_from_sender<T>()` | Take an owned object sent to the current sender |
+| `scenario.return_to_sender(obj)` | Return an owned object to the current sender |
+| `scenario.take_shared<T>()` | Take a shared object by type |
+| `test_scenario::return_shared(obj)` | Return a shared object |
+| `scenario.has_most_recent_for_sender<T>()` | Check if sender has an object of type `T` |
+| `scenario.end()` | Finalize the scenario (must be called in non-aborting tests) |
+
+### Success test — create and verify
+
+```move
+#[test]
+fun owner_can_update_item() {
+    let owner = @0xA;
+    let mut scenario = test_scenario::begin(owner);
+
+    // Tx 1: create an item (transferred to owner inside create_item)
+    app::create_item(b"sword".to_string(), scenario.ctx());
+
+    // Tx 2: owner takes the item and updates it
+    scenario.next_tx(owner);
+    let mut item = scenario.take_from_sender<Item>();
+    app::set_name(&mut item, b"great sword".to_string());
+    assert_eq!(app::name(&item), b"great sword".to_string());
+    scenario.return_to_sender(item);
+
+    scenario.end();
+}
+```
+
+### Unauthorized caller test
+
+```move
+#[test, expected_failure(abort_code = app::ENotOwner, location = app)]
+fun non_owner_cannot_update_item() {
+    let owner = @0xA;
+    let attacker = @0xB;
+    let mut scenario = test_scenario::begin(owner);
+
+    // Tx 1: owner creates a shared item
+    app::create_shared_item(b"shield".to_string(), scenario.ctx());
+
+    // Tx 2: attacker tries to update it — should abort
+    scenario.next_tx(attacker);
+    let mut item = scenario.take_shared<Item>();
+    app::admin_update(&mut item, b"hacked".to_string(), scenario.ctx());
+    // no cleanup — test aborts above
+}
+```
+
+### Shared object test
+
+```move
+#[test]
+fun shared_counter_increments() {
+    let mut scenario = test_scenario::begin(@0xA);
+
+    // Tx 1: create and share
+    app::create_counter(scenario.ctx());
+
+    // Tx 2: anyone can increment
+    scenario.next_tx(@0xB);
+    let mut counter = scenario.take_shared<Counter>();
+    app::increment(&mut counter);
+    assert_eq!(app::value(&counter), 1);
+    test_scenario::return_shared(counter);
+
+    scenario.end();
+}
+```
+
+### Testing `init` functions
+
+```move
+#[test]
+fun init_creates_admin_cap() {
+    let mut scenario = test_scenario::begin(@0xA);
+
+    // init is called automatically for the first tx in begin()
+    // if the module has an init function — but in tests you call it explicitly:
+    app::init_for_testing(scenario.ctx());
+
+    scenario.next_tx(@0xA);
+    assert!(scenario.has_most_recent_for_sender<AdminCap>());
+
+    scenario.end();
+}
+```
+
+Note: modules typically expose a `init_for_testing` or `test_init` helper since `init` itself is not directly callable in tests. Use `#[test_only]` to gate these helpers.
+
 ## Use `test_utils::destroy` for Cleanup
 
 Use the standard `test_utils::destroy` function to clean up test objects. Do not write custom `destroy_for_testing` functions.

--- a/naming-conventions/SKILL.md
+++ b/naming-conventions/SKILL.md
@@ -13,19 +13,29 @@ Move on Sui has specific naming conventions that differ from what AI agents typi
 
 All patterns sourced from https://move-book.com/guides/code-quality-checklist
 
-## Error Constants: EPascalCase
+## Error Constants: EPascalCase with `#[error]`
 
 Error constants MUST use PascalCase with an `E` prefix. Do NOT use SCREAMING_SNAKE_CASE.
+
+Use the `#[error]` attribute to attach human-readable messages to error constants. When an abort occurs, the message is included in the error output, making debugging much easier for users and support.
 
 ```move
 // WRONG
 const NOT_AUTHORIZED: u64 = 0;
 const INSUFFICIENT_BALANCE: u64 = 1;
 
-// CORRECT
+// CORRECT — with #[error] for readable abort messages
+#[error]
+const ENotAuthorized: vector<u8> = b"Caller is not authorized to perform this action";
+#[error]
+const EInsufficientBalance: vector<u8> = b"Insufficient balance for this operation";
+
+// Also valid — u64 without #[error] (less informative on abort)
 const ENotAuthorized: u64 = 0;
 const EInsufficientBalance: u64 = 1;
 ```
+
+When using `#[error]`, the constant type is `vector<u8>` (a byte string message) instead of `u64`. The compiler assigns numeric codes automatically. Prefer `#[error]` for all new code — it produces clearer error output in explorers, wallets, and logs.
 
 ## Regular Constants: ALL_CAPS
 

--- a/object-model/ownership.md
+++ b/object-model/ownership.md
@@ -6,13 +6,13 @@ Every object on Sui has one of five ownership types. The ownership type determin
 
 Owned by a specific 32-byte address. Only that address can use the object as a transaction input. Created through `transfer::transfer()` or `transfer::public_transfer()`.
 
-Address-owned objects skip consensus entirely (fastpath). This gives them the lowest latency and highest throughput. Most transactions on Sui (transfers, personal asset management, single-player game moves) touch only owned objects and execute in parallel.
+All transactions go through consensus on Sui. However, transactions touching only address-owned objects benefit from optimized consensus handling, giving them the lowest latency and highest throughput. Most transactions on Sui (transfers, personal asset management, single-player game moves) touch only owned objects and execute in parallel.
 
-The tradeoff: only one address can use the object. If multiple users need access, use a shared object instead.
+The tradeoff: only one address can use the object, and only one inflight transaction per object version is allowed. If multiple users need access, use a shared object. If a single owner needs multiple inflight transactions against the same object, use a party object.
 
-## Consensus-address-owned objects (party objects)
+## Party objects
 
-A hybrid between address-owned and shared objects. A consensus-address-owned object is owned by a single address but sequenced and versioned through consensus instead of the fastpath. APIs expose this ownership with a `ConsensusAddressOwner` owner variant.
+Party objects are a newer ownership form that combines single-address ownership with consensus sequencing. The underlying mechanism is called "consensus-address-owned," which is a special case of the broader party object concept (still in development as a full feature). APIs expose this ownership with a `ConsensusAddressOwner` owner variant.
 
 Party objects are the public Move-facing way to create this ownership form. They are created using `sui::transfer::party_transfer` or `sui::transfer::public_party_transfer`, and use the `sui::party::Party` type (currently restricted to `party::single_owner` for single-address ownership).
 
@@ -54,7 +54,7 @@ Use wrapping for tight coupling: when a child should only be accessible through 
 
 ## Object versioning
 
-Object versions use Lamport timestamps. When a transaction touches multiple objects, all of them receive the same new version: `1 + max(version of all input objects)`.
+Object versions use a system similar to Lamport timestamps, referred to as Lamport versioning. When a transaction touches multiple objects, all of them receive the same new version: `1 + max(version of all input objects)`.
 
 Example: if a transaction modifies an object at version 5 using a gas coin at version 3, both the object and the gas coin become version 6.
 
@@ -62,7 +62,7 @@ Only the most recent version is accessible to active transactions. Historical ve
 
 ### Versioning and ownership
 
-- **Fastpath (owned/immutable) objects:** Version is updated without consensus. Lowest latency. The transaction must use the exact current version as input. Coordinate offchain access or use a consensus object instead if frequent concurrent use is needed.
-- **Consensus (shared/party) objects:** Version is updated through consensus ordering. Adds latency but enables concurrent access without version locking issues.
+- **Address-owned / immutable objects:** Benefit from optimized consensus handling with lowest latency. The transaction must use the exact current version as input, and only one inflight transaction per object version is allowed. Coordinate offchain access or use a party/shared object if frequent concurrent use is needed.
+- **Shared / party objects:** Sequenced through full consensus ordering. Enables concurrent access — multiple inflight transactions can touch the same object without version locking issues.
 - **Wrapped objects:** Version increments when the parent is modified, maintaining unique (ID, version) pairs. While wrapped, the object is not directly accessible by version.
 - **Dynamic fields:** Version increments when the field is modified, following Lamport timestamps like regular objects.

--- a/ptbs/building.md
+++ b/ptbs/building.md
@@ -242,6 +242,8 @@ sendBackToUser(sponsorSigned);
 
 Both parties sign over the **entire TransactionData** including `GasData`. Signing only parts lets a malicious full node substitute gas data.
 
+**Sponsor safety note:** The sender can use `GasCoin` (which belongs to the sponsor) within the PTB — for example, splitting SUI from it or passing it to `transferObjects`. Sponsors should validate the PTB before signing to ensure the gas coin is not drained for non-gas purposes. Reject PTBs that pass `tx.gas` by value to anything other than the final transfer, or use `coinWithBalance` intents instead of raw gas coin access.
+
 ## Signing & executing
 
 ```ts

--- a/ptbs/fundamentals.md
+++ b/ptbs/fundamentals.md
@@ -50,10 +50,11 @@ The same pure bytes can be used at multiple compatible types if they deserialize
 Commands reference values via four `Argument` kinds:
 
 - **`Input(u16)`** — input at index `u16` in the `inputs` vector.
-- **`GasCoin`** — the SUI coin paying for gas. Special rules:
+- **`GasCoin`** — the SUI coin paying for gas. **Always present in every transaction**, even when using address-balance payment. When paying with address balances, an ephemeral gas coin is created for the transaction and deleted at the end if not transferred. Special rules:
   - Can be used by `&` or `&mut` anywhere.
-  - Can be passed by value **only** to `TransferObjects` (or `sui::coin::send_funds`).
+  - Can be passed by value **only** to `TransferObjects` (or `sui::coin::send_funds` once available).
   - To get an owned `Coin<SUI>` from the gas coin, split it first: `SplitCoins(GasCoin, [amount])`.
+  - In sponsored transactions, the **sender** can still use the GasCoin (which belongs to the sponsor). Sponsors should validate submitted PTBs to ensure the gas coin is not misused.
 - **`Result(u16)`** — shorthand for `NestedResult(i, 0)`. Valid only when command `i` has exactly one return value.
 - **`NestedResult(u16, u16)`** — `(command_index, result_index_within_that_command)`.
 
@@ -92,6 +93,8 @@ tx.moveCall({ target: `0x123::hero::equip_sword`, arguments: [hero, sword] });
 3. **Max gas budget (in MIST) is withdrawn from the gas coin.** Unused gas is refunded at end of execution, even if the gas coin changed owners.
 
 ### Argument usage rules
+
+These rules are **inferred by the runtime** from the Move function signatures being called. The PTB itself does not specify whether an argument is passed by reference, mutable reference, or value — the system determines this from the target function's parameter types.
 
 For each argument position:
 - **`&mut T` expected** — mutable borrow. Fails if any other borrow is outstanding.

--- a/sui-build-test/SKILL.md
+++ b/sui-build-test/SKILL.md
@@ -21,6 +21,23 @@ This compiles all modules, validates types, enforces resource safety, and produc
 
 For the canonical hello-world repository, run build commands from `sui-stack-hello-world/move/hello-world`.
 
+### `--build-env` flag
+
+When a package has an `[environments]` section in `Move.toml` with multiple networks, use `--build-env` to target a specific environment:
+
+```bash
+sui move build --build-env testnet
+sui move build --build-env mainnet
+```
+
+This resolves dependencies and package addresses for the specified environment. Without `--build-env`, the build uses the default environment or may fail with "Could not determine the correct dependencies" if multiple environments are defined and no default is set.
+
+The `--build-env` flag also applies to `sui move test`:
+
+```bash
+sui move test --build-env testnet
+```
+
 ### Debugging
 
 - **Move Trace Debugger:** Step-through debugger for Move execution traces with variable inspection.

--- a/sui-install/SKILL.md
+++ b/sui-install/SKILL.md
@@ -68,6 +68,7 @@ suiup show                   # list all installed binaries and their default sta
 | `update` | `suiup update sui@testnet` | Download the latest version (does NOT switch to it) |
 | `switch` | `suiup switch sui@testnet` | Set the latest installed version for a network as the active default |
 | `show` | `suiup show` | List all installed binaries with versions and defaults |
+| `status` | `suiup status` | Show which installed binaries have updates available and the command to update them |
 | `self update` | `suiup self update` | Update suiup itself |
 
 The `switch` command takes a `binary@network` argument (for example, `sui@testnet`, `walrus@testnet`, `move-analyzer@testnet`). It does not accept separate positional arguments like `suiup switch sui testnet v1.70.2`.

--- a/sui-move/SKILL.md
+++ b/sui-move/SKILL.md
@@ -29,8 +29,8 @@ This skill routes to focused reference files. Load only the ones relevant to the
 
 ### move — Move Language Fundamentals
 **Path:** `move.md`
-**Load when:** writing Move code, working with abilities, TxContext, time/Clock, init functions, One-Time Witness, packages, modules, structs, or resource safety.
-**Covers:** the four abilities and common combinations, TxContext methods, Clock object, init functions, OTW pattern, packages and upgrades, modules, structs, resource safety and object destruction, a worked Greeting example.
+**Load when:** writing Move code, working with abilities, TxContext, time/Clock, init functions, One-Time Witness, packages, modules, structs, resource safety, access control patterns, admin rotation, deny lists, or security review.
+**Covers:** the four abilities and common combinations, TxContext methods, Clock object, init functions, OTW pattern, packages and upgrades, modules, structs, resource safety and object destruction, a worked Greeting example, admin rotation (two-step transfer), regulated coins and deny lists, security review checklist.
 
 ### events-coins — Events and Coins
 **Path:** `events-coins.md`
@@ -75,6 +75,7 @@ This skill routes to focused reference files. Load only the ones relevant to the
 | Setting up Move.toml | `sui-move-project/` skill |
 | Writing a complete smart contract | move + events-coins + `object-model/` + `naming-conventions/` + `modern-move-syntax/` |
 | Code review | move + events-coins + `composable-move-functions/` + `naming-conventions/` + `modern-move-syntax/` |
+| Security review / access control audit | move + `object-model/` (patterns) + events-coins |
 
 ---
 

--- a/sui-move/move.md
+++ b/sui-move/move.md
@@ -2,6 +2,8 @@
 
 Move is Sui's smart contract language. It is platform-agnostic and designed around resource safety. Smart contracts on Sui are called Move packages.
 
+For the complete language reference, see [The Move Book](https://move-book.com).
+
 ## Move abilities
 
 Every struct in Move has a set of abilities that control what you can do with it. There are four abilities:

--- a/sui-move/move.md
+++ b/sui-move/move.md
@@ -175,3 +175,103 @@ Key patterns in this example:
 - `object::new(ctx)` generates a unique ID for the new object.
 - `transfer::share_object()` places the object in shared global storage so any address can interact with it.
 - `&mut Greeting` is a mutable reference, allowing modification without violating resource safety.
+
+## Access control patterns
+
+### Admin rotation (two-step transfer)
+
+Never transfer an `AdminCap` directly to a new address in one step — if the recipient address is wrong, the cap is lost forever. Use a two-step pattern:
+
+```move
+public struct AdminTransferRequest has key {
+    id: UID,
+    new_admin: address,
+}
+
+/// Step 1: current admin proposes a transfer
+public fun propose_admin_transfer(
+    cap: &AdminCap,
+    new_admin: address,
+    ctx: &mut TxContext,
+) {
+    transfer::transfer(AdminTransferRequest {
+        id: object::new(ctx),
+        new_admin,
+    }, new_admin);
+}
+
+/// Step 2: new admin accepts and receives the cap
+public fun accept_admin_transfer(
+    cap: AdminCap,
+    request: AdminTransferRequest,
+    ctx: &mut TxContext,
+) {
+    let AdminTransferRequest { id, new_admin } = request;
+    assert!(ctx.sender() == new_admin);
+    id.delete();
+    transfer::transfer(cap, new_admin);
+}
+```
+
+The new admin must actively call `accept_admin_transfer`, proving they control the target address. If the request is never accepted, the cap stays with the original admin.
+
+### Deny lists (regulated coins)
+
+Sui provides a system-level `DenyList` shared object (`0x403`) for regulated coins. Use `coin::create_regulated_currency` instead of `coin::create_currency` to enable address-based transfer restrictions:
+
+```move
+use sui::coin;
+use sui::deny_list::DenyList;
+
+public struct MY_TOKEN has drop {}
+
+fun init(otw: MY_TOKEN, ctx: &mut TxContext) {
+    let (treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+        otw, 9, b"TKN", b"Token", b"A regulated token", option::none(), ctx,
+    );
+    transfer::public_transfer(treasury_cap, ctx.sender());
+    transfer::public_transfer(deny_cap, ctx.sender());
+    transfer::public_freeze_object(metadata);
+}
+
+/// Add an address to the deny list (requires DenyCap)
+public fun block_address(
+    deny_list: &mut DenyList,
+    deny_cap: &mut DenyCap<MY_TOKEN>,
+    addr: address,
+    ctx: &mut TxContext,
+) {
+    coin::deny_list_v2_add(deny_list, deny_cap, addr, ctx);
+}
+
+/// Remove an address from the deny list
+public fun unblock_address(
+    deny_list: &mut DenyList,
+    deny_cap: &mut DenyCap<MY_TOKEN>,
+    addr: address,
+    ctx: &mut TxContext,
+) {
+    coin::deny_list_v2_remove(deny_list, deny_cap, addr, ctx);
+}
+```
+
+Key points:
+- `create_regulated_currency` returns an additional `DenyCap<T>` alongside the `TreasuryCap`.
+- The `DenyCap` authorizes adding/removing addresses from the deny list. Custody of the `DenyCap` is as important as the `TreasuryCap`.
+- Denied addresses cannot receive the coin type in any transaction. The restriction is enforced at the validator level.
+- The `DenyList` object at `0x403` is a system shared object. Reference it from TypeScript with `tx.object.denyList()`.
+
+For custom (non-coin) deny lists, store a `Table<address, bool>` or `VecSet<address>` in a shared object and check it in your entry functions.
+
+### Security review checklist
+
+When reviewing a Move package's access control:
+
+1. **Capability custody.** Where is each cap (`AdminCap`, `TreasuryCap`, `DenyCap`, `UpgradeCap`) created? Where does it end up? Is it transferred to `ctx.sender()` in `init`, or is it shared/wrapped? Can it be transferred to a new owner, and if so, through what mechanism?
+2. **Shared object entry points.** Every `public` or `entry` function that takes a `&mut SharedObject` is callable by any address. Verify that each one either (a) checks a capability, (b) checks `ctx.sender()` against a stored admin address, or (c) is intentionally permissionless.
+3. **`entry` vs `public` visibility.** `entry` functions are only callable as the first command in a PTB (not composable). `public` functions are callable from other Move code and PTBs. Prefer `public` for composability, but be aware that `public` functions can be called by any other package.
+4. **Admin rotation.** Is there a way to transfer admin authority? If so, does it use a two-step pattern? A single-step transfer risks permanent loss if the recipient address is wrong.
+5. **Deny list / blocklist.** For regulated tokens, is `create_regulated_currency` used? Is the `DenyCap` custody secured? For custom deny lists, are blocked addresses checked in all relevant entry points?
+6. **Event emission.** Are security-critical actions (admin changes, deny list modifications, object deletions, configuration updates) emitting events? Events are the only way for offchain monitoring to detect these actions.
+7. **Object deletion.** Can shared objects be deleted? If so, who can delete them? Deleting a shared object with dynamic fields renders those fields permanently inaccessible.
+8. **Upgrade policy.** Is the `UpgradeCap` held by a multisig or has the package been made immutable? An unrestricted `UpgradeCap` held by a single key means the entire package can be rewritten.

--- a/sui-publish/SKILL.md
+++ b/sui-publish/SKILL.md
@@ -4,10 +4,11 @@ description: >
   Publishing, upgrading, and deploying Sui Move packages. Use this skill when the
   user needs to publish a package, upgrade a published package, deploy to multiple
   networks, serialize transactions for multisig signing, run a local Sui network
-  (localnet), prepare for Mainnet launch, or debug dry run failures. Also use when
-  the user asks about sui client publish, sui client upgrade, UpgradeCap, upgrade
-  policies, Published.toml, --serialize-output, localnet, mainnet launch checklist,
-  gas estimation, multisig publishing, devInspectTransactionBlock, or --dry-run.
+  (localnet), prepare for Mainnet launch, monitor production deployments, or debug
+  dry run failures. Also use when the user asks about sui client publish, sui client
+  upgrade, UpgradeCap, upgrade policies, Published.toml, --serialize-output, localnet,
+  mainnet launch checklist, gas estimation, multisig publishing, production monitoring,
+  rollback, incident response, devInspectTransactionBlock, or --dry-run.
 ---
 
 # Publishing, Deploying & Local Network
@@ -253,3 +254,67 @@ Wallets (like Slush) automatically perform dry runs before presenting a transact
 From the TypeScript SDK, use `devInspectTransactionBlock` to dry-run a transaction programmatically. From the CLI, the `--dry-run` flag simulates execution.
 
 When debugging a dry run failure: check that all object IDs are correct, the object versions are current, the sender has sufficient gas, the function arguments match the expected types, and the active environment (`sui client active-env`) matches the network where the package is published.
+
+## Production monitoring
+
+Sui packages are immutable once published, so monitoring is critical — you cannot hotfix a live contract, only publish an upgrade.
+
+### What to monitor
+
+| Signal | How | Why |
+|---|---|---|
+| Failed transactions involving your package | Subscribe to transaction effects via gRPC streaming, filter by package ID | Detects Move aborts, gas failures, or unexpected reverts in production |
+| Gas spend | Track `gasUsed` from transaction effects | Catch unexpectedly expensive operations or gas drain attacks |
+| Event emission | Subscribe to events by type (`{packageId}::module::EventName`) via gRPC streaming | Core business telemetry — mints, transfers, admin actions, deny list changes |
+| Object creation/deletion rates | Query or subscribe to object changes filtered by your types | Detect abnormal activity (mass minting, object spam) |
+| Admin/cap usage | Filter events for capability-gated actions | Detect unauthorized or unexpected admin operations |
+| Shared object contention | Monitor transaction latency for shared-object transactions | High contention degrades UX; may need object sharding |
+
+### Implementation
+
+Use gRPC streaming subscriptions for real-time monitoring:
+
+```ts
+for await (const event of client.subscriptionService.subscribeEvents({
+  filter: { MoveEventModule: { package: PACKAGE_ID, module: 'my_module' } },
+})) {
+  // Forward to your monitoring stack (Grafana, Datadog, PagerDuty, etc.)
+}
+```
+
+For historical analysis, run a custom indexer (`sui-indexer-alt`) that writes relevant events and transaction effects to your own database. See the `accessing-data` skill's `indexers.md`.
+
+Emit events for every security-critical action in your Move code — admin changes, configuration updates, deny list modifications, object deletions. Events are the only way offchain systems can observe these actions.
+
+## Rollback and incident response
+
+**Sui packages cannot be rolled back.** Published bytecode is immutable. There is no `revert` or `rollback` command. Recovery means publishing a forward-fix upgrade.
+
+### If a bad upgrade is published
+
+1. **Assess scope.** Determine which functions are affected. Existing objects created by prior versions are still valid — their types are anchored to the original package ID.
+2. **Publish a fix upgrade immediately.** Write the corrected code, run tests, dry-run on Testnet, then `sui client upgrade` on Mainnet. The new package ID replaces the old one for all future calls.
+3. **Update frontends.** Point `PACKAGE_IDS` to the new (fixed) package ID. Type queries still use `ORIGINAL_PACKAGE_IDS`.
+4. **Communicate.** If the bug affected user-facing behavior, notify users through your app's channels.
+
+### If the UpgradeCap is compromised
+
+An attacker with the `UpgradeCap` can publish arbitrary code under your package. Mitigation:
+
+- **If you still hold the cap:** Immediately restrict it (`only_dep_upgrades` or `make_immutable`) to prevent further malicious upgrades.
+- **If the attacker holds the cap:** You cannot recover upgrade authority. Publish a new package, migrate users, and communicate the migration. This is why multisig custody of the `UpgradeCap` matters for production packages.
+
+### If a shared object is corrupted
+
+A buggy function may write invalid state to a shared object. Since shared objects are mutable by any transaction:
+
+- **If you can upgrade:** Publish an upgrade with a repair function that fixes the corrupted state. Gate it behind an `AdminCap`.
+- **If the package is immutable:** The only option is to deploy a new package with a migration function that reads the old object's data (if accessible) and creates corrected objects.
+
+### Prevention checklist
+
+- [ ] `UpgradeCap` held by multisig or restricted to `additive` / `dep_only`
+- [ ] All upgrades tested on Testnet with the same code, same publish flow
+- [ ] Admin actions emit events for monitoring
+- [ ] Critical shared objects have repair functions gated behind capabilities
+- [ ] Frontend can switch package IDs without a redeploy (environment config, not hardcoded)

--- a/sui-publish/SKILL.md
+++ b/sui-publish/SKILL.md
@@ -49,6 +49,26 @@ This deploys the package to the active network and returns:
 - An **UpgradeCap** object (sent to your address, controls future upgrades)
 - Object IDs for anything created during `init` functions
 
+### Test publishing (ephemeral networks)
+
+Use `sui client test-publish` to publish a package to an ephemeral environment for testing without persisting state to a real network:
+
+```bash
+sui client test-publish
+```
+
+This publishes the package, runs `init` functions, and returns the same output as `sui client publish` (package ID, UpgradeCap, created objects), but the deployment is not permanent. Use it to:
+
+- Verify that `init` functions execute correctly before committing to a real publish
+- Test publish + upgrade flows in CI without consuming Testnet/Devnet resources
+- Validate gas costs and object creation before a Mainnet deploy
+
+`test-publish` respects `--build-env` for multi-environment packages:
+
+```bash
+sui client test-publish --build-env testnet
+```
+
 ### After publishing
 
 The `published-at` field is automatically added to your `Published.toml`. To interact with the published package:

--- a/sui-publish/SKILL.md
+++ b/sui-publish/SKILL.md
@@ -68,13 +68,50 @@ Published packages are immutable, but you can upgrade by publishing a new versio
 sui client upgrade --upgrade-capability <CAP_ID>
 ```
 
+#### Finding your UpgradeCap
+
+The `UpgradeCap` object ID is needed for every upgrade. There are several ways to find it:
+
+1. **Published.toml** (preferred): After publishing, the toolchain records the cap ID in `Published.toml` under the `upgrade-capability` field for each environment.
+2. **Query owned objects**: List all `UpgradeCap` objects owned by the publish address:
+   ```bash
+   sui client objects --type 0x2::package::UpgradeCap
+   ```
+3. **Publish transaction output**: The original `sui client publish` output includes the `UpgradeCap` object ID in the created objects list.
+4. **Explorer**: Search for your address on SuiVision (`suivision.xyz`) or Suiscan (`suiscan.xyz`) and filter owned objects by type `0x2::package::UpgradeCap`.
+
+#### Upgrade policies
+
 Upgrade policies restrict what can change:
 
-- **Compatible:** Functions can be added but not removed. Struct layouts cannot change.
-- **Additive:** New modules can be added, but existing modules cannot change.
-- **Dependency-only:** Only dependency versions can be updated.
+- **Compatible** (default): The most permissive policy. See detailed rules below.
+- **Additive:** New modules can be added, but existing modules cannot change at all.
+- **Dependency-only:** Only dependency versions can be updated. No code changes.
 
 You can restrict the `UpgradeCap` in the same PTB as the publish command (for example, calling `only_additive_upgrades` on it immediately). Once restricted, you cannot widen the policy. You can also transfer the `UpgradeCap` to a multisig address or destroy it entirely to make the package permanently immutable.
+
+#### Compatible upgrade rules (detailed)
+
+Under the **compatible** policy, these changes are **allowed**:
+
+- Add new functions (public or private)
+- Add new modules
+- Change function implementations (body)
+- Add new struct types
+- Change private/friend function signatures
+
+These changes **break compatibility** and will be rejected:
+
+- Remove or rename an existing module
+- Remove or rename a public function
+- Change a public function's signature (parameters, return types, type parameters)
+- Remove, rename, or reorder struct fields
+- Change the type of a struct field
+- Add or remove struct abilities (`key`, `store`, `copy`, `drop`)
+- Remove a struct type entirely
+- Change a struct's type parameters
+
+Before upgrading, review your diff against these rules. The `sui client upgrade` command will reject incompatible changes at build time with a descriptive error.
 
 ### Type anchoring after upgrades
 

--- a/sui-publish/SKILL.md
+++ b/sui-publish/SKILL.md
@@ -4,9 +4,10 @@ description: >
   Publishing, upgrading, and deploying Sui Move packages. Use this skill when the
   user needs to publish a package, upgrade a published package, deploy to multiple
   networks, serialize transactions for multisig signing, run a local Sui network
-  (localnet), or debug dry run failures. Also use when the user asks about sui
-  client publish, sui client upgrade, UpgradeCap, upgrade policies, Published.toml,
-  --serialize-output, localnet, devInspectTransactionBlock, or --dry-run.
+  (localnet), prepare for Mainnet launch, or debug dry run failures. Also use when
+  the user asks about sui client publish, sui client upgrade, UpgradeCap, upgrade
+  policies, Published.toml, --serialize-output, localnet, mainnet launch checklist,
+  gas estimation, multisig publishing, devInspectTransactionBlock, or --dry-run.
 ---
 
 # Publishing, Deploying & Local Network
@@ -120,6 +121,87 @@ sui client publish --serialize-output
 ```
 
 This outputs base64 transaction bytes instead of executing.
+
+## Mainnet launch checklist
+
+Use this checklist when preparing a package for Mainnet publishing. Every item should be verified before executing the publish transaction.
+
+### 1. Tests and coverage
+
+Run the full test suite and confirm all tests pass:
+
+```bash
+sui move test
+```
+
+For coverage reporting (if your project requires a threshold):
+
+```bash
+sui move test --coverage
+sui move coverage summary
+```
+
+Fix any failing tests before proceeding. Do not publish untested code to Mainnet.
+
+### 2. Dependencies and addresses
+
+- Verify `Move.toml` uses `edition = "2024"` and has no legacy `[addresses]` section or git-based Sui framework dependency.
+- Confirm `[environments]` includes a `mainnet` entry with the correct chain ID.
+- If using MVR dependencies (`{ r.mvr = "@org/package" }`), verify they resolve on Mainnet.
+- Run `sui move build` to confirm clean compilation with no warnings.
+
+### 3. Upgrade policy decision
+
+Decide your upgrade policy **before** publishing — you cannot widen it later:
+
+| Policy | What you can change | When to use |
+|---|---|---|
+| **Compatible** (default) | Add functions, add modules, update implementations. Cannot remove functions or change struct layouts. | Most packages — gives flexibility for bug fixes while preserving type safety. |
+| **Additive** | Add new modules only. Existing modules are frozen. | Packages where you want to extend functionality but guarantee existing code never changes. |
+| **Dependency-only** | Only update dependency versions. | Nearly-finalized packages that should only track framework updates. |
+| **Immutable** | Nothing. Package is permanently frozen. | Fully audited packages where immutability is a trust guarantee (e.g., token contracts). |
+
+To restrict the policy in the same transaction as publish, include a `moveCall` to `sui::package::only_additive_upgrades`, `only_dep_upgrades`, or `make_immutable` on the `UpgradeCap` in your publish PTB.
+
+### 4. Gas estimation
+
+Mainnet SUI has real monetary value. Estimate gas before publishing:
+
+```bash
+sui client publish --dry-run
+```
+
+The dry-run output includes `computationCost`, `storageCost`, and `storageRebate`. The total gas required is `computationCost + storageCost - storageRebate`. Ensure your address holds enough SUI to cover this amount plus a margin.
+
+### 5. Signer and custody plan
+
+Decide who controls the publish address and the `UpgradeCap`:
+
+- **Single signer:** Simplest. One key publishes and holds the `UpgradeCap`. Suitable for personal projects or early-stage development.
+- **Multisig:** For teams or high-value packages. Create a multisig address, publish using `--serialize-output`, and have the required signers sign offline. Transfer the `UpgradeCap` to the multisig address in the same PTB as publish.
+- **Immutable on publish:** If no upgrades will ever be needed, destroy the `UpgradeCap` in the publish PTB (`sui::package::make_immutable`). This removes custody concerns entirely.
+
+For multisig publishing:
+
+```bash
+# Generate unsigned transaction bytes
+sui client publish --serialize-output
+
+# Each signer signs the bytes, then combine and execute
+```
+
+### 6. Final pre-publish verification
+
+Before executing the publish transaction on Mainnet:
+
+- [ ] `sui client active-env` returns `mainnet`
+- [ ] `sui client balance` shows sufficient SUI for gas (check dry-run estimate)
+- [ ] `sui move build` succeeds with no warnings
+- [ ] `sui move test` passes with all tests green
+- [ ] `Move.toml` has correct `edition`, no legacy format
+- [ ] Upgrade policy is decided and restriction call is included in the PTB (if applicable)
+- [ ] Signer key or multisig is ready
+- [ ] You have verified the package on Testnet first — same code, same tests, same publish flow
 
 ## Dry runs and transaction debugging
 


### PR DESCRIPTION
## Summary
Updates to `sui-publish/SKILL.md`:
- Add **Mainnet launch checklist** — tests/coverage, dependency validation, upgrade policy decision matrix, gas estimation via dry-run, signer/custody plan, final pre-publish verification
- Add **UpgradeCap lookup methods** — Published.toml, `sui client objects --type 0x2::package::UpgradeCap`, publish output, explorer
- Add **detailed compatible upgrade rules** — explicit allowed/rejected change lists so the model doesn't have to guess what breaks compatibility
- Update skill description to trigger on mainnet launch, gas estimation, and multisig publishing queries

## Test plan
- [ ] Run sui-publish evals
- [ ] Test prompt: "Prepare this package for Mainnet publishing" — confirm structured checklist grounded in skill content
- [ ] Test prompt: "Prepare an upgrade for this published Sui package" — confirm model shows how to find UpgradeCap and lists specific compatibility rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)