### PR TITLE
Add zklogin-enoki and sui-sponsored-transactions skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ npx skills add mystenlabs/skills --all
 
 ## Skills
 
-No skills published yet. Check back soon or watch this repo for updates.
+| Skill | What it covers |
+|-------|----------------|
+| [`zklogin-enoki`](zklogin-enoki/) | Passwordless social login (zkLogin) and gasless onboarding for Sui apps with Enoki — `registerEnokiWallets` + dApp Kit, backend `EnokiClient`, and manual zkLogin. |
+| [`sui-sponsored-transactions`](sui-sponsored-transactions/) | Sponsored / gasless transactions on Sui — the native sponsor + `GasData` dual-signature flow with the TypeScript SDK, plus the Enoki gas station, and the equivocation/locked-object risks. |
 
 ## Repo Structure
 

--- a/sui-sponsored-transactions/SKILL.md
+++ b/sui-sponsored-transactions/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: sui-sponsored-transactions
+description: >
+  Sponsored (gasless) transactions on Sui — paying a user's gas so they transact
+  without holding SUI. Use this skill whenever the user wants a "gas station",
+  "gasless", "fee-less", or "sponsored" transactions, wants their app to pay gas
+  for users, is wiring up the native Sui sponsor + GasData dual-signature flow with
+  the TypeScript SDK (`setGasOwner`, `setGasPayment`, `Transaction.fromKind`,
+  `onlyTransactionKind`, executing with two signatures), is building or operating a
+  gas station / sponsor backend, or needs to understand the equivocation /
+  locked-gas-object risk. Covers both the native protocol mechanism (works with any
+  Sui wallet/keypair) and the managed Enoki gas station. For passwordless zkLogin
+  social login specifically, use the `zklogin-enoki` skill instead.
+---
+
+# Sui Sponsored Transactions
+
+> **MCP tool:** When available in your environment, also query the Sui documentation MCP server (`https://sui.mcp.kapa.ai`) for up-to-date answers. Use it for verification and for details not covered by these reference files.
+
+> **Source constraint:** All information in this skill is sourced exclusively from official Mysten Labs documentation: [docs.sui.io](https://docs.sui.io), [sdk.mystenlabs.com](https://sdk.mystenlabs.com), [docs.enoki.mystenlabs.com](https://docs.enoki.mystenlabs.com), and the [MystenLabs](https://github.com/MystenLabs) source. When extending or updating this skill, only pull from these sources. Do not use third-party blogs or tutorials, and do not extrapolate SDK method names — verify them against the typedoc.
+
+A sponsored transaction lets one party (the **sponsor**) pay the gas for another party's (the **user's**) transaction. The user never needs to hold SUI. This is the foundation of "gasless" onboarding on Sui.
+
+Sui supports this **natively at the protocol level**: a transaction carries a `GasData` whose gas coins are owned by the sponsor, and **both** the user and the sponsor sign the same transaction bytes. This works with any Sui wallet or keypair. [Enoki](https://docs.enoki.mystenlabs.com) provides a managed gas station on top of the same mechanism.
+
+This skill prevents the most common AI-coding mistakes here:
+
+1. **Putting the gas coins under the wrong owner.** In `GasData`, the gas payment objects must be owned by the **sponsor** (`setGasOwner(sponsorAddress)`), not the sender. Getting this wrong means it isn't sponsored.
+2. **Forgetting the second signature.** A sponsored transaction needs **two** signatures — the user's and the sponsor's — over the *same* `TransactionData`. Executing with one fails.
+3. **Ignoring the equivocation / locked-object risk.** Reusing the same sponsor gas coin across concurrent transactions can lock it until the next epoch. Production gas stations need a coin pool.
+4. **Using deprecated v1 SDK names.** The current API is `@mysten/sui` (`Transaction`, `signTransaction`), not `@mysten/sui.js` (`TransactionBlock`, `signTransactionBlock`).
+
+This skill routes to focused reference files. Load only the ones relevant to the current task.
+
+---
+
+## Reference files
+
+### native-flow — Native Sponsored Transactions (TypeScript SDK)
+**Path:** `native-flow.md`
+**Load when:** implementing sponsorship with `@mysten/sui` directly, building the dual-signature flow, splitting work between a frontend and a sponsor backend, or choosing among the user-proposed / sponsor-proposed / wildcard patterns.
+**Covers:** the three roles and `GasData`, building `onlyTransactionKind` bytes, `Transaction.fromKind`, `setSender` / `setGasOwner` / `setGasPayment` / `setGasBudget` / `setGasPrice`, signing with both keypairs, executing with a two-signature array (gRPC `signatures` vs JSON-RPC `signature`), and the three sponsorship patterns.
+
+### enoki-gas-station — Managed Sponsorship with Enoki
+**Path:** `enoki-gas-station.md`
+**Load when:** using Enoki to sponsor transactions instead of running your own gas station, calling `EnokiClient.createSponsoredTransaction` / `executeSponsoredTransaction`, or scoping sponsorship with allowlists.
+**Covers:** the managed build → sponsor → sign → execute flow, the `jwt` vs `sender` input variants, `allowedMoveCallTargets` / `allowedAddresses`, the public-vs-private API key rule, and when to choose Enoki over a self-hosted gas station.
+
+### security — Equivocation, Locking, and Griefing
+**Path:** `security.md`
+**Load when:** operating a gas station in production, hardening a sponsor backend, or debugging locked gas objects / rejected sponsored transactions.
+**Covers:** the equivocation → locked-until-next-epoch risk, concurrent gas-object reuse, the gas-coin pool mitigation (Sui_Owned_Object_Pools), censorship/griefing and direct-to-fullnode submission, and gas-coin reservation requirements.
+
+---
+
+## Routing guide
+
+| Task | Load |
+|------|------|
+| What is a sponsored transaction / how it works | SKILL.md only |
+| The three roles and GasData | native-flow |
+| Implement sponsorship with `@mysten/sui` | native-flow |
+| Build transaction-kind bytes on the client | native-flow |
+| Set the sponsor as gas owner | native-flow |
+| Execute with two signatures | native-flow |
+| User-proposed vs sponsor-proposed vs wildcard | native-flow |
+| Sponsor with Enoki instead of self-hosting | enoki-gas-station |
+| Scope what the sponsor pays for | enoki-gas-station + security |
+| Where does the private API key go | enoki-gas-station |
+| Gas object got locked / equivocation | security |
+| Production gas station hardening | security |
+| Sponsor withholding / censorship | security |
+| Full integration / code review | **all reference files** |
+
+---
+
+## Key concepts
+
+- **Three roles:** the **user** (wants to transact), the **gas station** (provides gas payment objects), and the **sponsor** (funds the gas station). Often the gas station and sponsor are the same backend.
+- **`GasData` owner is the sponsor.** A transaction's `GasData` has `payment` (gas coins), `owner` (the sponsor address), `price`, and `budget`. The gas coins must be owned by `owner`. Set it with `tx.setGasOwner(sponsorAddress)`.
+- **Two signatures over the same bytes.** Both the user and the sponsor sign the identical `TransactionData` (which includes `GasData`). Execution submits both signatures.
+- **Current SDK:** `@mysten/sui`, class `Transaction`, `keypair.signTransaction(bytes)`. The v1 `@mysten/sui.js` / `TransactionBlock` / `signTransactionBlock` API is deprecated.
+- **Enoki** is the managed option: it runs the gas station and signs as sponsor for you, scoped by allowlists. Native sponsorship gives you full control but you operate the gas-coin pool.
+
+## Rules
+
+- The gas payment coins must be owned by the **sponsor**; set `tx.setGasOwner(sponsorAddress)`. All coins in `GasData.payment` must share one owner.
+- A sponsored transaction requires **both** the user's and the sponsor's signatures over the same built bytes. Do not execute with only one.
+- The user builds only the transaction *kind* (`tx.build({ client, onlyTransactionKind: true })`); the sponsor reconstructs it with `Transaction.fromKind(...)` and attaches gas data.
+- Do not reuse the same sponsor gas-coin version across concurrent sponsored transactions — it risks equivocation and locking the coin until the next epoch. Use a coin pool (see security).
+- Use the current `@mysten/sui` `Transaction` API, not the deprecated `@mysten/sui.js` `TransactionBlock` API.
+- With Enoki, keep the **private** API key on the backend and scope sponsorship with `allowedMoveCallTargets`.
+
+## Common mistakes
+
+- **Gas owned by the sender, not the sponsor.** Then the sender pays gas — it isn't sponsored. The gas coins must be the sponsor's, with `setGasOwner` pointing at the sponsor.
+- **Executing with a single signature.** Sponsored transactions need both signatures over the same `TransactionData`.
+- **Building a full transaction on the client.** The user should build with `onlyTransactionKind: true`; the sponsor adds gas. Building full gas data on the client defeats sponsorship.
+- **Reusing one gas coin concurrently.** Leads to equivocation and a coin locked until the next epoch. Operate a pool.
+- **Reaching for deprecated v1 names** (`TransactionBlock`, `signTransactionBlock`). Use `Transaction` and `signTransaction`.
+- **Submitting only through the sponsor.** A malicious sponsor could withhold the transaction; the user can submit the dual-signed bytes directly to a full node.

--- a/sui-sponsored-transactions/enoki-gas-station.md
+++ b/sui-sponsored-transactions/enoki-gas-station.md
@@ -1,0 +1,95 @@
+# Managed Sponsorship with Enoki
+
+Sourced from [docs.enoki.mystenlabs.com/ts-sdk/sponsored-transactions](https://docs.enoki.mystenlabs.com/ts-sdk/sponsored-transactions) and the [`@mysten/enoki` source](https://github.com/MystenLabs/ts-sdks/tree/main/packages/enoki). Enoki is a managed gas station built on the same native mechanism in `native-flow.md` — it runs the gas-coin pool and signs as sponsor for you.
+
+> Choose Enoki when you don't want to operate a gas station (coin pool, equivocation handling, sponsor key management). Choose the native flow when you need full control or want to avoid the managed dependency. The two are interchangeable at the protocol level — both produce a dual-signed sponsored transaction.
+
+## Setup (backend)
+
+The **private/secret** Enoki API key lives **only on the server** — it authorizes sponsorship.
+
+```typescript
+import { EnokiClient } from '@mysten/enoki';
+
+const enoki = new EnokiClient({
+  apiKey: process.env.ENOKI_PRIVATE_API_KEY!, // backend only
+});
+```
+
+## Build → sponsor → sign → execute
+
+**1. Client builds transaction-kind bytes** (no gas data):
+
+```typescript
+const transactionKindBytes = await tx.build({
+  client: suiClient,
+  onlyTransactionKind: true,
+});
+// send transactionKindBytes (+ sender) to the backend
+```
+
+**2. Backend creates the sponsored transaction.** Pass **either** a `jwt` **or** a `sender` (+ optional allowlists) — verified input type:
+
+```typescript
+type CreateSponsoredTransactionApiInput = {
+  network?: EnokiNetwork;          // 'testnet' | 'mainnet'
+  transactionKindBytes: string;
+} & (
+  | { jwt: string; sender?: never; allowedAddresses?: never; allowedMoveCallTargets?: never }
+  | { sender: string; allowedAddresses?: string[]; allowedMoveCallTargets?: string[]; jwt?: never }
+);
+```
+
+```typescript
+const sponsored = await enoki.createSponsoredTransaction({
+  network: 'mainnet',
+  sender: '0xUSER_ADDRESS',
+  transactionKindBytes,
+  allowedMoveCallTargets: ['0xPKG::module::function'], // scope what you pay for
+  // allowedAddresses: ['0x...'],
+});
+// sponsored exposes `bytes` to sign and a `digest` to execute with
+```
+
+**3. Sign** the returned `bytes` with the sender's key (their wallet / zkLogin signature) → `signature`.
+
+**4. Backend executes** — verified input type:
+
+```typescript
+interface ExecuteSponsoredTransactionApiInput {
+  digest: string;
+  signature: string;
+}
+```
+
+```typescript
+await enoki.executeSponsoredTransaction({
+  digest: sponsored.digest,
+  signature,
+});
+```
+
+> The `{ bytes, digest }` return shape of `createSponsoredTransaction` matches the documented usage but was not quoted verbatim from the type source — verify against installed SDK types if exactness matters.
+
+## `jwt` vs `sender` variant
+
+- **`jwt`** — identify the user by their zkLogin JWT; Enoki resolves the sender. Use when the backend has the user's JWT (zkLogin apps).
+- **`sender` + allowlists** — identify the user by address and explicitly scope sponsorship.
+
+The two are mutually exclusive (enforced by the type union).
+
+## Security rules
+
+- **Private key is backend-only.** Never ship it to the browser. (The frontend public key is only for registering Enoki wallets — see the `zklogin-enoki` skill.)
+- **Always scope sponsorship** with `allowedMoveCallTargets` (and optionally `allowedAddresses`) so the gas station only pays for your app's intended calls. An unscoped sponsor can be drained.
+- **Build with `onlyTransactionKind: true`** — pass `transactionKindBytes`, not a fully-built transaction; Enoki supplies the gas.
+
+## Enoki vs self-hosted gas station
+
+| Factor | Self-hosted (native) | Enoki |
+|---|---|---|
+| Gas-coin pool / equivocation handling | You operate it (see `security.md`) | Managed |
+| Sponsor key management | You hold the key | Managed (private API key) |
+| Scoping | Validate kind server-side yourself | `allowedMoveCallTargets` / `allowedAddresses` |
+| Networks | any | mainnet / testnet |
+| Control | Maximum | Bounded by Enoki |

--- a/sui-sponsored-transactions/evals/evals.json
+++ b/sui-sponsored-transactions/evals/evals.json
@@ -1,0 +1,132 @@
+{
+  "skill_name": "sui-sponsored-transactions",
+  "source_constraint": "All expected outputs and expectations are grounded exclusively in official Mysten Labs documentation: docs.sui.io, sdk.mystenlabs.com, docs.enoki.mystenlabs.com, and the MystenLabs source. Graders should flag any claims sourced from third-party blogs or tutorials, and any SDK method names not confirmable against the official typedoc.",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "What is a sponsored transaction on Sui and how does it let a user transact without holding SUI?",
+      "expected_output": "An explanation of the native sponsor/GasData model with the three roles and the dual-signature requirement.",
+      "expectations": [
+        "Explains that a sponsor pays the gas for the user's transaction so the user needs no SUI",
+        "Names the three roles: user, gas station, and sponsor",
+        "States that the gas payment coins are owned by the sponsor (GasData.owner), not the user",
+        "Explains that both the user and the sponsor sign the same TransactionData bytes",
+        "Mentions that GasData contains payment, owner, price, and budget",
+        "Does not claim a single signature is sufficient for a sponsored transaction"
+      ],
+      "sources": [
+        "https://docs.sui.io/concepts/transactions/sponsored-transactions"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Write the TypeScript to sponsor a user's transaction on Sui: the user builds it on the frontend and my backend pays the gas.",
+      "expected_output": "Code using @mysten/sui where the user builds onlyTransactionKind bytes, the sponsor reconstructs with Transaction.fromKind, sets gas owner/payment, both sign, and it executes with two signatures.",
+      "expectations": [
+        "User builds with tx.build({ client, onlyTransactionKind: true })",
+        "Sponsor reconstructs the transaction with Transaction.fromKind(kindBytes)",
+        "Calls setSender(userAddress) and setGasOwner(sponsorAddress)",
+        "Sets the sponsor's gas coins with setGasPayment(...)",
+        "Both the user keypair and sponsor keypair sign the same built bytes via signTransaction",
+        "Executes with an array of both signatures (signatures: [userSig, sponsorSig] for gRPC, or signature: [...] for JSON-RPC)",
+        "Uses the @mysten/sui v2 Transaction API, not @mysten/sui.js TransactionBlock"
+      ],
+      "sources": [
+        "https://sdk.mystenlabs.com/sui/transactions/signing-and-execution",
+        "https://docs.sui.io/concepts/transactions/sponsored-transactions"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "In my sponsored transaction setup, whose address should own the gas coins — the user's or the sponsor's? I set the gas payment to the user's coins and it's not working.",
+      "expected_output": "A correction that the gas coins must be owned by the sponsor, set via setGasOwner to the sponsor address.",
+      "expectations": [
+        "States that the gas payment coins must be owned by the sponsor, not the user",
+        "Explains that GasData.owner is the sponsor and is set with setGasOwner(sponsorAddress)",
+        "Explains that all coins in GasData.payment must share the same owner (the sponsor)",
+        "Clarifies that if the user's coins pay gas, it is not actually sponsored",
+        "Does not suggest the user should provide the gas coins"
+      ],
+      "sources": [
+        "https://docs.sui.io/concepts/transactions/sponsored-transactions"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "My gas station works in testing but under load some sponsored transactions get rejected and a gas coin seems stuck until the next epoch. What's happening and how do I fix it?",
+      "expected_output": "Identification of the equivocation/locked-object risk from reusing a gas coin concurrently, with the gas-coin-pool mitigation.",
+      "expectations": [
+        "Explains that reusing the same gas object version across concurrent transactions causes equivocation",
+        "States that an equivocated owned object can be locked until the next epoch",
+        "Recommends maintaining a pool of distinct gas coins, one version per in-flight transaction",
+        "Mentions the MystenLabs Sui_Owned_Object_Pools library as a mitigation",
+        "Explains that conflicting transactions force a rebuild or re-sign rather than blind retry"
+      ],
+      "sources": [
+        "https://docs.sui.io/concepts/transactions/sponsored-transactions",
+        "https://github.com/MystenLabs/Sui_Owned_Object_Pools"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "I don't want to run my own gas station infrastructure. How can I sponsor transactions on Sui using Enoki instead?",
+      "expected_output": "The Enoki EnokiClient backend flow with createSponsoredTransaction / executeSponsoredTransaction, allowlists, and the private-key rule.",
+      "expectations": [
+        "Uses EnokiClient with the private API key on the backend only",
+        "Builds transactionKindBytes on the client with onlyTransactionKind: true",
+        "Calls createSponsoredTransaction with network, sender (or jwt), and transactionKindBytes",
+        "Scopes sponsorship with allowedMoveCallTargets (and optionally allowedAddresses)",
+        "Signs the returned bytes and calls executeSponsoredTransaction with digest and signature",
+        "States that the private key must never be exposed to the frontend",
+        "Notes that Enoki manages the gas-coin pool and sponsor signing for you"
+      ],
+      "sources": [
+        "https://docs.enoki.mystenlabs.com/ts-sdk/sponsored-transactions",
+        "https://github.com/MystenLabs/ts-sdks/tree/main/packages/enoki"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "What are the different sponsorship patterns on Sui — can the sponsor initiate, or only the user?",
+      "expected_output": "An explanation of the three patterns: user-proposed, sponsor-proposed, and wildcard GasData.",
+      "expectations": [
+        "Describes the user-proposed flow where the user builds the transaction kind and the sponsor adds gas",
+        "Describes the sponsor-proposed flow where the sponsor constructs and signs first, then the user signs",
+        "Describes the wildcard / GasData-object pattern where the sponsor provides gas for any transaction within budget",
+        "States that in all patterns the gas coins are owned by the sponsor and both parties sign",
+        "Does not claim only the user can initiate"
+      ],
+      "sources": [
+        "https://docs.sui.io/concepts/transactions/sponsored-transactions"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "I'm worried a sponsor or gas station could censor my users' transactions. Is that possible with sponsored transactions, and how do I mitigate it?",
+      "expected_output": "Acknowledgement of the censorship/griefing risk when submitting through the sponsor, with the direct-to-fullnode mitigation.",
+      "expectations": [
+        "Explains that submitting the dual-signed transaction through the sponsor lets the sponsor delay or withhold it",
+        "States that the user holds fully dual-signed bytes",
+        "Recommends the user submit the dual-signed transaction directly to a full node to bypass a misbehaving sponsor",
+        "Frames this as a censorship-resistance mitigation"
+      ],
+      "sources": [
+        "https://docs.sui.io/concepts/transactions/sponsored-transactions"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Should I build my Sui sponsored-transaction code with TransactionBlock and signTransactionBlock from @mysten/sui.js?",
+      "expected_output": "A correction pointing to the current @mysten/sui Transaction API instead of the deprecated v1 package.",
+      "expectations": [
+        "States that @mysten/sui.js with TransactionBlock / signTransactionBlock is the deprecated v1 API",
+        "Recommends the current @mysten/sui package with the Transaction class and signTransaction",
+        "Maps the sponsorship methods to the current API (setGasOwner, setGasPayment, Transaction.fromKind, onlyTransactionKind)",
+        "Does not generate new code using the deprecated v1 API"
+      ],
+      "sources": [
+        "https://sdk.mystenlabs.com/sui/transactions/signing-and-execution"
+      ]
+    }
+  ]
+}

--- a/sui-sponsored-transactions/native-flow.md
+++ b/sui-sponsored-transactions/native-flow.md
@@ -1,0 +1,98 @@
+# Native Sponsored Transactions (TypeScript SDK)
+
+Sourced from [docs.sui.io/concepts/transactions/sponsored-transactions](https://docs.sui.io/concepts/transactions/sponsored-transactions) and [sdk.mystenlabs.com/sui/transactions/signing-and-execution](https://sdk.mystenlabs.com/sui/transactions/signing-and-execution). Uses the current `@mysten/sui` (v2) `Transaction` API. Verify exact method names against the SDK typedoc if a lint flags them.
+
+## The model: three roles + GasData
+
+- **User** — wants to execute a transaction.
+- **Gas station** — provides the gas payment objects.
+- **Sponsor** — funds the gas station.
+
+A `TransactionData` carries the programmable transaction (the "kind") plus a `GasData`:
+
+```rust
+pub struct GasData {
+    pub payment: Vec<ObjectRef>, // gas coins — all owned by `owner`
+    pub owner: SuiAddress,       // the SPONSOR
+    pub price: u64,
+    pub budget: u64,
+}
+```
+
+The gas coins in `payment` are owned by the **sponsor** (`owner`), not the user. That is what makes the transaction sponsored.
+
+## The dual-signature rule
+
+Both the user and the sponsor sign the **same** `TransactionData` bytes (which include `GasData`). Execution submits **both** signatures. A single signature is not enough.
+
+## Flow: user builds kind, sponsor adds gas
+
+**1. User builds only the transaction kind** (no gas, no sender-owned gas coins):
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+// tx.moveCall({ ... }) etc.
+const kindBytes = await tx.build({ client, onlyTransactionKind: true });
+// send kindBytes (+ the user's address) to the sponsor backend
+```
+
+**2. Sponsor reconstructs and attaches gas data:**
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const sponsoredTx = Transaction.fromKind(kindBytes);
+sponsoredTx.setSender(userAddress);          // the user originates the tx
+sponsoredTx.setGasOwner(sponsorAddress);     // sponsor pays — GasData.owner
+sponsoredTx.setGasPayment(sponsorGasCoins);  // sponsor's gas coins (ObjectRef[])
+// optional overrides (otherwise auto from dry-run):
+// sponsoredTx.setGasBudget(budget);
+// sponsoredTx.setGasPrice(price);
+
+const bytes = await sponsoredTx.build({ client });
+```
+
+- `Transaction.fromKind(kindBytes)` — reconstructs a `Transaction` from kind bytes so gas data can be added.
+- `setSender(address)` — the transaction originator (the user).
+- `setGasOwner(address)` — sets the **sponsor** as `GasData.owner`. This is the line that makes it sponsored.
+- `setGasPayment(coins)` — the sponsor's gas coins, an array of `{ objectId, version, digest }`. An empty array `[]` pays from the sponsor address's gas balance instead of explicit coins.
+- `setGasBudget` / `setGasPrice` — override the auto (dry-run-derived) values when needed.
+
+**3. Both parties sign the same bytes:**
+
+```typescript
+const { signature: sponsorSignature } = await sponsorKeypair.signTransaction(bytes);
+// the user signs the SAME bytes (via their wallet/keypair):
+const { signature: userSignature } = await userKeypair.signTransaction(bytes);
+```
+
+`keypair.signTransaction(bytes)` returns `{ bytes, signature }`.
+
+**4. Execute with both signatures.** Two execution clients, different param names:
+
+```typescript
+// New gRPC client — `signatures` is a string[]:
+await grpcClient.executeTransaction({
+  transaction: bytes,
+  signatures: [userSignature, sponsorSignature],
+});
+
+// JSON-RPC SuiClient — `signature` also accepts an array for sponsored txns:
+await client.executeTransactionBlock({
+  transactionBlock: bytes,
+  signature: [userSignature, sponsorSignature], // order can be either
+  options: { showEffects: true },
+});
+```
+
+The protocol's `tx_signatures` list must contain both signatures, in either order.
+
+## The three sponsorship patterns
+
+1. **User-proposed (`GasLessTransactionData`)** — user builds the kind (no gas) → sends to sponsor → sponsor adds gas and signs → returns to user → user signs → submits. (The flow shown above.)
+2. **Sponsor-proposed** — sponsor constructs and signs the full `TransactionData` (tx + gas) → sends to user → user signs → submits.
+3. **Wildcard / `GasData` object** — sponsor hands the user a `GasData` object; the user can construct and sign any valid transaction within the budget (a blanket gas station).
+
+> Reminder: the gas coins must always be owned by the sponsor (`GasData.owner`), regardless of pattern. See `security.md` for the equivocation/locking risk that shapes how a production gas station manages those coins.

--- a/sui-sponsored-transactions/security.md
+++ b/sui-sponsored-transactions/security.md
@@ -1,0 +1,42 @@
+# Equivocation, Locking, and Griefing
+
+Sourced from [docs.sui.io/concepts/transactions/sponsored-transactions](https://docs.sui.io/concepts/transactions/sponsored-transactions) and [MystenLabs/Sui_Owned_Object_Pools](https://github.com/MystenLabs/Sui_Owned_Object_Pools). These are the risks a production gas station must handle.
+
+## Equivocation → gas object locked until next epoch
+
+A sponsor's gas coin is an **owned object**. If the same gas object version is used in two competing (equivocating) transactions, validators can split their reservations on it, and the object becomes **locked until the next epoch** — unusable for sponsorship until then.
+
+The docs call this out directly:
+- "If another inflight transaction already uses one of those same object versions, the sponsored transaction can be rejected and must be rebuilt or re-signed."
+- "If competing transactions split validator reservations, the object can be equivocated until the next epoch."
+
+**Mitigation: a gas-coin pool.** Do not reuse one gas coin version across concurrent sponsored transactions. Maintain a pool of distinct gas coins and hand out a different one per in-flight transaction. Mysten provides [`Sui_Owned_Object_Pools`](https://github.com/MystenLabs/Sui_Owned_Object_Pools) — "tools for managing multiple concurrent transactions … helping to avoid object equivocation and locking." A single-coin gas station will lock up under concurrency.
+
+## Concurrent object use / re-signing
+
+Because the sponsored transaction is signed over specific object versions (including the gas coins), an inflight transaction touching the same versions forces the sponsored transaction to be **rebuilt or re-signed**. Design the sponsor backend to rebuild on conflict rather than retrying the identical bytes.
+
+## Censorship / griefing
+
+If the user submits the dual-signed transaction **through the sponsor / gas station** rather than directly to a full node, the sponsor "might delay or withhold the transaction from the network."
+
+**Mitigation:** the user holds fully dual-signed bytes and can **submit them directly to a full node**, bypassing a misbehaving sponsor. Where censorship resistance matters, return the signed bytes to the client and let it submit.
+
+## Gas-coin requirements
+
+- The sponsor must hold SUI gas coins owned by the **sponsor address** (= `GasData.owner`).
+- `GasData.payment` is a `Vec<ObjectRef>` — multiple coins allowed, but **all must share the same owner** (the sponsor).
+- `GasData.price` (reference gas price) and `GasData.budget` complete the struct; the SDK auto-fills them via dry-run unless overridden with `setGasPrice` / `setGasBudget`.
+- A gas station typically **reserves** coins from its pool per request so concurrent transactions never share a coin version.
+
+## Scoping (when using a sponsor backend / Enoki)
+
+Independent of the locking risk, scope **what** you sponsor so the gas station can't be drained by paying for arbitrary calls. With Enoki, set `allowedMoveCallTargets` (and optionally `allowedAddresses`) — see `enoki-gas-station.md`. With a self-hosted gas station, validate the transaction kind server-side before attaching gas.
+
+## Checklist for a production gas station
+
+- [ ] Gas coins owned by the sponsor address; `setGasOwner(sponsorAddress)`.
+- [ ] A pool of distinct gas coins; one coin version per in-flight transaction.
+- [ ] Rebuild/re-sign on object-version conflict rather than blind retry.
+- [ ] Server-side validation of the transaction kind before sponsoring (allowlist).
+- [ ] Return dual-signed bytes to the client so it can submit directly if needed.

--- a/zklogin-enoki/SKILL.md
+++ b/zklogin-enoki/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: zklogin-enoki
+description: >
+  Passwordless (Web2-style) authentication and gasless transactions for Sui apps
+  using zkLogin and Enoki. Use this skill whenever the user wants social login
+  (Google / Facebook / Twitch / Apple sign-in) that produces a self-custodial Sui
+  address, wants users to onboard without a wallet extension or seed phrase, wants
+  to sponsor gas so users transact without holding SUI ("gasless", "sponsored
+  transactions", "gas station"), is integrating `@mysten/enoki`, registering Enoki
+  wallets into dApp Kit (`registerEnokiWallets`), building a backend sponsor with
+  `EnokiClient`, or implementing zkLogin manually (ephemeral key, nonce, JWT, ZK
+  proof, user salt, address derivation). Also use when choosing between Enoki and
+  a manual zkLogin integration, or debugging OAuth redirect / allowed-origin /
+  network-mismatch / salt-management issues.
+---
+
+# Sui zkLogin + Enoki
+
+> **MCP tool:** When available in your environment, also query the Sui documentation MCP server (`https://sui.mcp.kapa.ai`) for up-to-date answers. Use it for verification and for details not covered by these reference files.
+
+> **Source constraint:** All information in this skill is sourced exclusively from official Mysten Labs documentation: [docs.enoki.mystenlabs.com](https://docs.enoki.mystenlabs.com), [docs.sui.io](https://docs.sui.io), and the [MystenLabs/ts-sdks](https://github.com/MystenLabs/ts-sdks) source. When extending or updating this skill, only pull from these sources. Do not use third-party blogs, tutorials, or unofficial documentation, and do not extrapolate API surface from other SDKs.
+
+zkLogin lets a user authenticate with a normal OAuth provider (Google, Facebook, Twitch, Apple, …) and control a **self-custodial Sui address** — no seed phrase, no browser extension, and the OAuth identity is never publicly linked to the on-chain address. Enoki is Mysten Labs' managed service on top of zkLogin: it runs the ZK prover, manages the user salt, and provides **sponsored (gasless) transactions** so users never need SUI for gas.
+
+This skill prevents the most common AI-coding mistakes in this area:
+
+1. **Teaching a deprecated Enoki API.** The current flow registers Enoki accounts as standard wallets into **dApp Kit** via `registerEnokiWallets()` and drives everything through normal dApp Kit hooks. The older `EnokiFlow` / `useEnokiFlow` / `useZkLogin` / `EnokiFlowProvider` surface no longer appears in current docs — do not generate it.
+2. **Leaking the private Enoki API key into the frontend.** The frontend uses the **public** key; the **private/secret** key is backend-only (it can authorize sponsorship).
+3. **Hand-rolling zkLogin salt management when Enoki would do it.** Manual salt management is the single biggest footgun — lost salts permanently lock users out of their addresses. Enoki removes this entirely.
+4. **Confusing "signed through Enoki" with "sponsored".** Signing via an Enoki wallet does not by itself pay gas; sponsorship is a separate flow with its own allowlist.
+
+This skill routes to focused reference files. Load only the ones relevant to the current task.
+
+---
+
+## Reference files
+
+### concepts — How zkLogin Works
+**Path:** `concepts.md`
+**Load when:** explaining what zkLogin is, how a Sui address is derived from an OAuth login, the roles of the ephemeral key pair, nonce, JWT, ZK proof, user salt, and `maxEpoch` session expiry, what Enoki manages vs what the protocol requires, or which OAuth providers are supported.
+**Covers:** the zkLogin trust model, the flow elements (provider, ephemeral key, nonce, JWT, ZK proof, salt, address derivation), address-derivation inputs, session expiry, supported providers per network, and what Enoki abstracts away.
+
+### frontend-auth — Social Login with Enoki + dApp Kit
+**Path:** `frontend-auth.md`
+**Load when:** adding social/passwordless login to a React app, calling `registerEnokiWallets`, wiring the OAuth sign-in flow through dApp Kit hooks, reading the user's zkLogin address, or handling network changes / re-registration.
+**Covers:** install, `registerEnokiWallets` arguments and the `useEffect` re-registration pattern, filtering Enoki wallets with `isEnokiWallet`, connecting per-provider via `useConnectWallet`, reading the account with `useCurrentAccount`, the auto pop-up OAuth flow, and Enoki Portal configuration (origins/redirects, providers, API keys).
+
+### sponsored-transactions — Gasless / Sponsored Transactions
+**Path:** `sponsored-transactions.md`
+**Load when:** making transactions free for users, sponsoring gas, building a backend `EnokiClient` sponsor, or scoping what the sponsor will pay for.
+**Covers:** the frontend `signAndExecuteTransaction` path through an Enoki wallet, the backend build → sponsor → sign → execute flow with `createSponsoredTransaction` / `executeSponsoredTransaction`, the `jwt` vs `sender` input variants, `allowedMoveCallTargets` / `allowedAddresses` allowlists, `onlyTransactionKind` byte building, and the public-vs-private-key security rule.
+
+### manual-zklogin — zkLogin Without Enoki
+**Path:** `manual-zklogin.md`
+**Load when:** integrating zkLogin directly with `@mysten/sui` (no Enoki), running your own prover/salt service, or deciding between Enoki and a manual build.
+**Covers:** the manual flow (`Ed25519Keypair`, `generateRandomness`, `generateNonce`, `jwtToAddress`, `getExtendedEphemeralPublicKey`, `genAddressSeed`, `getZkLoginSignature`), the salt-management responsibilities and footguns, and an Enoki-vs-manual decision guide.
+
+---
+
+## Routing guide
+
+| Task | Load |
+|------|------|
+| What is zkLogin / how does it work | concepts |
+| How is the Sui address derived from a login | concepts |
+| Ephemeral key, nonce, JWT, proof, salt, maxEpoch | concepts |
+| Which OAuth providers are supported | concepts |
+| Add Google/social login to a React app | frontend-auth |
+| `registerEnokiWallets` arguments | frontend-auth |
+| Read the logged-in user's Sui address | frontend-auth |
+| OAuth redirect / allowed origins not working | frontend-auth |
+| Re-register on network change | frontend-auth |
+| Make transactions free for users / gasless | sponsored-transactions |
+| Backend sponsor with `EnokiClient` | sponsored-transactions |
+| Scope what the sponsor pays for | sponsored-transactions |
+| Where does the private API key go | sponsored-transactions |
+| zkLogin without Enoki / own prover | manual-zklogin |
+| User salt management | manual-zklogin |
+| Enoki vs manual zkLogin | manual-zklogin + concepts |
+| Full integration / code review | **all reference files** |
+
+---
+
+## Key concepts
+
+- **zkLogin** is a Sui protocol primitive. **Enoki** is a managed service that implements zkLogin for you (prover + salt) and adds sponsored transactions. You can use zkLogin without Enoki, but then you own the prover and salt infrastructure.
+- The user's **Sui address is derived from `sub` + `iss` + `aud` + `user_salt`** — not from a private key. It is stable across sessions and cannot be converted to/from a normal keypair address.
+- An **ephemeral key pair** signs transactions for the duration of a session, bounded by **`maxEpoch`**. Losing the ephemeral key only ends the session; funds are safe because the address is derived from the OAuth identity + salt.
+- The **current Enoki frontend flow** registers Enoki accounts as **dApp Kit wallets** (`registerEnokiWallets`) and uses standard dApp Kit hooks (`useWallets`, `useConnectWallet`, `useCurrentAccount`, `useSignAndExecuteTransaction`). There is no separate Enoki provider component in the current API.
+- **Two API keys:** a **public** key for the frontend (`registerEnokiWallets`) and a **private** key for the backend (`EnokiClient`). Configure providers, allowed origins, and keys in the **Enoki Portal** (`https://portal.enoki.mystenlabs.com`).
+- **Sponsorship is its own flow.** It is configured/authorized server-side and scoped with allowlists; it is not implied by signing through an Enoki wallet.
+
+## Rules
+
+- Never put the **private/secret** Enoki API key in frontend code or any bundle shipped to the browser. Frontend gets the **public** key only.
+- Use the current `registerEnokiWallets` + dApp Kit hook flow. Do not generate `EnokiFlow`, `useEnokiFlow`, `useZkLogin`, `useAuthCallback`, or `EnokiFlowProvider` — they are absent from current docs.
+- Enoki wallets are bound to a single network. Re-register (`registerEnokiWallets`) whenever the dApp Kit network changes, and call the returned `unregister` on cleanup.
+- Always scope sponsorship with `allowedMoveCallTargets` (and optionally `allowedAddresses`) so the sponsor only pays for intended calls.
+- Build the sponsored transaction bytes on the client with `tx.build({ client, onlyTransactionKind: true })` — pass `transactionKindBytes`, not a fully-built transaction with gas data.
+- When using Enoki, do **not** also hand-roll user-salt storage — Enoki manages the salt. Only manage salt yourself in a fully manual zkLogin integration.
+- Enoki wallet signing auto-approves (no confirmation pop-up). Add your own confirmation/cancel UI before executing.
+- Configure matching redirect URLs / allowed origins in **both** the Enoki Portal and each OAuth provider's console.
+
+## Common mistakes
+
+- **Shipping the private API key to the browser.** It can authorize gas sponsorship — treat it like a server secret. Frontend uses the public key.
+- **Generating the legacy `EnokiFlow` API.** The current flow is `registerEnokiWallets` + dApp Kit hooks; the old flow does not appear in current docs.
+- **Assuming signing through Enoki makes a transaction gasless.** Sponsorship is a separate, server-authorized flow with an allowlist.
+- **Forgetting to re-register on network change.** Enoki wallets are network-bound; a stale registration leaves accounts non-functional after switching networks.
+- **Manually managing user salt while also using Enoki.** Enoki owns the salt; doing both leads to mismatched/lost addresses.
+- **Omitting `allowedMoveCallTargets`.** An unscoped sponsor can be drained by paying for arbitrary move calls.
+- **Mismatched redirect URLs.** If the Portal/provider redirect config doesn't match the app origin, the OAuth flow fails silently.

--- a/zklogin-enoki/concepts.md
+++ b/zklogin-enoki/concepts.md
@@ -1,0 +1,57 @@
+# How zkLogin Works
+
+Sourced from [docs.sui.io/concepts/cryptography/zklogin](https://docs.sui.io/concepts/cryptography/zklogin) and [docs.enoki.mystenlabs.com](https://docs.enoki.mystenlabs.com). If unsure about any detail, fetch from these pages rather than guessing.
+
+## What zkLogin is
+
+zkLogin is a Sui protocol primitive that lets a user send transactions from a Sui address using an OAuth/OIDC credential (a normal web login), **without a seed phrase or private key the user has to manage, and without publicly linking the OAuth identity to the on-chain address.**
+
+The key property: the on-chain address is controlled by "whoever can log into this OAuth account (plus a salt)", proven in zero knowledge, so observers cannot tell which Google/Facebook/Twitch account owns which Sui address.
+
+## The elements of the flow
+
+| Element | Role |
+|---|---|
+| **OAuth/OIDC provider** | Authenticates the user and issues a JWT (`id_token`). OpenID Connect over OAuth 2.0. |
+| **Ephemeral key pair** `(eph_sk, eph_pk)` | Generated per session. Signs transactions while the session is valid. Losing it only ends the session — funds stay safe. |
+| **Nonce** | Embeds a hash of the ephemeral public key + expiry (`maxEpoch`) + randomness. Sent in the OAuth request so the returned JWT is bound to this session. |
+| **JWT** | Issued by the provider. Key claims: `iss` (issuer/provider), `aud` (app/client ID), `sub` (stable per-user ID). |
+| **ZK proof** | A Groth16 zkSNARK proving the nonce was derived correctly, the provider's RSA signature on the JWT is valid, and the address derivation is correct — all **without revealing** the OAuth data on-chain. |
+| **User salt** | A secret value that **unlinks** the OAuth identifier from the on-chain address. Required for both proof generation and address derivation. |
+
+## Address derivation
+
+The Sui address is derived from:
+
+```
+address = f(sub, iss, aud, user_salt)
+```
+
+Consequences:
+- The address is **stable** across logins as long as `sub`, `iss`, `aud`, and `user_salt` stay the same.
+- It is **not** derived from a private key and cannot be converted to/from a normal keypair address.
+- Changing the OAuth client ID (`aud`) or the salt changes the address — i.e. the user loses access to the old one. (See `manual-zklogin.md` for the salt footguns.)
+
+## Session expiry (`maxEpoch`)
+
+A login session can only authorize transactions up to `maxEpoch` (a future Sui epoch chosen at login time, e.g. `currentEpoch + N`). When it expires, the user re-authenticates with the provider; the **address stays the same**, only the ephemeral session is renewed.
+
+## Supported OAuth providers
+
+Per docs.sui.io, supported on mainnet/testnet/devnet: **Google, Facebook, Twitch, Apple, AWS (Tenant), Karrier One, Credenza3**. Devnet-only: **Slack, Kakao, Microsoft**.
+
+Enoki's frontend SDK exposes a first-class provider map for **Google, Facebook, and Twitch** (see `frontend-auth.md`). For providers outside that map, verify current Enoki support in the Enoki Portal / docs before promising it.
+
+## What Enoki manages for you
+
+zkLogin by itself requires you to run a ZK proving service and manage user salts. **Enoki** is Mysten Labs' managed service that handles both, and adds sponsored transactions:
+
+| Responsibility | Manual zkLogin | With Enoki |
+|---|---|---|
+| ZK prover | You run/host it | Enoki runs it |
+| User salt storage & derivation | **You own it** (high-risk) | Enoki manages it |
+| Ephemeral key / nonce / session | You build it | Enoki SDK handles it via dApp Kit |
+| Sponsored (gasless) transactions | Build your own gas station | Built in (`EnokiClient`) |
+| Networks | mainnet / testnet / devnet | mainnet / testnet |
+
+Rule of thumb: **use Enoki unless you have a specific reason to self-host the prover and salt.** The main reason teams regret a manual build is salt management — losing salts permanently locks users out of their addresses.

--- a/zklogin-enoki/evals/evals.json
+++ b/zklogin-enoki/evals/evals.json
@@ -1,0 +1,169 @@
+{
+  "skill_name": "zklogin-enoki",
+  "source_constraint": "All expected outputs and expectations are grounded exclusively in official Mysten Labs documentation: docs.enoki.mystenlabs.com, docs.sui.io, and the MystenLabs/ts-sdks source. Graders should flag any claims sourced from third-party blogs, tutorials, or unofficial documentation, and any API surface extrapolated from other SDKs.",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "What is zkLogin on Sui and how does a user end up with a Sui address just by signing in with Google?",
+      "expected_output": "An explanation of zkLogin as a Sui primitive that derives a self-custodial address from an OAuth login, covering the JWT, ephemeral key, nonce, ZK proof, salt, and address derivation, without claiming the OAuth identity is publicly linked on-chain.",
+      "expectations": [
+        "Explains that zkLogin lets a user control a self-custodial Sui address using an OAuth/OIDC credential, with no seed phrase",
+        "States that the OAuth identity is NOT publicly linked to the on-chain address",
+        "Describes the ephemeral key pair that signs transactions during a session",
+        "Mentions the nonce binds the ephemeral public key, maxEpoch, and randomness, and is sent to the provider",
+        "Explains the JWT and its claims (iss, aud, sub)",
+        "States that the address is derived from sub + iss + aud + user_salt (not from a private key)",
+        "Mentions a zero-knowledge proof is used so OAuth data is not revealed on-chain",
+        "Does not claim the zkLogin address can be converted to/from a normal keypair address"
+      ],
+      "sources": [
+        "https://docs.sui.io/concepts/cryptography/zklogin"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I'm building a React app on Sui and want users to log in with Google and get a wallet automatically. What's the recommended way to do this with Enoki?",
+      "expected_output": "A walkthrough of the current Enoki flow: registerEnokiWallets into dApp Kit with the public API key, then sign in via dApp Kit hooks, reading the address from useCurrentAccount.",
+      "expectations": [
+        "Recommends installing @mysten/enoki",
+        "Uses registerEnokiWallets with client, network, apiKey (public key), and a providers map containing google",
+        "Drives sign-in through dApp Kit hooks (useWallets, useConnectWallet, useCurrentAccount)",
+        "Uses isEnokiWallet to filter the wallet list and connect via connect({ wallet })",
+        "States that currentAccount.address is the user's zkLogin Sui address",
+        "Does NOT use the legacy EnokiFlow, useEnokiFlow, useZkLogin, useAuthCallback, or EnokiFlowProvider APIs",
+        "Notes that the public API key (not the private key) is used in the frontend"
+      ],
+      "sources": [
+        "https://docs.enoki.mystenlabs.com/ts-sdk/register",
+        "https://docs.enoki.mystenlabs.com/ts-sdk/sign-in"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Write the Enoki auth setup for my Sui dApp. Here's my Enoki config — public key pk_xxx, private key sk_xxx, Google client id abc. Wire up login.",
+      "expected_output": "Frontend code that uses ONLY the public key in registerEnokiWallets and never references the private key, with a note that the private key is backend-only.",
+      "expectations": [
+        "Uses the public key (pk_xxx) in registerEnokiWallets",
+        "Does NOT place the private key (sk_xxx) anywhere in frontend code",
+        "Explicitly warns that the private/secret key must stay on the backend only",
+        "Explains that the private key can authorize gas sponsorship and must be treated as a server secret",
+        "Uses the current registerEnokiWallets + dApp Kit hook flow"
+      ],
+      "sources": [
+        "https://docs.enoki.mystenlabs.com/ts-sdk/register",
+        "https://docs.enoki.mystenlabs.com/http-api"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "I want my Sui users to never pay gas. How do I make transactions sponsored/gasless with Enoki?",
+      "expected_output": "An explanation of the backend EnokiClient sponsorship flow: build transactionKindBytes on the client, createSponsoredTransaction on the backend with allowlists, sign, then executeSponsoredTransaction.",
+      "expectations": [
+        "Explains that sponsorship is authorized on the backend with the private API key (EnokiClient)",
+        "Builds the transaction on the client with tx.build({ client, onlyTransactionKind: true }) to get transactionKindBytes",
+        "Uses createSponsoredTransaction with network, sender (or jwt), and transactionKindBytes",
+        "Scopes sponsorship with allowedMoveCallTargets (and optionally allowedAddresses)",
+        "Signs the returned bytes and calls executeSponsoredTransaction with digest and signature",
+        "States that the private key must not be exposed to the frontend",
+        "Does not claim that simply signing through an Enoki wallet makes a transaction gasless"
+      ],
+      "sources": [
+        "https://docs.enoki.mystenlabs.com/ts-sdk/sponsored-transactions",
+        "https://github.com/MystenLabs/ts-sdks/tree/main/packages/enoki"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "If I sign a transaction through the connected Enoki wallet on the frontend, does that automatically mean the user doesn't pay gas?",
+      "expected_output": "A correction clarifying that signing through Enoki does not by itself sponsor gas; sponsorship is a separate backend-authorized flow.",
+      "expectations": [
+        "States clearly that signing through an Enoki wallet does NOT by itself make a transaction gasless",
+        "Explains that sponsorship is a separate flow authorized on the backend with the private key",
+        "Mentions the sponsored flow uses createSponsoredTransaction / executeSponsoredTransaction with an allowlist",
+        "Notes that Enoki wallet signing auto-approves (no confirmation prompt), so the app should add its own confirmation UI"
+      ],
+      "sources": [
+        "https://docs.enoki.mystenlabs.com/ts-sdk/transactions",
+        "https://docs.enoki.mystenlabs.com/ts-sdk/sponsored-transactions"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "My Enoki login works on testnet but after I let users switch to mainnet the wallet stops working. What's wrong?",
+      "expected_output": "Identification that Enoki wallets are network-bound and must be re-registered when the network changes, with the useEffect + unregister pattern.",
+      "expectations": [
+        "Explains that Enoki wallets are bound to a single network",
+        "States that registerEnokiWallets must be called again when the network changes",
+        "Recommends tracking the network (e.g. via useSuiClientContext) and re-registering inside a useEffect",
+        "Mentions calling the returned unregister function for cleanup",
+        "Does not suggest that a single registration works across all networks"
+      ],
+      "sources": [
+        "https://docs.enoki.mystenlabs.com/ts-sdk/register"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Should I implement zkLogin myself with @mysten/sui or use Enoki? I'm worried about managing user salts.",
+      "expected_output": "A recommendation that leans toward Enoki because it manages the salt and prover, with an honest comparison and the salt footguns called out.",
+      "expectations": [
+        "Explains that manual zkLogin requires you to run a ZK prover and manage user salts",
+        "States that Enoki manages both the salt and the prover",
+        "Warns that losing user salts permanently locks users out of their addresses",
+        "Warns that changing the OAuth client id (aud) or salt changes/loses the derived address",
+        "Recommends Enoki unless there's a specific reason to self-host (e.g. devnet, full control)",
+        "Mentions that the manual flow uses functions like generateNonce, jwtToAddress, genAddressSeed, and getZkLoginSignature from @mysten/sui"
+      ],
+      "sources": [
+        "https://docs.sui.io/guides/developer/cryptography/zklogin-integration",
+        "https://docs.enoki.mystenlabs.com"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "How does a zkLogin session expire, and what happens to the user's address when it does?",
+      "expected_output": "An explanation of maxEpoch-bounded sessions and that the address is stable across re-authentication.",
+      "expectations": [
+        "Explains that a session is bounded by maxEpoch (a future epoch chosen at login)",
+        "States that when the session expires the user re-authenticates with the provider",
+        "States that the user's Sui address stays the same across re-authentication",
+        "Explains that the ephemeral key only authorizes transactions while the session is valid",
+        "Notes that losing the ephemeral key only ends the session and does not lose funds"
+      ],
+      "sources": [
+        "https://docs.sui.io/concepts/cryptography/zklogin"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Which OAuth providers can I use with zkLogin on Sui mainnet?",
+      "expected_output": "A list of supported providers grounded in the Sui docs, distinguishing mainnet/testnet support from devnet-only providers.",
+      "expectations": [
+        "Lists Google, Facebook, Twitch, and Apple among supported providers",
+        "Does not claim providers that are not in the official documentation",
+        "Distinguishes broadly-supported providers from devnet-only ones (e.g. Slack, Kakao, Microsoft) if it lists them",
+        "Notes that Enoki's frontend provider map exposes google, facebook, and twitch as first-class"
+      ],
+      "sources": [
+        "https://docs.sui.io/concepts/cryptography/zklogin",
+        "https://docs.enoki.mystenlabs.com/ts-sdk/register"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "I'm sponsoring transactions for my users with Enoki. How do I make sure the sponsor only pays for my app's contract calls and can't be drained?",
+      "expected_output": "Guidance to scope sponsorship with allowedMoveCallTargets (and allowedAddresses), keep the private key on the backend, and use the sender/allowlist input variant.",
+      "expectations": [
+        "Recommends setting allowedMoveCallTargets to the app's specific move call targets",
+        "Mentions allowedAddresses as an optional additional scope on the sender",
+        "Explains that an unscoped sponsor can be drained by paying for arbitrary move calls",
+        "States that the private API key must stay on the backend",
+        "Mentions that createSponsoredTransaction accepts a sender + allowlists variant (distinct from the jwt variant)"
+      ],
+      "sources": [
+        "https://docs.enoki.mystenlabs.com/ts-sdk/sponsored-transactions",
+        "https://github.com/MystenLabs/ts-sdks/tree/main/packages/enoki"
+      ]
+    }
+  ]
+}

--- a/zklogin-enoki/frontend-auth.md
+++ b/zklogin-enoki/frontend-auth.md
@@ -1,0 +1,130 @@
+# Social Login with Enoki + dApp Kit
+
+Sourced from [docs.enoki.mystenlabs.com/ts-sdk](https://docs.enoki.mystenlabs.com/ts-sdk), `/ts-sdk/register`, and `/ts-sdk/sign-in`. This is the **current** Enoki frontend flow. Do not generate the legacy `EnokiFlow` / `useEnokiFlow` / `useZkLogin` / `EnokiFlowProvider` API — it is absent from current docs.
+
+## Install
+
+```bash
+npm install @mysten/enoki
+```
+
+This assumes you already have **dApp Kit** set up (`@mysten/dapp-kit`): the app wrapped in `QueryClientProvider` → `SuiClientProvider` → `WalletProvider`. Enoki registers its accounts via the Wallet Standard, so they appear through `useWallets()` like any other wallet.
+
+## Step 1 — Register Enoki wallets into dApp Kit
+
+`registerEnokiWallets` registers a wallet per configured OAuth provider:
+
+```typescript
+import { registerEnokiWallets } from '@mysten/enoki';
+import { SuiClient, getFullnodeUrl } from '@mysten/sui/client';
+
+const suiClient = new SuiClient({ url: getFullnodeUrl('testnet') });
+
+const { unregister } = registerEnokiWallets({
+  client: suiClient,
+  network: 'testnet',
+  apiKey: 'YOUR_PUBLIC_ENOKI_API_KEY', // public key — safe for the frontend
+  providers: {
+    google:   { clientId: 'YOUR_GOOGLE_CLIENT_ID' },
+    facebook: { clientId: 'YOUR_FACEBOOK_CLIENT_ID' },
+    twitch:   { clientId: 'YOUR_TWITCH_CLIENT_ID' },
+  },
+});
+```
+
+Arguments:
+- `client` — a `SuiClient` pointed at the target network's fullnode.
+- `network` — `'testnet'` | `'mainnet'` (type `EnokiNetwork`).
+- `apiKey` — your **public** Enoki API key. Never the private key.
+- `providers` — map keyed by `google` / `facebook` / `twitch`, each `{ clientId, redirectUrl? }`. `clientId` comes from that provider's OAuth console. `redirectUrl` defaults to the current page if omitted.
+- Returns `{ unregister }`.
+
+### Re-register on network change
+
+Enoki wallets are bound to one network. Track the active network and re-register when it changes, cleaning up with `unregister`:
+
+```typescript
+import { useEffect } from 'react';
+import { useSuiClientContext } from '@mysten/dapp-kit';
+import { isEnokiNetwork, registerEnokiWallets } from '@mysten/enoki';
+
+function RegisterEnokiWallets() {
+  const { client, network } = useSuiClientContext();
+
+  useEffect(() => {
+    if (!isEnokiNetwork(network)) return;
+    const { unregister } = registerEnokiWallets({
+      client,
+      network,
+      apiKey: 'YOUR_PUBLIC_ENOKI_API_KEY',
+      providers: {
+        google: { clientId: 'YOUR_GOOGLE_CLIENT_ID' },
+      },
+    });
+    return unregister; // cleanup on network change / unmount
+  }, [client, network]);
+
+  return null;
+}
+```
+
+> `isEnokiNetwork` guards against registering on an unsupported network. Verify the exact guard name against the installed SDK types if your linter flags it.
+
+## Step 2 — Render sign-in buttons
+
+Filter the dApp Kit wallet list down to Enoki wallets and key them by provider:
+
+```typescript
+import { useConnectWallet, useCurrentAccount, useWallets } from '@mysten/dapp-kit';
+import { isEnokiWallet, type EnokiWallet, type AuthProvider } from '@mysten/enoki';
+
+function SignIn() {
+  const currentAccount = useCurrentAccount();
+  const { connect } = useConnectWallet();
+
+  const wallets = useWallets().filter(isEnokiWallet);
+  const walletsByProvider = wallets.reduce(
+    (map, wallet) => map.set(wallet.provider, wallet),
+    new Map<AuthProvider, EnokiWallet>(),
+  );
+
+  const googleWallet = walletsByProvider.get('google');
+
+  if (currentAccount) {
+    return <div>Signed in as {currentAccount.address}</div>;
+  }
+
+  return (
+    <button
+      disabled={!googleWallet}
+      onClick={() => googleWallet && connect({ wallet: googleWallet })}
+    >
+      Sign in with Google
+    </button>
+  );
+}
+```
+
+- `isEnokiWallet` — type guard to keep only Enoki wallets.
+- `AuthProvider` — the provider union **type** (`'google' | 'facebook' | 'twitch' | …`). It is a TypeScript type, **not** a React provider component.
+- `EnokiWallet` — wallet type; has a `.provider` field.
+- `connect({ wallet })` triggers the OAuth flow. The Enoki SDK **handles the OAuth flow automatically in a pop-up window** — there is no separate callback handler to wire up in the current API.
+- After a successful connect, `useCurrentAccount()` returns the account; **`currentAccount.address` is the user's zkLogin Sui address.**
+
+> The current docs document the auto pop-up flow. A redirect-mode (non-popup) callback handler is not documented on the current pages — don't assert a specific handler name for it.
+
+## Step 3 — Enoki Portal configuration
+
+In the **Enoki Portal** (`https://portal.enoki.mystenlabs.com`):
+- Create API keys (public for frontend, private for backend).
+- Enable each OAuth provider and paste its `clientId`.
+- Configure **allowed origins / redirect URLs** to match your app.
+
+In **each OAuth provider's console** (Google Cloud, Meta, Twitch): register the same redirect URLs / authorized origins. Mismatched redirect config is the most common reason the login flow fails silently.
+
+## Gotchas
+
+- **Public vs private key:** only the **public** key goes in `registerEnokiWallets`. The private key is backend-only (see `sponsored-transactions.md`).
+- **Network binding:** re-register on network change or the account won't work.
+- **Redirect/origin mismatch:** must match in both the Portal and the provider console.
+- **Auto-approve signing:** Enoki wallet signing skips the confirmation prompt — add your own confirmation UI before executing transactions.

--- a/zklogin-enoki/manual-zklogin.md
+++ b/zklogin-enoki/manual-zklogin.md
@@ -1,0 +1,95 @@
+# zkLogin Without Enoki
+
+Sourced from [docs.sui.io/guides/developer/cryptography/zklogin-integration](https://docs.sui.io/guides/developer/cryptography/zklogin-integration). Functions are from `@mysten/sui`. Use this only when you have a specific reason **not** to use Enoki — you will own a ZK prover and (critically) user-salt management.
+
+> **Default recommendation:** use Enoki (`frontend-auth.md`). Enoki removes salt management and the prover, which are the two hardest, highest-risk parts of a manual build.
+
+## The manual flow
+
+**1. Ephemeral key pair + max epoch**
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+
+const ephemeralKeyPair = new Ed25519Keypair();
+const maxEpoch = currentEpoch + 2; // session valid until this epoch
+```
+
+**2. Randomness + nonce**
+
+```typescript
+import { generateNonce, generateRandomness } from '@mysten/sui/zklogin';
+
+const randomness = generateRandomness();
+const nonce = generateNonce(ephemeralKeyPair.getPublicKey(), maxEpoch, randomness);
+// put `nonce` in the OAuth authorization URL
+```
+
+**3. Get the JWT**
+
+Redirect to the provider with the nonce; on return, read the `id_token` (JWT) and decode it to a `JwtPayload` (claims `iss`, `aud`, `sub`).
+
+**4. User salt — your responsibility (the footgun)**
+
+You must produce a stable `user_salt` per user. Either store a `sub`→salt mapping, or derive it via HKDF from a master seed. The docs explicitly warn:
+
+- **Losing salts = users permanently lose access** to their addresses.
+- You **cannot** rotate the master seed or change the OAuth client ID (`aud`) without changing — and thus losing — every derived address.
+
+This is the single biggest reason to use Enoki instead.
+
+**5. Derive the address**
+
+```typescript
+import { jwtToAddress } from '@mysten/sui/zklogin';
+
+const userAddress = jwtToAddress(jwt, userSalt, false);
+```
+
+**6. Get the ZK proof**
+
+```typescript
+import { getExtendedEphemeralPublicKey } from '@mysten/sui/zklogin';
+
+const extendedEphemeralPublicKey = getExtendedEphemeralPublicKey(
+  ephemeralKeyPair.getPublicKey(),
+);
+// POST { jwt, extendedEphemeralPublicKey, maxEpoch, jwtRandomness: randomness, salt: userSalt, keyClaimName: 'sub' }
+// to a proving service -> response is the PartialZkLoginSignature
+```
+
+You host or call a proving service. (Enoki provides one via `EnokiClient.createZkLoginZkp`; see `sponsored-transactions.md`.)
+
+**7. Assemble and execute**
+
+```typescript
+import { genAddressSeed, getZkLoginSignature } from '@mysten/sui/zklogin';
+
+// sign the transaction bytes with the ephemeral key to get `userSignature`
+const addressSeed = genAddressSeed(
+  BigInt(userSalt),
+  'sub',
+  decodedJwt.sub,
+  decodedJwt.aud,
+).toString();
+
+const zkLoginSignature = getZkLoginSignature({
+  inputs: { ...partialZkLoginSignature, addressSeed },
+  maxEpoch,
+  userSignature,
+});
+// execute the transaction with zkLoginSignature
+```
+
+## Enoki vs manual — decision guide
+
+| Factor | Manual zkLogin | Enoki |
+|---|---|---|
+| ZK prover | You host/call one | Managed |
+| User salt | **You manage (high risk)** | Managed |
+| Sponsored transactions | Build a gas station yourself | Built in |
+| Control / customization | Maximum | Bounded by Enoki |
+| Operational risk | High (salt loss = lost addresses) | Low |
+| Networks | mainnet / testnet / devnet | mainnet / testnet |
+
+Choose **manual** only when you need devnet, full control of the prover/salt, or to avoid the managed dependency — and you can operate salt storage safely. Otherwise choose **Enoki**.

--- a/zklogin-enoki/sponsored-transactions.md
+++ b/zklogin-enoki/sponsored-transactions.md
@@ -1,0 +1,112 @@
+# Gasless / Sponsored Transactions
+
+Sourced from [docs.enoki.mystenlabs.com/ts-sdk/transactions](https://docs.enoki.mystenlabs.com/ts-sdk/transactions), `/ts-sdk/sponsored-transactions`, and the [`@mysten/enoki` source](https://github.com/MystenLabs/ts-sdks/tree/main/packages/enoki) (`EnokiClient`). Sponsorship lets your app pay gas so users transact without holding SUI.
+
+> This file covers sponsorship **as used with Enoki + zkLogin**. For the native, protocol-level Sui sponsored-transaction flow (sponsor + `GasData` dual signatures, gas-station patterns, and the equivocation / locked-object risks) — including sponsoring transactions for users who do *not* use Enoki — see the separate **`sui-sponsored-transactions`** skill.
+
+> **Signing ≠ sponsorship.** Signing a transaction through an Enoki wallet does not by itself make it gasless. Sponsorship is a separate, server-authorized flow with an allowlist. Don't conflate the two.
+
+## Frontend: signing through an Enoki wallet
+
+For a normal (user-pays) transaction, use the standard dApp Kit hook — the connected Enoki wallet signs it:
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+import { useSignAndExecuteTransaction } from '@mysten/dapp-kit';
+
+function Demo() {
+  const { mutateAsync: signAndExecuteTransaction } = useSignAndExecuteTransaction();
+
+  async function handleClick() {
+    const transaction = new Transaction();
+    // transaction.moveCall({ ... }) etc.
+    const { digest } = await signAndExecuteTransaction({ transaction });
+  }
+}
+```
+
+Enoki wallet signing **auto-approves** (no confirmation pop-up), so add your own confirm/cancel UI. For a fully **sponsored** transaction, the sponsoring is authorized by your backend using the private key (below).
+
+## Backend: `EnokiClient` sponsor
+
+The **private/secret** Enoki API key lives **only on the server**. It can authorize gas sponsorship, so treat it like any other server secret.
+
+```typescript
+import { EnokiClient } from '@mysten/enoki';
+
+const enoki = new EnokiClient({
+  apiKey: process.env.ENOKI_PRIVATE_API_KEY!, // backend only
+});
+```
+
+### The build → sponsor → sign → execute flow
+
+**1. Client builds transaction-kind bytes** (no gas data). Crucially, use `onlyTransactionKind: true`:
+
+```typescript
+const transactionKindBytes = await tx.build({
+  client: suiClient,
+  onlyTransactionKind: true,
+});
+// send transactionKindBytes (+ sender) to your backend
+```
+
+**2. Backend creates the sponsored transaction.** The input takes **either** a `jwt` **or** a `sender` (+ optional allowlists) — verified input type:
+
+```typescript
+type CreateSponsoredTransactionApiInput = {
+  network?: EnokiNetwork;          // 'testnet' | 'mainnet'
+  transactionKindBytes: string;
+} & (
+  | { jwt: string; sender?: never; allowedAddresses?: never; allowedMoveCallTargets?: never }
+  | { sender: string; allowedAddresses?: string[]; allowedMoveCallTargets?: string[]; jwt?: never }
+);
+```
+
+```typescript
+const sponsored = await enoki.createSponsoredTransaction({
+  network: 'mainnet',
+  sender: '0xUSER_ZKLOGIN_ADDRESS',
+  transactionKindBytes,
+  allowedMoveCallTargets: ['0xPKG::module::function'], // scope what you pay for
+  // allowedAddresses: ['0x...'],                       // optionally scope by sender
+});
+// sponsored exposes `bytes` to sign and a `digest` to execute with
+```
+
+**3. Sign** the returned `bytes` with the sender's key (the user's ephemeral/zkLogin signature via their Enoki wallet, or a keypair) to produce a `signature`.
+
+**4. Backend executes** — verified input type:
+
+```typescript
+interface ExecuteSponsoredTransactionApiInput {
+  digest: string;
+  signature: string;
+}
+```
+
+```typescript
+await enoki.executeSponsoredTransaction({
+  digest: sponsored.digest,
+  signature,
+});
+```
+
+> The `{ bytes, digest }` shape returned by `createSponsoredTransaction` is consistent with the README usage but was not quoted verbatim from the type source — treat the return field names as the documented usage pattern and verify against installed SDK types if exactness matters.
+
+### `jwt` vs `sender` variant
+
+- **`jwt`** — identify the user by their zkLogin JWT; Enoki resolves the sender. Use when the backend has the user's JWT.
+- **`sender` + allowlists** — identify the user by address and explicitly scope sponsorship with `allowedMoveCallTargets` / `allowedAddresses`.
+
+The two are mutually exclusive (enforced by the type union). You cannot pass both.
+
+## Security rules
+
+- **Private key is backend-only.** Never ship it to the browser or any client bundle. The frontend uses the public key (`registerEnokiWallets`).
+- **Always scope sponsorship.** Set `allowedMoveCallTargets` (and optionally `allowedAddresses`) so the sponsor only pays for your app's intended move calls. An unscoped sponsor can be drained by paying for arbitrary calls.
+- **Build with `onlyTransactionKind: true`.** Pass `transactionKindBytes`, not a fully-built transaction with gas data — the sponsor supplies the gas.
+
+## Other `EnokiClient` methods
+
+For lower-level / manual zkLogin via Enoki's prover: `getApp`, `getZkLogin`, `getZkLoginAddresses`, `createZkLoginNonce`, `createZkLoginZkp`, plus SuiNS subname helpers (`getSubnames`, `createSubname`, `deleteSubname`). Most apps only need `createSponsoredTransaction` / `executeSponsoredTransaction` plus the frontend flow in `frontend-auth.md`.


### PR DESCRIPTION
## Summary

Two new Sui agent skills for the highest-friction parts of consumer onboarding — passwordless auth and gasless UX:

### `zklogin-enoki` — passwordless social login
Social login (Google / Facebook / Twitch / Apple) producing a self-custodial Sui address via zkLogin + Enoki, with no seed phrase or extension.
- Teaches the **current** `registerEnokiWallets` + dApp Kit flow and explicitly bans the legacy `EnokiFlow` / `useEnokiFlow` / `useZkLogin` API that agents tend to hallucinate.
- Reference files: `concepts` (how zkLogin works), `frontend-auth` (Enoki + dApp Kit), `sponsored-transactions` (backend `EnokiClient`), `manual-zklogin` (no-Enoki path + decision guide).
- 10 evals.

### `sui-sponsored-transactions` — gasless / sponsored transactions
The **native** protocol mechanism (works with any wallet/keypair), plus the managed Enoki gas station.
- Reference files: `native-flow` (sponsor + `GasData` dual-signature flow with `@mysten/sui`), `enoki-gas-station` (managed option), `security` (equivocation → locked-until-next-epoch, gas-coin pools, censorship/direct-to-fullnode).
- 8 evals.

The two skills have distinct triggers ("social login / no seed phrase" vs "gas station / gasless / sponsor gas") per the *one skill per capability* guideline, and they cross-reference each other.

## Why these
zkLogin onboarding and gasless UX are the two things consumer Sui apps reach for first, and there was no skill for either. The common failure modes (deprecated Enoki API, leaking the private key to the frontend, "signing ≠ sponsorship", gas owned by the wrong party, equivocation locking) are exactly what AI agents get wrong today — each is a rule + an eval here.

## Conventions / quality
- Trigger-style `description`, routing-guide tables, on-demand reference files, `Rules` / `Common mistakes` sections — matching the existing `object-model` skill.
- Per-skill **source constraint**: sourced exclusively from `docs.sui.io`, `docs.enoki.mystenlabs.com`, `sdk.mystenlabs.com`, and MystenLabs source. No third-party material.
- API derived from a focused docs pass; a few details the docs leave ambiguous (e.g. `createSponsoredTransaction` exact return shape, the `isEnokiNetwork` guard name) are flagged inline as "verify against typedoc" rather than asserted.
- `evals/evals.json` included for both (required for merge).

## Notes for reviewers
- Both skills are net-new directories; `README.md` Skills table updated to list them.
- Happy to adjust eval `sources`/`expectations`, split or merge files, or rename per your conventions.
