### PR TITLE
Fix skill gaps found building full-stack dApps

### DIFF
--- a/frontend-apps/queries.md
+++ b/frontend-apps/queries.md
@@ -78,7 +78,7 @@ All hang off `client.core`:
 | Method | Returns |
 |---|---|
 | `getObject({ objectId, include })` | `{ object }` |
-| `getObjects({ objectIds, include })` | `{ objects }` |
+| `getObjects({ objectIds, include })` | `{ objects }` — elements can be `Object` or `Error` (see note below) |
 | `listOwnedObjects({ owner, type?, cursor?, limit?, include? })` | `{ objects, cursor }` |
 | `listCoins({ owner, coinType?, cursor?, limit? })` | `{ coins, cursor }` |
 | `listBalances({ owner })` | `{ balances }` |
@@ -111,6 +111,26 @@ for (const obj of result.objects) {
 ```
 
 Alternatively, use `include: { content: true }` to get raw BCS bytes and parse with generated types (from `@mysten/codegen`). `json` is easier for quick access; `content` is more reliable across API implementations.
+
+### `getObjects` returns `(Object | Error)[]`
+
+When batch-fetching with `getObjects`, individual entries can be `Error` instances (e.g. if an object was deleted or the ID is invalid). Always narrow the type before accessing fields:
+
+```ts
+const { objects } = await client.core.getObjects({
+  objectIds: ids,
+  include: { json: true },
+});
+
+const valid = objects
+  .filter((o): o is Exclude<typeof o, Error> => !(o instanceof Error) && !!o.json)
+  .map((o) => ({
+    objectId: o.objectId,
+    name: String((o.json as Record<string, unknown>).name ?? ''),
+  }));
+```
+
+Without this guard, TypeScript will error on `o.json` and `o.objectId` because `Error` has neither property.
 
 **Type anchoring after upgrades:** when filtering by type in `listOwnedObjects`, always use the **original** package ID where the struct was first published — not the upgraded package ID. Struct types are permanently anchored to the original package. Use the upgraded package ID only for calling functions via `moveCall`.
 
@@ -147,7 +167,7 @@ function MintButton() {
     if (result.$kind === 'FailedTransaction') throw new Error('Mint failed');
 
     // ✅ Wait for indexing BEFORE invalidating
-    await client.waitForTransaction({ digest: result.Transaction.digest });
+    await client.core.waitForTransaction({ digest: result.Transaction.digest });
 
     await queryClient.invalidateQueries({ queryKey: ['balance', account?.address] });
     await queryClient.invalidateQueries({ queryKey: ['owned-nfts', account?.address] });

--- a/frontend-apps/react.md
+++ b/frontend-apps/react.md
@@ -9,7 +9,7 @@ Source: https://sdk.mystenlabs.com/dapp-kit/getting-started/react
 | `useCurrentAccount()` | `UiWalletAccount \| null` | Connected address; null-check always required |
 | `useCurrentWallet()` | `UiWallet \| null` | Connected wallet (name, icon, accounts list) |
 | `useWalletConnection()` | `{ status, wallet, account, ... }` | Full connection state incl. `connecting` / `reconnecting` |
-| `useCurrentNetwork()` | active network string | Read current network |
+| `useCurrentNetwork()` | `string` (e.g. `'testnet'`) — not a tuple | Read current network |
 | `useCurrentClient()` | `SuiGrpcClient` for current network | Passing to TanStack Query / imperative calls |
 | `useDAppKit()` | the dApp Kit instance | Imperative actions: `signAndExecuteTransaction`, `connectWallet`, `switchNetwork`, etc. |
 | `useWallets()` | `UiWallet[]` | List detected wallets (custom wallet menu) |

--- a/frontend-apps/transactions.md
+++ b/frontend-apps/transactions.md
@@ -39,8 +39,9 @@ function ActionButton() {
       }
 
       // Wait for indexing, then invalidate caches
+      // Note: useCurrentClient() returns ClientWithCoreApi — use client.core for methods
       const digest = result.Transaction.digest;
-      await client.waitForTransaction({ digest });
+      await client.core.waitForTransaction({ digest });
       await queryClient.invalidateQueries({ queryKey: ['balance', account.address] });
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Unknown error');
@@ -211,10 +212,10 @@ tx signed → wallet returns digest → fullnode finalizes (fast)
 await dAppKit.signAndExecuteTransaction(...);
 await queryClient.invalidateQueries(...);  // BAD
 
-// ✅ Wait first
+// ✅ Wait first (use client.core — that's what useCurrentClient returns)
 const result = await dAppKit.signAndExecuteTransaction(...);
 if (result.$kind === 'FailedTransaction') throw new Error(...);
-await client.waitForTransaction({ digest: result.Transaction.digest });
+await client.core.waitForTransaction({ digest: result.Transaction.digest });
 await queryClient.invalidateQueries(...);  // GOOD
 ```
 
@@ -223,7 +224,8 @@ await queryClient.invalidateQueries(...);  // GOOD
 | Symptom | Cause | Fix |
 |---|---|---|
 | User rejects in wallet | normal | Catch and show a "cancelled" state — not an error |
-| "Insufficient gas" | wallet has too little SUI | UX: surface the address and amount, suggest faucet (testnet) or exchange (mainnet) |
+| "Insufficient gas" | wallet has too little SUI for gas budget | UX: surface the address and amount, suggest faucet (testnet) or exchange (mainnet) |
+| `InsufficientCoinBalance` (command 0) | `splitCoins` from gas requests more than the gas coin can cover after reserving for gas budget — the gas coin must cover payment + gas | Reduce price, merge coins first, or tell the user how much SUI they need (price + ~0.01 SUI for gas) |
 | "Nothing to execute" | PTB has no effective commands | Check you actually added commands to `tx` before signing |
 | Tx executes but fails Move assertion | Move code aborted | Catch `result.FailedTransaction`, surface the error message verbatim |
 | Tx succeeds but UI doesn't update | missing `waitForTransaction` / `invalidateQueries` | Add both, in that order |

--- a/ptbs/building.md
+++ b/ptbs/building.md
@@ -80,6 +80,19 @@ tx.pure(new Uint8Array([0, 1, 2]))
 - `tx.splitCoins(tx.gas, [tx.pure.u64(amount)])` — most common pattern: derive an owned `Coin<SUI>` from gas.
 - `tx.mergeCoins(tx.gas, [tx.object(extra1), tx.object(extra2)])` — consolidate owned SUI into the gas coin before using it.
 
+**`InsufficientCoinBalance` when splitting from gas:** the gas coin must cover both the split amount *and* the gas budget. If the user's gas coin has 0.5 SUI and you split 0.45 SUI, there may not be enough left for gas (~0.01 SUI). The wallet selects gas budget via dry-run, but cannot increase the coin's balance. Surface this error to users with the amount they need and suggest the faucet (testnet) or merging coins.
+
+**Use `BigInt` for large MIST amounts.** When coin amounts come from JSON responses (e.g. a listing price fetched from chain), they parse as `number` or `string`. Always wrap with `BigInt(amount)` to avoid silent precision loss:
+
+```ts
+// ✅ Safe for any MIST value
+const coins = tx.splitCoins(tx.gas, [BigInt(listing.price)]);
+tx.moveCall({ target: '...::buy', arguments: [coins[0]] });
+
+// ⚠️ Risky — JS number precision loss above 2^53
+const coins = tx.splitCoins(tx.gas, [listing.price]);
+```
+
 ## Commands — TS SDK signatures
 
 ```ts
@@ -121,6 +134,10 @@ Each command returns a destructurable/indexable result:
 // Single-return: destructure
 const [coin] = tx.splitCoins(tx.gas, [tx.pure.u64(100)]);
 tx.transferObjects([coin], tx.pure.address(to));
+
+// Single-return: index (equivalent)
+const coins = tx.splitCoins(tx.gas, [BigInt(price)]);
+tx.moveCall({ target: '...::buy', arguments: [coins[0]] });
 
 // Multi-return: destructure
 const [nft1, nft2] = tx.moveCall({ target: '0xpkg::mint::two' });

--- a/sui-publish/SKILL.md
+++ b/sui-publish/SKILL.md
@@ -81,6 +81,22 @@ sui client call --package <PACKAGE_ID> --module greeting --function new
 sui client object <OBJECT_ID>
 ```
 
+### "Your package is already published" error
+
+If you see this error when running `sui client publish`, it means `Published.toml` already has an entry for your active environment. This happens when iterating on a package during development.
+
+To publish a fresh copy (new package ID, new `init` objects):
+
+```bash
+rm Published.toml Move.lock
+sui move build
+sui client publish
+```
+
+Deleting `Move.lock` is necessary because it can also cache the published state. After the fresh publish, both files are regenerated with the new package address.
+
+To **upgrade** the existing package instead of deploying a new one, use `sui client upgrade` (see below).
+
 ### Upgrading a published package
 
 Published packages are immutable, but you can upgrade by publishing a new version linked to the original. The `UpgradeCap` object controls upgrade authority.


### PR DESCRIPTION
## Summary

- Fixes 7 documentation gaps discovered while building two complete Sui dApps (an arcade game and a bookstore marketplace) using the skills as the sole reference
- All fixes address real errors hit during development — `waitForTransaction` wrong path, `useCurrentNetwork` type confusion, `InsufficientCoinBalance` with no guidance, `getObjects` type narrowing, `splitCoins` BigInt requirement, and "already published" error recovery

## Changes

**frontend-apps/react.md**
- Clarify `useCurrentNetwork()` returns `string` (e.g. `'testnet'`), not a tuple — prevents `const [network] = useCurrentNetwork()` errors

**frontend-apps/transactions.md**
- Fix `client.waitForTransaction()` → `client.core.waitForTransaction()` in all examples (`useCurrentClient()` returns `ClientWithCoreApi`)
- Add `InsufficientCoinBalance` to the error handling table with cause and fix

**frontend-apps/queries.md**
- Fix `client.waitForTransaction()` → `client.core.waitForTransaction()` in cache invalidation example
- Document `getObjects` return type as `(Object | Error)[]` with type guard example code

**ptbs/building.md**
- Add `InsufficientCoinBalance` explanation: gas coin must cover split amount + gas budget
- Document `BigInt` requirement for large MIST amounts from JSON responses
- Add `coins[0]` indexing pattern alongside existing destructuring pattern

**sui-publish/SKILL.md**
- Add "Your package is already published" error recovery section (`rm Published.toml Move.lock`)

## Test plan

- [x] Verified all fixes against actual SDK types in `@mysten/sui@2.16.0` and `@mysten/dapp-kit-react@2.0.1`
- [x] Built two full-stack dApps (Move + React) using updated guidance without errors
- [ ] Review that examples compile against current SDK versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)