### PR TITLE
Add Slack notification for eval failures

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -102,3 +102,23 @@ jobs:
               repo: context.repo.repo,
               body
             });
+
+      - name: Notify Slack on eval failures
+        if: failure()
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_EVAL_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "❌ Skill eval failures detected",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "❌ *Skill eval failures detected* — ${{ github.event_name == 'pull_request' && format('PR #{0}', github.event.pull_request.number) || 'scheduled run' }}\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Summary
- Adds a Slack notification step to the eval workflow that fires when any eval fails
- Posts to `SLACK_EVAL_WEBHOOK_URL` with a link to the workflow run
- Works for all trigger types: PR, weekly schedule, and manual dispatch

## Setup required
- Add `SLACK_EVAL_WEBHOOK_URL` as a repository secret (Slack incoming webhook URL)

## Test plan
- [ ] Add the repo secret
- [ ] Trigger a manual eval run from the Actions tab to verify the webhook posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)