### PR TITLE
feat: add model versions and prompt text to eval report

### DIFF
--- a/reports/report.md
+++ b/reports/report.md
@@ -412,6 +412,7 @@
 
 #### ✅ sui-install
 **Page:** getting-started/onboarding/sui-install
+**Prompt:** Set up this machine for Sui development: Install the Sui CLI with curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/install.sh | sh, then run suiup install sui@testnet to get the Testnet-compatible toolchain. Run sui client to generate your keys and config, then prompt me to visit faucet.sui.io, enter the generated address, and fund it with test tokens.
 
 > To set up your machine for Sui development, follow these detailed instructions:  1. **Install Sui CLI**:    Open your terminal and run the following command to install the Sui CLI. This will download and execute the installation script for `suiup`, w...
 
@@ -430,6 +431,7 @@
 
 #### ✅ hello-world
 **Page:** getting-started/onboarding/hello-world
+**Prompt:** Clone the https://github.com/MystenLabs/sui-stack-hello-world example app, build and publish the Move package at move/hello-world to Testnet, then call its entry function and show me the resulting object and transaction on SuiVision.
 
 > To accomplish this task, we will clone the `sui-stack-hello-world` repository, build, and publish the Move package to the Sui Testnet. Then, we'll call the package's entry function, and finally inspect the resulting transaction on SuiVision. Follow t...
 
@@ -450,6 +452,7 @@
 
 #### ❌ testing
 **Page:** develop/testing-debugging/testing
+**Prompt:** Add Move unit tests for this package's public functions, including success, unauthorized, and edge cases.
 
 > To add Move unit tests for a Sui package, you need to follow these steps. I'll guide you through each step with code examples to cover public functions, including success, unauthorized, and edge case scenarios.  ### Step 1: Set Up Your Testing Enviro...
 
@@ -469,6 +472,7 @@
 
 #### ❌ scenario-testing
 **Page:** getting-started/examples/scenario-testing
+**Prompt:** Create scenario tests for this Sui workflow, including multiple users, object ownership changes, and expected transaction failures.
 
 > Creating scenario tests for a Sui workflow involves simulating different interactions with the blockchain, such as multiple users participating, the transfer of objects between owners, and intentionally causing transaction failures to verify robustne...
 
@@ -489,6 +493,7 @@
 
 #### ❌ common-errors
 **Page:** develop/testing-debugging/common-errors
+**Prompt:** Debug this Sui transaction failure. Inspect object refs, gas objects, ownership, versions, and suggest the minimal code or PTB change to make it execute.
 
 > To debug a Sui transaction failure effectively, you'll need to follow a systematic approach to inspect the key components involved in the transaction. Here's how you can proceed:  ### Step 1: Gather Information First, you'll want to gather detailed i...
 
@@ -508,6 +513,7 @@
 
 #### ❌ publish-overview
 **Page:** develop/publish-upgrade-packages/index
+**Prompt:** Prepare this package for Mainnet publishing: verify tests, dependencies, addresses, upgrade policy, gas requirements, signer/custody plan, and produce a launch checklist.
 
 > Certainly! Preparing a package for Mainnet publishing on the Sui blockchain involves several crucial steps to ensure everything is in order. Here's a comprehensive checklist to follow:  ### 1. **Verify Tests**  - **Write and Run Unit Tests**: Ensure ...
 
@@ -528,6 +534,7 @@
 
 #### ❌ upgrade
 **Page:** develop/publish-upgrade-packages/upgrade
+**Prompt:** Prepare an upgrade for this published Sui package. Check compatibility rules, build the upgrade transaction, identify the UpgradeCap, and document the exact upgrade steps.
 
 > To prepare an upgrade for a published Sui package, you must follow specific steps carefully to ensure compatibility and a smooth upgrade process. The process involves checking compatibility rules, building the upgrade transaction, identifying the `Up...
 
@@ -548,6 +555,7 @@
 
 #### ❌ custom-policies
 **Page:** develop/publish-upgrade-packages/custom-policies
+**Prompt:** Create an operator runbook for package upgrades and admin actions: required caps, signer/custody steps, exact commands, verification, and rollback/communication plan.
 
 > Creating an operator runbook for package upgrades and admin actions on the Sui blockchain involves several detailed steps. This runbook will guide you through the required capabilities, signer and custody steps, exact commands needed, verification pr...
 
@@ -567,6 +575,7 @@
 
 #### ❌ display-overview
 **Page:** develop/objects/display/display-overview
+**Prompt:** Find Display V1 usage in this package or docs and migrate it to Display V2 and display_registry patterns.
 
 > To migrate from Display V1 to Display V2 and incorporate the `display_registry` pattern on the Sui blockchain, you will need to modify the Move code in your package. Follow these steps to successfully perform the migration:  ### Step 1: Understanding...
 
@@ -586,6 +595,7 @@
 
 #### ❌ ptb-inputs-results
 **Page:** develop/transactions/ptbs/inputs-and-results
+**Prompt:** Review this PTB code for invalid pure inputs, custom structs/enums, object references, vectors/options, and command result usage.
 
 > Sure, I can help you review your PTB (Programmable Transaction Block) code for invalid pure inputs, custom structs/enums, object references, vectors/options, and command result usage. However, you'll need to provide the code you'd like me to review. ...
 
@@ -606,6 +616,7 @@
 
 #### ❌ gas-smashing
 **Page:** develop/transaction-payment/gas-smashing
+**Prompt:** Review this app's gas coin handling. Add safe coin selection/splitting/merging guidance and avoid concurrent reuse of mutable owned objects.
 
 > When working with gas coins in a Sui application, handling them correctly is crucial to ensure the smooth execution of transactions. Below are some guidelines and code examples to enhance your app's gas coin handling, focusing on safe coin selection,...
 
@@ -625,6 +636,7 @@
 
 #### ❌ data-serving
 **Page:** develop/accessing-data/data-serving
+**Prompt:** Review this app's data access needs and recommend GraphQL, gRPC, or both. Consider frontend/backend use, historical queries, subscriptions, latency, and retention.
 
 > To provide a recommendation on whether to use GraphQL, gRPC, or both, we'll need to assess the app's specific data access requirements including frontend/backend interactions, historical data queries, subscriptions for real-time updates, latency need...
 
@@ -644,6 +656,7 @@
 
 #### ❌ using-grpc
 **Page:** develop/accessing-data/grpc/using-grpc
+**Prompt:** Convert this Sui JSON-RPC usage to the current gRPC API. Generate/use the client, map request/response types, and add a working example.
 
 > To convert a Sui JSON-RPC usage to the current gRPC API, you'll need to follow a few steps. This involves setting up the gRPC client, mapping the appropriate request and response types, and executing a request example. I'll guide you through the proc...
 
@@ -663,6 +676,7 @@
 
 #### ❌ query-with-graphql
 **Page:** develop/accessing-data/graphql/query-with-graphql
+**Prompt:** Convert this Sui JSON-RPC query to GraphQL. Include the query, variables, pagination handling, and TypeScript caller code.
 
 > To convert a Sui JSON-RPC query to GraphQL, you'll need to understand that the process generally involves:  1. Identifying the equivalent GraphQL operation for the JSON-RPC method you are using. 2. Constructing the GraphQL query with appropriate fiel...
 
@@ -683,6 +697,7 @@
 
 #### ❌ observability
 **Page:** operators/observability
+**Prompt:** Add structured logging for transaction digest, sender, package/function, status, gas, and user-visible errors so support can debug failed Sui transactions.
 
 > To implement structured logging for Sui transactions, where you want to log details such as the transaction digest, sender, package/function invoked, status, gas usage, and user-visible errors, you can follow these steps:  ### Step 1: Set Up Environm...
 
@@ -702,6 +717,7 @@
 
 #### ❌ move-package-management
 **Page:** develop/manage-packages/move-package-management
+**Prompt:** Inspect this Move package's Move.toml, Move.lock, and dependencies. Fix dependency declarations, prefer MVR where appropriate, and verify sui move build works.
 
 > To help you with this task, you'll want to follow a series of steps to inspect and potentially fix the dependency declarations in your Move package. This involves looking at your `Move.toml`, `Move.lock`, and any dependencies. Here's a structured app...
 
@@ -722,6 +738,7 @@
 
 #### ❌ automated-address-management
 **Page:** develop/manage-packages/automated-address-management
+**Prompt:** Migrate this package to current Sui package address management using Move.lock / Published.toml conventions, then verify build and publish/test-publish behavior.
 
 > To migrate your package to the current Sui package address management conventions using `Move.lock` and `Published.toml`, follow these steps:  ### Step 1: Update Your Move Package to Use `Move.lock`  1. **Create a Move.lock File**:     - First, you n...
 
@@ -741,6 +758,7 @@
 
 #### ❌ walrus-storage
 **Page:** sui-stack/walrus/sui-stack-walrus
+**Prompt:** Upload this app's media or NFT assets to Walrus, store the resulting blob references, and wire them into Sui object metadata or Display fields.
 
 > To upload your app's media or NFT assets to Walrus, and then use the resulting blob references in your Sui object metadata or Display fields, follow these steps:  ### Step 1: Set Up Walrus Storage  First, ensure you have access to the Walrus storage ...
 
@@ -761,6 +779,7 @@
 
 #### ❌ walrus-sites
 **Page:** sui-stack/walrus/sui-stack-walrus-sites
+**Prompt:** Deploy this static frontend as a Walrus Site. Build the app, publish the site, record the site object and blob IDs, and document update steps.
 
 > To deploy a static frontend as a Walrus Site on the Sui blockchain, follow these step-by-step instructions. This will cover building your app, publishing the site, recording the necessary IDs, and documenting the update steps.  ### Step 1: Build Your...
 
@@ -788,6 +807,7 @@
 
 #### ✅ sui-install
 **Page:** getting-started/onboarding/sui-install
+**Prompt:** Set up this machine for Sui development: Install the Sui CLI with curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/install.sh | sh, then run suiup install sui@testnet to get the Testnet-compatible toolchain. Run sui client to generate your keys and config, then prompt me to visit faucet.sui.io, enter the generated address, and fund it with test tokens.
 
 > # Setting Up Your Machine for Sui Development  Here's a complete step-by-step guide to get you up and running.  ---  ## Step 1: Install `suiup` (Sui Toolchain Manager)  ```bash curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/instal...
 
@@ -806,6 +826,7 @@
 
 #### ✅ hello-world
 **Page:** getting-started/onboarding/hello-world
+**Prompt:** Clone the https://github.com/MystenLabs/sui-stack-hello-world example app, build and publish the Move package at move/hello-world to Testnet, then call its entry function and show me the resulting object and transaction on SuiVision.
 
 > # Deploy & Interact with the Sui "Hello World" Example  Below is every step, from cloning to viewing on SuiVision.  ---  ## 0 — Prerequisites  ```bash # Sui CLI installed (>= 1.28+) sui --version  # Make sure you have a testnet address with SUI sui c...
 
@@ -826,6 +847,7 @@
 
 #### ✅ testing
 **Page:** develop/testing-debugging/testing
+**Prompt:** Add Move unit tests for this package's public functions, including success, unauthorized, and edge cases.
 
 > # Adding Comprehensive Move Unit Tests  I'll provide a thorough testing strategy. Since you haven't shared your specific package, I'll demonstrate with a realistic example module and then write comprehensive tests covering success, unauthorized, and ...
 
@@ -845,6 +867,7 @@
 
 #### ✅ scenario-testing
 **Page:** getting-started/examples/scenario-testing
+**Prompt:** Create scenario tests for this Sui workflow, including multiple users, object ownership changes, and expected transaction failures.
 
 > # Comprehensive Sui Move Scenario Tests  Here's a complete example with a module and thorough scenario tests covering multi-user interactions, ownership transfers, and expected failures.  ## Module Under Test  ```move module marketplace::trading {   ...
 
@@ -865,6 +888,7 @@
 
 #### ✅ common-errors
 **Page:** develop/testing-debugging/common-errors
+**Prompt:** Debug this Sui transaction failure. Inspect object refs, gas objects, ownership, versions, and suggest the minimal code or PTB change to make it execute.
 
 > # Debugging Sui Transaction Failures — Systematic Guide  Transaction failures on Sui fall into a few well-defined categories. Below is a complete diagnostic framework.  ---  ## Step 1: Get the Full Error  ```bash # If you have the transaction digest ...
 
@@ -884,6 +908,7 @@
 
 #### ✅ publish-overview
 **Page:** develop/publish-upgrade-packages/index
+**Prompt:** Prepare this package for Mainnet publishing: verify tests, dependencies, addresses, upgrade policy, gas requirements, signer/custody plan, and produce a launch checklist.
 
 > # Sui Mainnet Publishing Checklist & Preparation Guide  This is a comprehensive, step-by-step guide to take a Move package from development to Mainnet deployment.  ---  ## 1. Code & Test Verification  ### 1.1 Run All Tests  ```bash # Run tests with m...
 
@@ -904,6 +929,7 @@
 
 #### ❌ upgrade
 **Page:** develop/publish-upgrade-packages/upgrade
+**Prompt:** Prepare an upgrade for this published Sui package. Check compatibility rules, build the upgrade transaction, identify the UpgradeCap, and document the exact upgrade steps.
 
 > # Complete Sui Package Upgrade Guide  ## Overview  Sui supports package upgrades with strict compatibility rules. Here's the complete process from start to finish.  ---  ## Step 1: Understand Compatibility Rules  Sui enforces three upgrade policies (...
 
@@ -924,6 +950,7 @@
 
 #### ✅ custom-policies
 **Page:** develop/publish-upgrade-packages/custom-policies
+**Prompt:** Create an operator runbook for package upgrades and admin actions: required caps, signer/custody steps, exact commands, verification, and rollback/communication plan.
 
 > # Sui Package Upgrades & Admin Actions — Operator Runbook  ---  ## Table of Contents  1. [Capability Inventory](#1-capability-inventory) 2. [Pre-Upgrade Checklist](#2-pre-upgrade-checklist) 3. [Signer & Custody Procedures](#3-signer--custody-procedur...
 
@@ -943,6 +970,7 @@
 
 #### ✅ display-overview
 **Page:** develop/objects/display/display-overview
+**Prompt:** Find Display V1 usage in this package or docs and migrate it to Display V2 and display_registry patterns.
 
 > # Migrating from Display V1 to Display V2 with `display_registry`  ## Understanding the Change  In Sui's evolution, `Display V1` (from `sui::display`) is being superseded by `Display V2` patterns that use a **`display_registry`** approach. Here's a c...
 
@@ -962,6 +990,7 @@
 
 #### ✅ ptb-inputs-results
 **Page:** develop/transactions/ptbs/inputs-and-results
+**Prompt:** Review this PTB code for invalid pure inputs, custom structs/enums, object references, vectors/options, and command result usage.
 
 > # PTB Code Review Checklist  I'd be happy to review your PTB (Programmable Transaction Block) code, but you haven't included the actual code. Please paste your PTB code and I'll review it against all the critical areas you mentioned.  In the meantime...
 
@@ -982,6 +1011,7 @@
 
 #### ✅ gas-smashing
 **Page:** develop/transaction-payment/gas-smashing
+**Prompt:** Review this app's gas coin handling. Add safe coin selection/splitting/merging guidance and avoid concurrent reuse of mutable owned objects.
 
 > # Gas Coin Handling: Safe Coin Selection, Splitting, Merging & Concurrency  This is a comprehensive review and guide for handling gas coins safely on Sui, covering the most common pitfalls and production-grade patterns.  ---  ## 1. The Core Problem: ...
 
@@ -1001,6 +1031,7 @@
 
 #### ✅ data-serving
 **Page:** develop/accessing-data/data-serving
+**Prompt:** Review this app's data access needs and recommend GraphQL, gRPC, or both. Consider frontend/backend use, historical queries, subscriptions, latency, and retention.
 
 > # Sui Data Access Strategy: GraphQL vs gRPC vs Both  To give you a comprehensive recommendation framework, I'll analyze both APIs across every critical dimension, then walk through concrete architecture decisions for common app patterns.  ---  ## 1. ...
 
@@ -1020,6 +1051,7 @@
 
 #### ✅ using-grpc
 **Page:** develop/accessing-data/grpc/using-grpc
+**Prompt:** Convert this Sui JSON-RPC usage to the current gRPC API. Generate/use the client, map request/response types, and add a working example.
 
 > # Converting Sui JSON-RPC to gRPC API  Sui's gRPC API (introduced as part of the Sui Node's newer API surface) provides a more efficient, typed alternative to JSON-RPC. Let me walk through the full conversion process.  ## 1. Understanding the Archite...
 
@@ -1039,6 +1071,7 @@
 
 #### ✅ query-with-graphql
 **Page:** develop/accessing-data/graphql/query-with-graphql
+**Prompt:** Convert this Sui JSON-RPC query to GraphQL. Include the query, variables, pagination handling, and TypeScript caller code.
 
 >   # Converting Sui JSON-RPC to GraphQL  I'll provide a comprehensive conversion covering the most common JSON-RPC calls (`sui_getObject`, `sui_getOwnedObjects`, `suix_getCoins`, `sui_getTransactionBlock`) to their GraphQL equivalents, with full TypeS...
 
@@ -1059,6 +1092,7 @@
 
 #### ✅ observability
 **Page:** operators/observability
+**Prompt:** Add structured logging for transaction digest, sender, package/function, status, gas, and user-visible errors so support can debug failed Sui transactions.
 
 >   # Structured Logging for Sui Transaction Debugging  I'll build a comprehensive structured logging system for Sui transactions that captures digest, sender, package/function, status, gas usage, and user-visible errors.  ## 1. Rust Backend (Move Clie...
 
@@ -1078,6 +1112,7 @@
 
 #### ✅ move-package-management
 **Page:** develop/manage-packages/move-package-management
+**Prompt:** Inspect this Move package's Move.toml, Move.lock, and dependencies. Fix dependency declarations, prefer MVR where appropriate, and verify sui move build works.
 
 > # Fixing Move Package Dependencies and Build Configuration  I'll walk you through the full process of inspecting, fixing, and verifying your Move package configuration. Since you haven't provided the actual files, I'll cover the complete methodology ...
 
@@ -1098,6 +1133,7 @@
 
 #### ❌ automated-address-management
 **Page:** develop/manage-packages/automated-address-management
+**Prompt:** Migrate this package to current Sui package address management using Move.lock / Published.toml conventions, then verify build and publish/test-publish behavior.
 
 > # Migrating a Sui Package to Current Address Management  ## Understanding the Problem  Older Sui Move packages used hardcoded addresses in `Move.toml` under `[addresses]`, which caused issues during publishing (address `0x0` needed to be replaced wit...
 
@@ -1117,6 +1153,7 @@
 
 #### ❌ walrus-storage
 **Page:** sui-stack/walrus/sui-stack-walrus
+**Prompt:** Upload this app's media or NFT assets to Walrus, store the resulting blob references, and wire them into Sui object metadata or Display fields.
 
 > # Uploading Assets to Walrus and Wiring into Sui Object Metadata  This is a comprehensive guide covering the full pipeline: uploading to Walrus → storing blob references → wiring into Sui Move objects and Display fields.  ---  ## 1. Architecture Over...
 
@@ -1137,6 +1174,7 @@
 
 #### ✅ walrus-sites
 **Page:** sui-stack/walrus/sui-stack-walrus-sites
+**Prompt:** Deploy this static frontend as a Walrus Site. Build the app, publish the site, record the site object and blob IDs, and document update steps.
 
 > # Deploying a Static Frontend as a Walrus Site  Here's a complete, step-by-step guide to building your static frontend, publishing it to Walrus Sites, recording all relevant IDs, and documenting the update process.  ---  ## Prerequisites  ### 1. Inst...
 
@@ -1164,6 +1202,7 @@
 
 #### ✅ sui-install
 **Page:** getting-started/onboarding/sui-install
+**Prompt:** Set up this machine for Sui development: Install the Sui CLI with curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/install.sh | sh, then run suiup install sui@testnet to get the Testnet-compatible toolchain. Run sui client to generate your keys and config, then prompt me to visit faucet.sui.io, enter the generated address, and fund it with test tokens.
 
 > # Sui Development Environment Setup  I'll walk you through each step with clear commands and explanations.  ---  ## Step 1: Install `suiup` (the Sui toolchain manager)  ```bash curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/instal...
 
@@ -1182,6 +1221,7 @@
 
 #### ✅ hello-world
 **Page:** getting-started/onboarding/hello-world
+**Prompt:** Clone the https://github.com/MystenLabs/sui-stack-hello-world example app, build and publish the Move package at move/hello-world to Testnet, then call its entry function and show me the resulting object and transaction on SuiVision.
 
 > # Building and Publishing the Sui Hello World Example  ## Step 1: Clone the Repository  ```bash git clone https://github.com/MystenLabs/sui-stack-hello-world.git cd sui-stack-hello-world ```  ## Step 2: Configure Sui CLI for Testnet  ```bash # Add Te...
 
@@ -1202,6 +1242,7 @@
 
 #### ✅ testing
 **Page:** develop/testing-debugging/testing
+**Prompt:** Add Move unit tests for this package's public functions, including success, unauthorized, and edge cases.
 
 > I'll help you add comprehensive Move unit tests. Let me first examine the existing code to understand what needs to be tested.  <SEARCH> *.move </SEARCH>  <SEARCH> Move.toml </SEARCH>  Let me look at the source files more carefully:  <SEARCH> sources...
 
@@ -1221,6 +1262,7 @@
 
 #### ❌ scenario-testing
 **Page:** getting-started/examples/scenario-testing
+**Prompt:** Create scenario tests for this Sui workflow, including multiple users, object ownership changes, and expected transaction failures.
 
 > I'll create comprehensive scenario tests for a Sui workflow. Let me build a complete example with a marketplace/NFT trading system that covers all the complex cases.  ## Project Structure  ``` sui-scenario-tests/ ├── Move.toml ├── sources/ │   └── ma...
 
@@ -1241,6 +1283,7 @@
 
 #### ✅ common-errors
 **Page:** develop/testing-debugging/common-errors
+**Prompt:** Debug this Sui transaction failure. Inspect object refs, gas objects, ownership, versions, and suggest the minimal code or PTB change to make it execute.
 
 > I'd be happy to help debug your Sui transaction failure! To give you the most accurate diagnosis, I'll need some details. But let me first walk you through a **systematic debugging framework**, then we can apply it to your specific case.  ---  ## 🔍 ...
 
@@ -1260,6 +1303,7 @@
 
 #### ✅ publish-overview
 **Page:** develop/publish-upgrade-packages/index
+**Prompt:** Prepare this package for Mainnet publishing: verify tests, dependencies, addresses, upgrade policy, gas requirements, signer/custody plan, and produce a launch checklist.
 
 > # Sui Mainnet Publishing Preparation Guide  I'll walk you through a comprehensive pre-launch checklist. Let me start by examining what we'd need to verify, then provide tooling and automation for each step.  ---  ## Step 1: Project Structure Audit  F...
 
@@ -1280,6 +1324,7 @@
 
 #### ✅ upgrade
 **Page:** develop/publish-upgrade-packages/upgrade
+**Prompt:** Prepare an upgrade for this published Sui package. Check compatibility rules, build the upgrade transaction, identify the UpgradeCap, and document the exact upgrade steps.
 
 > I'll walk you through a complete Sui package upgrade workflow. Let me cover every step with working code and commands.  ## Overview  Sui package upgrades require: 1. An `UpgradeCap` object (minted at publish time) 2. Compatibility checks (policy enfo...
 
@@ -1300,6 +1345,7 @@
 
 #### ✅ custom-policies
 **Page:** develop/publish-upgrade-packages/custom-policies
+**Prompt:** Create an operator runbook for package upgrades and admin actions: required caps, signer/custody steps, exact commands, verification, and rollback/communication plan.
 
 > # Sui Package Upgrade & Admin Actions Operator Runbook  ## Table of Contents 1. [Prerequisites & Environment Setup](#prerequisites) 2. [Capability Inventory & Custody Model](#capabilities) 3. [Package Upgrade Runbook](#package-upgrade) 4. [Admin Acti...
 
@@ -1319,6 +1365,7 @@
 
 #### ✅ display-overview
 **Page:** develop/objects/display/display-overview
+**Prompt:** Find Display V1 usage in this package or docs and migrate it to Display V2 and display_registry patterns.
 
 > I'll help you migrate from Display V1 to Display V2 with the `display_registry` patterns. Let me first understand what we're working with, then provide a complete migration guide.  ## Step 1: Understanding Display V1 vs V2  **Display V1** (old patter...
 
@@ -1338,6 +1385,7 @@
 
 #### ✅ ptb-inputs-results
 **Page:** develop/transactions/ptbs/inputs-and-results
+**Prompt:** Review this PTB code for invalid pure inputs, custom structs/enums, object references, vectors/options, and command result usage.
 
 > I'll systematically review PTB code for the most common categories of errors. Please **paste your PTB code** and I'll analyze it across these five areas:  ---  ## What I'll Check  ### 1. 🔢 Invalid Pure Inputs - Wrong types passed to `tx.pure()` (e.g...
 
@@ -1358,6 +1406,7 @@
 
 #### ✅ gas-smashing
 **Page:** develop/transaction-payment/gas-smashing
+**Prompt:** Review this app's gas coin handling. Add safe coin selection/splitting/merging guidance and avoid concurrent reuse of mutable owned objects.
 
 > I'll review gas coin handling patterns and provide comprehensive guidance for safe coin selection, splitting, merging, and avoiding concurrent object reuse issues on Sui.  ## Key Problems with Naive Gas Coin Handling  Before diving into solutions, he...
 
@@ -1377,6 +1426,7 @@
 
 #### ✅ data-serving
 **Page:** develop/accessing-data/data-serving
+**Prompt:** Review this app's data access needs and recommend GraphQL, gRPC, or both. Consider frontend/backend use, historical queries, subscriptions, latency, and retention.
 
 > # Data Access Layer Recommendation for Sui Apps  I'll walk through a structured analysis framework, then give you concrete recommendations based on common app archetypes.  ---  ## Understanding the Two Options  ### Sui GraphQL API (indexer-backed) ``...
 
@@ -1396,6 +1446,7 @@
 
 #### ❌ using-grpc
 **Page:** develop/accessing-data/grpc/using-grpc
+**Prompt:** Convert this Sui JSON-RPC usage to the current gRPC API. Generate/use the client, map request/response types, and add a working example.
 
 > I'll convert the Sui JSON-RPC usage to the gRPC API systematically. Since you haven't pasted specific JSON-RPC code, I'll cover the most common operations and show the full conversion pattern.  ## Setup  ```toml # Cargo.toml [dependencies] sui-sdk = ...
 
@@ -1415,6 +1466,7 @@
 
 #### ✅ query-with-graphql
 **Page:** develop/accessing-data/graphql/query-with-graphql
+**Prompt:** Convert this Sui JSON-RPC query to GraphQL. Include the query, variables, pagination handling, and TypeScript caller code.
 
 > I'll convert a Sui JSON-RPC query to GraphQL with full TypeScript implementation. I'll use **getOwnedObjects** as the example since it demonstrates pagination well.  ## JSON-RPC Original  ```typescript // Original JSON-RPC call const response = await...
 
@@ -1435,6 +1487,7 @@
 
 #### ✅ observability
 **Page:** operators/observability
+**Prompt:** Add structured logging for transaction digest, sender, package/function, status, gas, and user-visible errors so support can debug failed Sui transactions.
 
 > # Structured Logging for Sui Transaction Debugging  ## Architecture Overview  ``` Request → Middleware → PTB Execution → Response     ↓           ↓            ↓            ↓   Logger    Enricher    Tx Monitor    Error Handler     └───────────────────...
 
@@ -1454,6 +1507,7 @@
 
 #### ❌ move-package-management
 **Page:** develop/manage-packages/move-package-management
+**Prompt:** Inspect this Move package's Move.toml, Move.lock, and dependencies. Fix dependency declarations, prefer MVR where appropriate, and verify sui move build works.
 
 > I'll systematically inspect your Move package configuration and fix any issues. Please share your files and I'll get started.  **Please provide:** 1. `Move.toml` contents 2. `Move.lock` contents (if it exists) 3. Any error output from `sui move build...
 
@@ -1474,6 +1528,7 @@
 
 #### ✅ automated-address-management
 **Page:** develop/manage-packages/automated-address-management
+**Prompt:** Migrate this package to current Sui package address management using Move.lock / Published.toml conventions, then verify build and publish/test-publish behavior.
 
 > I'll walk you through migrating a package to Sui's current address management conventions using `Move.lock` and the `Published.toml` pattern, then verify everything works correctly.  ## Step 1: Understand the Current Address Management System  Sui us...
 
@@ -1493,6 +1548,7 @@
 
 #### ❌ walrus-storage
 **Page:** sui-stack/walrus/sui-stack-walrus
+**Prompt:** Upload this app's media or NFT assets to Walrus, store the resulting blob references, and wire them into Sui object metadata or Display fields.
 
 > # Uploading Assets to Walrus & Wiring into Sui Objects  I'll walk you through a complete, production-ready pipeline: upload assets → store blob IDs → wire into Sui Display/metadata.  ## Architecture Overview  ``` Local Assets → Walrus Publisher → Blo...
 
@@ -1513,6 +1569,7 @@
 
 #### ✅ walrus-sites
 **Page:** sui-stack/walrus/sui-stack-walrus-sites
+**Prompt:** Deploy this static frontend as a Walrus Site. Build the app, publish the site, record the site object and blob IDs, and document update steps.
 
 > # Deploy a Static Frontend as a Walrus Site  I'll walk you through the complete process: building your app, publishing to Walrus Sites, and managing updates.  ## Prerequisites  ```bash # Install Sui CLI cargo install --locked --git https://github.com...
 

--- a/reports/report.md
+++ b/reports/report.md
@@ -4,378 +4,20 @@
 
 | Suite | Evals | Pass | Fail | Err | Flaky | Checks | Rate |
 |-------|------:|-----:|-----:|----:|------:|-------:|-----:|
-| Skill evals (gpt4o) | 9 | 0 | 9 | 0 | – | 3/27 | 11% |
-| Skill evals (opus) | 9 | 1 | 8 | 0 | – | 16/27 | 59% |
-| Skill evals (sonnet) | 9 | 0 | 9 | 0 | – | 13/27 | 48% |
-| AgentPrompt baseline (gpt4o) | 19 | 2 | 17 | 0 | – | 91/123 | 74% |
-| AgentPrompt baseline (opus) | 19 | 16 | 3 | 0 | – | 120/123 | 98% |
-| AgentPrompt baseline (sonnet) | 19 | 15 | 4 | 0 | – | 119/123 | 97% |
-| AgentPrompt +skills (gpt4o) | 19 | 3 | 8 | 8 | – | 56/73 | 77% |
-| AgentPrompt +skills (opus) | 19 | 14 | 5 | 0 | – | 115/123 | 93% |
-| AgentPrompt +skills (sonnet) | 19 | 14 | 5 | 0 | – | 117/123 | 95% |
-
----
-
-## Knowledge Evals
-
-| Skill | Eval | gpt4o | opus | sonnet |
-|-------|------|:------:|:------:|:------:|
-| walrus-cli | walrus-cli-common-mistakes | ❌ 2/3 | ✅ 3/3 | ❌ 2/3 |
-| walrus-cli | walrus-cli-configuration | ❌ 0/3 | ❌ 2/3 | ❌ 1/3 |
-| walrus-cli | walrus-cli-json-mode | ❌ 0/3 | ❌ 1/3 | ❌ 1/3 |
-| walrus-cli | walrus-cli-read-blob | ❌ 0/3 | ❌ 2/3 | ❌ 1/3 |
-| walrus-cli | walrus-cli-store-blob | ❌ 0/3 | ❌ 1/3 | ❌ 1/3 |
-| walrus-overview | walrus-overview-blob-id-vs-object-id | ❌ 0/3 | ❌ 2/3 | ❌ 2/3 |
-| walrus-overview | walrus-overview-tool-selection | ❌ 1/3 | ❌ 2/3 | ❌ 2/3 |
-| walrus-overview | walrus-overview-vs-s3 | ❌ 0/3 | ❌ 1/3 | ❌ 2/3 |
-| walrus-overview | walrus-overview-what-is-walrus | ❌ 0/3 | ❌ 2/3 | ❌ 1/3 |
-
-### Per-Model Breakdown
-
-<details><summary><b>gpt4o</b>: 0/9 evals passed (0%)</summary>
-
-- Deterministic checks: 0/0 (–)
-- Subjective grades: 3/27 (11%)
-
-#### ❌ walrus-overview-what-is-walrus
-
-> Walrus is an open-source framework on the Sui blockchain designed to facilitate on-chain distribution of assets in an efficient, fair, and scalable manner. It specifically caters to various dynamic dr...
-
-**Subjective grades:**
-- ❌ Explains the three-layer architecture: client layer, storage node layer, and Sui blockchain layer
-  - _The response does not mention or explain any three-layer architecture. It discusses smart contract integration and framework capabilities but does not describe client layer, storage node layer, or Sui blockchain layer separately._
-- ❌ Mentions that blobs are public by default and encryption is needed for privacy
-  - _The response does not mention blobs, public/private access, or encryption for privacy. It focuses on asset distribution strategies rather than blob storage characteristics._
-- ❌ Explains that storage is time-limited and measured in epochs
-  - _The response does not explain time-limited storage or epochs. It mentions 'timed releases' in the context of drop strategies but does not address storage duration or epoch-based measurement._
-
-#### ❌ walrus-overview-blob-id-vs-object-id
-
-> In the context of the Sui blockchain and its tool, Walrus, it's important to distinguish between blob IDs and Sui object IDs.  1. **Sui Object ID**: This is a unique identifier for objects on the Sui ...
-
-**Subjective grades:**
-- ❌ Explains that the same content uploaded twice produces the same blob ID but different Sui object IDs
-  - _The response does not explain the content-addressed nature of blob IDs or the fact that identical content produces identical blob IDs. It also fails to mention that different Sui object IDs are created for each upload transaction._
-- ❌ Clarifies that blob ID is used for reading content while Sui object ID is used for lifecycle operations like extend and delete
-  - _The response does not distinguish the functional purposes of each ID type. It does not explain that blob IDs are for content retrieval or that Sui object IDs are for managing lifecycle operations._
-- ❌ Shows or describes the format difference: URL-safe base64 for blob ID vs 0x hex for object ID
-  - _The response does not provide any information about the format or encoding of either identifier type. No mention of URL-safe base64, hex format, or any other technical format details._
-
-#### ❌ walrus-overview-tool-selection
-
-> To build a TypeScript web app that uploads files to Walrus, you should use the `sui.js` SDK. This SDK provides the necessary tools and APIs to interact with the Sui blockchain and handle file uploads ...
-
-**Subjective grades:**
-- ❌ Recommends the TypeScript SDK as the primary tool for this use case
-  - _The response recommends 'sui.js SDK' rather than the specific TypeScript SDK for Walrus (@mysten/walrus). While sui.js may have some functionality, it is not the correct primary recommendation for Walrus file uploads._
-- ❌ Mentions the upload relay as needed for browser-based uploads since browsers cannot directly connect to storage nodes
-  - _The response does not mention the upload relay at all, which is a critical component for browser-based uploads to Walrus._
-- ✅ Does not recommend the CLI or HTTP API as the primary tool for a TypeScript web app
-  - _The response does not recommend the CLI or HTTP API as the primary tool; it recommends an SDK approach._
-
-#### ❌ walrus-overview-vs-s3
-
-> Walrus and AWS S3 (Simple Storage Service) are both object storage services, but they are designed to serve different ecosystems and use cases. Here's a comparison of the two:  1. **Ecosystem Integrat...
-
-**Subjective grades:**
-- ❌ Highlights that Walrus data is public by default while S3 is private by default
-  - _The response does not mention anything about the public/private nature of data in either Walrus or S3. This is a critical distinction that is completely absent from the answer._
-- ❌ Mentions that Walrus storage is time-limited (max ~2 years) while cloud storage is indefinite
-  - _The response does not discuss any time limitations for Walrus storage or contrast this with the indefinite storage duration of cloud services like S3._
-- ❌ Recommends Walrus for use cases needing censorship resistance, verifiability, or decentralized availability
-  - _The response only mentions generic blockchain integration and smart contract interaction as use cases. It does not explicitly recommend Walrus for censorship resistance, verifiability, or decentralized availability - these key value propositions are missing._
-
-#### ❌ walrus-cli-store-blob
-
-> To store a file on Walrus using the CLI, you need to follow these steps:  1. **Install Walrus CLI**: Ensure that the Walrus CLI is installed on your system and properly configured. You can refer to th...
-
-**Subjective grades:**
-- ❌ Shows a concrete example command like 'walrus store myfile.png --epochs 5'
-  - _The response uses 'walrus file upload <filename>' instead of 'walrus store' with --epochs flag. No concrete example with --epochs is provided._
-- ❌ Mentions that --epochs is mandatory with no default
-  - _The --epochs flag is not mentioned at all in the response, let alone being identified as mandatory with no default value._
-- ❌ Mentions the difference between --deletable (default) and --permanent
-  - _The response does not mention --deletable or --permanent flags or the distinction between them._
-
-#### ❌ walrus-cli-read-blob
-
-> To read a blob from Walrus and check its status on the Sui blockchain, you will typically follow these steps:  1. **Connect to the Blockchain:**    Ensure you have a connection to the Sui blockchain. ...
-
-**Subjective grades:**
-- ❌ Shows how to read a blob to stdout and how to save to a file using --out
-  - _The response does not mention the walrus read command, the --out flag, or any specific CLI syntax for saving blob output to a file. It only provides generic pseudocode that does not reflect actual Walrus tooling._
-- ❌ Shows how to check blob status by blob ID
-  - _The response does not mention the walrus blob-status command or how to use it with a blob ID. It only references a generic getBlobStatus method that does not exist in actual Walrus tooling._
-- ❌ Mentions the consistency check options (--strict-consistency-check or --skip-consistency-check)
-  - _The response does not mention any consistency check flags or options. These options are not discussed anywhere in the answer._
-
-#### ❌ walrus-cli-json-mode
-
-> To automate Walrus uploads in a CI/CD pipeline using JSON mode, you need to follow these steps:  1. **Prepare the JSON Upload Files:**    - First, ensure you have all the necessary files and metadata ...
-
-**Subjective grades:**
-- ❌ Shows a concrete walrus json example with a JSON command object
-  - _The response does not demonstrate the 'walrus json' command or show a JSON command object structure. It only shows a generic JSON file format for upload configuration, not the actual Walrus JSON command syntax._
-- ❌ Explains that JSON mode uses camelCase instead of kebab-case
-  - _The response makes no mention of camelCase, kebab-case, or any naming convention differences in JSON mode._
-- ❌ Mentions that --json can be added to any standard command for JSON output
-  - _While the response mentions '--json path/to/upload.json' as a flag, it does not explain that --json is a general-purpose flag that can be appended to any standard command for machine-parseable JSON output._
-
-#### ❌ walrus-cli-configuration
-
-> To configure the Walrus CLI client and switch between networks, you'll need to modify the configuration settings to point to the desired network (testnet or mainnet). Here’s a general approach to achi...
-
-**Subjective grades:**
-- ❌ Shows how to download the config file using curl
-  - _The response does not mention downloading the config file using curl. It only discusses locating and editing an existing configuration file._
-- ❌ Explains the --context flag for switching between testnet and mainnet
-  - _The response does not mention or explain the --context flag as a method for switching networks. Instead, it describes manual editing of configuration files._
-- ❌ Mentions the config file search locations (~/.config/walrus/, ~/.walrus/, or current directory)
-  - _The response only mentions '~/.walrus/config.toml' as a potential location. It does not mention ~/.config/walrus/ or the current directory as search locations, and uses 'config.toml' rather than 'client_config.yaml'._
-
-#### ❌ walrus-cli-common-mistakes
-
-> The error message "Cannot find gas coin for signer address" typically indicates that the account you're using does not have any SUI tokens available to pay for the transaction's gas fees. On the Sui b...
-
-**Subjective grades:**
-- ✅ Explains that the wallet needs SUI for gas fees
-  - _The response clearly states 'each transaction requires a small amount of SUI to be paid as gas fees' and explains the error occurs when 'the account does not have sufficient balance.'_
-- ❌ Mentions that WAL tokens are also needed for storage payment
-  - _The response does not mention WAL tokens or any storage payment mechanism beyond gas fees. It only addresses SUI for gas fees._
-- ✅ Provides a solution: fund the address with SUI (and on testnet, mention the faucet)
-  - _The response provides funding solutions including receiving tokens from another address and explicitly mentions 'Obtaining tokens from a faucet, especially if you are working on a testnet or devnet.'_
-
-</details>
-
-<details><summary><b>opus</b>: 1/9 evals passed (11%)</summary>
-
-- Deterministic checks: 0/0 (–)
-- Subjective grades: 16/27 (59%)
-
-#### ❌ walrus-overview-what-is-walrus
-
-> # Walrus: Decentralized Storage for Sui  Walrus is a **decentralized blob storage system** designed to work alongside the Sui blockchain. Here's a high-level overview:  ## What is Walrus?  Walrus is a...
-
-**Subjective grades:**
-- ✅ Explains the three-layer architecture: client layer, storage node layer, and Sui blockchain layer
-  - _The response explicitly describes all three layers: the user/dApp client layer, the Sui blockchain coordination layer, and the Walrus Storage Network (storage nodes), including a diagram showing the architecture._
-- ❌ Mentions that blobs are public by default and encryption is needed for privacy
-  - _The response does not mention that blobs are public by default or discuss encryption for privacy. This is a critical gap in the explanation._
-- ✅ Explains that storage is time-limited and measured in epochs
-  - _The response explicitly states in the 'Storage Epochs & Payment' section that 'Storage is purchased in epochs (time periods)' and that 'storage can be extended by paying for additional epochs,' clearly indicating time-limited storage._
-
-#### ❌ walrus-overview-blob-id-vs-object-id
-
-> # Blob ID vs Sui Object ID in Walrus  These are two distinct identifiers in Walrus that serve different purposes. Here's a clear breakdown:  ## Blob ID  - **What it is**: A content-based identifier de...
-
-**Subjective grades:**
-- ✅ Explains that the same content uploaded twice produces the same blob ID but different Sui object IDs
-  - _The response explicitly demonstrates this in the 'Example Scenario' section where User A and User B both store 'Hello World', resulting in the same blob ID (0xabc123...) but different Sui object IDs (0xobj001... vs 0xobj002...). This is also reinforced in the key distinction table and the 'Why This Matters' section._
-- ✅ Clarifies that blob ID is used for reading content while Sui object ID is used for lifecycle operations like extend and delete
-  - _The response clearly states blob ID is 'used to read/download data' with a curl example, while Sui object ID is used for 'on-chain operations like extending storage duration, transferring ownership, or burning.' The comparison table explicitly shows 'Reading/downloading data' for blob ID vs 'On-chain management (ownership, lifecycle)' for Sui object ID._
-- ❌ Shows or describes the format difference: URL-safe base64 for blob ID vs 0x hex for object ID
-  - _The response does not describe the actual format differences between blob ID and Sui object ID. While it shows example identifiers (0xabc123... and 0xobj001...), both are presented with '0x' hex prefixes, and there is no mention of URL-safe base64 format for blob IDs or clarification that blob IDs use a different format than Sui object IDs._
-
-#### ❌ walrus-overview-tool-selection
-
-> # Uploading Files to Walrus with TypeScript  You should use the **Walrus TypeScript SDK (`@mysten/walrus`)**. It's the official client library designed for interacting with Walrus from TypeScript/Java...
-
-**Subjective grades:**
-- ✅ Recommends the TypeScript SDK as the primary tool for this use case
-  - _The response explicitly recommends '@mysten/walrus' TypeScript SDK as the primary tool in the opening statement and provides installation and usage examples._
-- ❌ Mentions the upload relay as needed for browser-based uploads since browsers cannot directly connect to storage nodes
-  - _The response does not mention the upload relay at all. While it provides browser file input examples and discusses browser uploads, it fails to explain that an upload relay is needed for browsers to upload files since browsers cannot directly connect to Walrus storage nodes._
-- ✅ Does not recommend the CLI or HTTP API as the primary tool for a TypeScript web app
-  - _The response does not mention or recommend the CLI or HTTP API. It focuses exclusively on the TypeScript SDK as the appropriate tool._
-
-#### ❌ walrus-overview-vs-s3
-
-> # Walrus vs AWS S3: Comparison Guide  ## Architecture Comparison  | Feature | **Walrus** | **AWS S3** | |---|---|---| | **Architecture** | Decentralized, built on Sui blockchain | Centralized, owned b...
-
-**Subjective grades:**
-- ❌ Highlights that Walrus data is public by default while S3 is private by default
-  - _The response does not explicitly state that Walrus data is public by default or that S3 is private by default. While the response mentions 'Access Control' differences, it does not clearly address the default privacy posture of either system._
-- ❌ Mentions that Walrus storage is time-limited (max ~2 years) while cloud storage is indefinite
-  - _The response mentions 'epochs' in the storage model and shows epoch-based pricing, but does not explicitly state that Walrus storage is time-limited to approximately 2 years maximum, nor does it compare this to S3's indefinite storage duration._
-- ✅ Recommends Walrus for use cases needing censorship resistance, verifiability, or decentralized availability
-  - _The response explicitly recommends Walrus for censorship resistance (section 1), verifiable storage/proof of availability (section 2), and decentralized availability through integration with Sui smart contracts and decentralized web hosting (sections 3-4)._
-
-#### ❌ walrus-cli-store-blob
-
-> # Storing Files on Walrus Using the CLI  You can store files on Walrus using the `walrus` CLI tool. Here's how:  ## Basic Store Command  ```bash walrus store <FILE_PATH> ```  For example:  ```bash wal...
-
-**Subjective grades:**
-- ✅ Shows a concrete example command like 'walrus store myfile.png --epochs 5'
-  - _The response includes the concrete example 'walrus store --epochs 5 my_file.txt' which directly matches the expected pattern._
-- ❌ Mentions that --epochs is mandatory with no default
-  - _The response states 'By default, files are stored for a certain number of epochs' which explicitly contradicts the expectation that --epochs is mandatory with no default. The response implies a default exists rather than stating --epochs is mandatory._
-- ❌ Mentions the difference between --deletable (default) and --permanent
-  - _The response does not mention --deletable or --permanent flags at all, nor does it explain any difference between storage types or permanence options._
-
-#### ❌ walrus-cli-read-blob
-
-> # Reading Blobs from Walrus  You can read blobs from Walrus and check their status using the Walrus HTTP API (aggregator and publisher endpoints).  ## Reading a Blob by Blob ID  Use the **aggregator**...
-
-**Subjective grades:**
-- ✅ Shows how to read a blob to stdout and how to save to a file using --out
-  - _The response explicitly shows both `walrus read <BLOB_ID>` for reading to stdout and `walrus read <BLOB_ID> --out output_file.txt` for saving to a file in the CLI section._
-- ✅ Shows how to check blob status by blob ID
-  - _The response includes `walrus blob-status <BLOB_ID>` command in the CLI section, demonstrating how to check blob status by blob ID._
-- ❌ Mentions the consistency check options (--strict-consistency-check or --skip-consistency-check)
-  - _The response does not mention or show the --strict-consistency-check or --skip-consistency-check options anywhere in the documentation._
-
-#### ❌ walrus-cli-json-mode
-
-> # Walrus CLI JSON Mode for CI/CD Automation  JSON mode enables machine-readable output from the Walrus CLI, perfect for scripting and CI/CD pipelines.  ## Enabling JSON Mode  Add the `--json` flag to ...
-
-**Subjective grades:**
-- ❌ Shows a concrete walrus json example with a JSON command object
-  - _The response does not show a `walrus json` command (a dedicated JSON command). Instead, it only demonstrates the `--json` flag added to existing commands like `walrus store --json`. There is no example of a standalone `walrus json` subcommand with a JSON command object._
-- ❌ Explains that JSON mode uses camelCase instead of kebab-case
-  - _The response does not explicitly explain or mention the camelCase vs kebab-case naming convention. While example JSON output uses camelCase (e.g., 'newlyCreated', 'blobObject'), there is no explanation contrasting this with kebab-case or discussing naming conventions in JSON mode._
-- ✅ Mentions that --json can be added to any standard command for JSON output
-  - _The response clearly states 'Add the `--json` flag to any Walrus CLI command' in the 'Enabling JSON Mode' section and demonstrates this with multiple examples (store, read, blob-status)._
-
-#### ❌ walrus-cli-configuration
-
-> # Configuring the Walrus CLI Client  The Walrus CLI client uses a configuration file to manage network settings. Here's how to set it up and switch between networks.  ## Configuration File Location  T...
-
-**Subjective grades:**
-- ✅ Shows how to download the config file using curl
-  - _The response includes a curl command to download the testnet configuration file from the official repository under the 'Getting the Correct Configuration' section._
-- ✅ Explains the --context flag for switching between testnet and mainnet
-  - _The response explicitly mentions and demonstrates the --context flag in Option 2, showing examples: 'walrus --context testnet <command>' and 'walrus --context mainnet <command>'._
-- ❌ Mentions the config file search locations (~/.config/walrus/, ~/.walrus/, or current directory)
-  - _The response only mentions ~/.config/walrus/client_config.yaml as the default configuration file location and does not mention ~/.walrus/ or current directory as alternative search locations._
-
-#### ✅ walrus-cli-common-mistakes
-
-> # "Cannot Find Gas Coin for Signer Address" Error  This error means your wallet doesn't have enough SUI tokens to pay for the transaction gas fees. Here's how to diagnose and fix it:  ## Common Causes...
-
-**Subjective grades:**
-- ✅ Explains that the wallet needs SUI for gas fees
-  - _The response explicitly states 'This error means your wallet doesn't have enough SUI tokens to pay for the transaction gas fees' in the opening, and provides multiple sections explaining SUI requirements for gas._
-- ✅ Mentions that WAL tokens are also needed for storage payment
-  - _Section 6 'Walrus-Specific: Insufficient WAL + SUI' explicitly states 'When storing blobs with Walrus, you need both: SUI — for gas fees, WAL — for storage payment' with code examples showing how to check WAL balance._
-- ✅ Provides a solution: fund the address with SUI (and on testnet, mention the faucet)
-  - _The response provides multiple funding solutions including the testnet faucet command 'sui client faucet', devnet faucet URL, and mainnet exchange purchase instructions. The Quick Diagnostic Checklist and Walrus-Specific Example both demonstrate faucet usage._
-
-</details>
-
-<details><summary><b>sonnet</b>: 0/9 evals passed (0%)</summary>
-
-- Deterministic checks: 0/0 (–)
-- Subjective grades: 13/27 (48%)
-
-#### ❌ walrus-overview-what-is-walrus
-
-> # Walrus: Decentralized Storage on Sui  ## What is Walrus?  Walrus is a **decentralized blob storage and availability system** designed specifically for storing large binary objects (blobs) — such as ...
-
-**Subjective grades:**
-- ❌ Explains the three-layer architecture: client layer, storage node layer, and Sui blockchain layer
-  - _While the response describes storage nodes and Sui's role, it does not explicitly identify or label a 'three-layer architecture' with these three distinct layers named as such. The response discusses components but does not frame them as a formal three-layer architecture._
-- ❌ Mentions that blobs are public by default and encryption is needed for privacy
-  - _The response does not mention anything about blobs being public by default or discuss encryption requirements for privacy. This topic is entirely absent._
-- ✅ Explains that storage is time-limited and measured in epochs
-  - _The response explicitly states 'Storage epochs define time periods for which storage is guaranteed' and mentions storage periods in the context of PoA certificates, clearly indicating storage is time-limited and epoch-based._
-
-#### ❌ walrus-overview-blob-id-vs-object-id
-
-> # Blob ID vs Sui Object ID in Walrus  These are two **distinct identifiers** that serve completely different purposes. Let me break them down clearly.  ---  ## Blob ID  The **blob ID is a cryptographi...
-
-**Subjective grades:**
-- ✅ Explains that the same content uploaded twice produces the same blob ID but different Sui object IDs
-  - _The response explicitly demonstrates this in the 'Same file uploaded twice' scenario section, showing Upload #1 and Upload #2 both producing the same blob ID (0x4a7b3c...) but different Sui object IDs (0x9f2e1a... vs 0x7c3b2f...). This is also reinforced in the comparison table._
-- ✅ Clarifies that blob ID is used for reading content while Sui object ID is used for lifecycle operations like extend and delete
-  - _The response clearly states 'Use BLOB ID to READ data' with a readBlob example, and 'Use SUI OBJECT ID for on-chain operations' with an extendBlob example. The key characteristics sections also explicitly mention blob ID is for 'retrieve data' while Sui object ID is for 'on-chain operations (extend, delete, transfer)'._
-- ❌ Shows or describes the format difference: URL-safe base64 for blob ID vs 0x hex for object ID
-  - _The response shows example formats (0x4a7b3c... for blob ID and 0x9f2e1a... for Sui object ID) but does not explicitly state or describe the format difference. Both examples are shown in 0x hex format, and there is no mention of URL-safe base64 encoding for blob IDs or any explanation of the actual format specifications._
-
-#### ❌ walrus-overview-tool-selection
-
-> ## Uploading Files to Walrus from a TypeScript Web App  For a TypeScript web app, you should use the **Walrus TypeScript/JavaScript SDK** (`@mysten/walrus`).  ---  ## Installation  ```bash npm install...
-
-**Subjective grades:**
-- ✅ Recommends the TypeScript SDK as the primary tool for this use case
-  - _The response clearly and explicitly recommends the TypeScript/JavaScript SDK (@mysten/walrus) as the primary tool in the opening sentence and throughout the documentation._
-- ❌ Mentions the upload relay as needed for browser-based uploads since browsers cannot directly connect to storage nodes
-  - _The response does not mention the upload relay at all. While it claims the SDK is 'browser compatible' and 'works directly in web apps', it does not explain the role of the upload relay in handling browser uploads to Walrus, which is a critical technical detail for this use case._
-- ✅ Does not recommend the CLI or HTTP API as the primary tool for a TypeScript web app
-  - _The response does not recommend the CLI or HTTP API as primary tools. It explicitly states 'No CLI needed' and focuses entirely on the TypeScript SDK as the solution._
-
-#### ❌ walrus-overview-vs-s3
-
-> # Walrus vs AWS S3: A Comparison  ## What is Walrus?  Walrus is a **decentralized storage network** built on Sui blockchain, designed for storing large binary objects (blobs) with cryptographic guaran...
-
-**Subjective grades:**
-- ✅ Highlights that Walrus data is public by default while S3 is private by default
-  - _The comparison table explicitly states 'Public by default, on-chain logic' for Walrus and 'IAM policies, private by default' for S3. This distinction is clearly articulated._
-- ❌ Mentions that Walrus storage is time-limited (max ~2 years) while cloud storage is indefinite
-  - _The response mentions epochs and that users 'pay for storage duration in epochs (not ongoing)' with an example of '52 epochs (~1 year of storage)', but does not explicitly state the maximum time limit for Walrus storage (approximately 2 years) or contrast this with S3's indefinite storage capability._
-- ✅ Recommends Walrus for use cases needing censorship resistance, verifiability, or decentralized availability
-  - _The response explicitly recommends Walrus for: (1) censorship-resistant publishing with examples like whistleblowing documents, (2) smart contract verified content with on-chain availability proofs, (3) NFTs with verifiable integrity, and (4) DeFi protocol data with integrity proofs. These directly address censorship resistance, verifiability, and decentralized availability._
-
-#### ❌ walrus-cli-store-blob
-
-> # Storing a File on Walrus Using the CLI  You can store a file on Walrus using the `walrus store` command. Here are the main ways to do it:  ## Basic Store Command  ```bash walrus store <FILE_PATH> ``...
-
-**Subjective grades:**
-- ✅ Shows a concrete example command like 'walrus store myfile.png --epochs 5'
-  - _The response includes the concrete example 'walrus store myfile.txt --epochs 5' which matches the expected format._
-- ❌ Mentions that --epochs is mandatory with no default
-  - _The response explicitly states '--epochs <N>' has a 'default is 1', which contradicts the expectation that it is mandatory with no default._
-- ❌ Mentions the difference between --deletable (default) and --permanent
-  - _The response does not mention or discuss --deletable or --permanent flags at all._
-
-#### ❌ walrus-cli-read-blob
-
-> # Reading a Blob from Walrus and Checking Its Status  ## Overview  Walrus provides two main ways to interact with blobs: 1. **Publisher/Aggregator REST API** - Simple HTTP endpoints 2. **Walrus Client...
-
-**Subjective grades:**
-- ❌ Shows how to read a blob to stdout and how to save to a file using --out
-  - _The response shows REST API curl commands and a CLI command 'walrus blob-status' but does not explicitly show a 'walrus read' or 'walrus blob read' command with --out flag for saving to a file. The curl examples are for REST API, not the CLI tool with --out option._
-- ✅ Shows how to check blob status by blob ID
-  - _The response clearly shows the 'walrus blob-status --blob-id <BLOB_ID>' command in section 2, with example output and explanation._
-- ❌ Mentions the consistency check options (--strict-consistency-check or --skip-consistency-check)
-  - _The response does not mention or reference --strict-consistency-check or --skip-consistency-check options anywhere in the documentation._
-
-#### ❌ walrus-cli-json-mode
-
-> # Using Walrus JSON Mode in CI/CD Pipelines  JSON mode makes Walrus output machine-parseable, perfect for automation scripts.  ## Enabling JSON Mode  Add the `--json` flag to any Walrus CLI command:  ...
-
-**Subjective grades:**
-- ❌ Shows a concrete walrus json example with a JSON command object
-  - _The response demonstrates the --json flag added to standard commands (e.g., `walrus --json store`), but does not show a separate `walrus json` command with a JSON command object as a distinct feature. The expectation requires a concrete example of a `walrus json` subcommand, which is not present._
-- ❌ Explains that JSON mode uses camelCase instead of kebab-case
-  - _The response shows camelCase in JSON output examples (e.g., `newlyCreated`, `blobObject`, `blobId`, `storedEpoch`) but never explicitly explains or mentions that JSON mode uses camelCase instead of kebab-case. This distinction is not stated anywhere in the response._
-- ✅ Mentions that --json can be added to any standard command for JSON output
-  - _The response explicitly states 'Add the `--json` flag to any Walrus CLI command' in the 'Enabling JSON Mode' section and demonstrates this pattern across multiple commands (store, read, blob-status, info)._
-
-#### ❌ walrus-cli-configuration
-
-> # Configuring the Walrus CLI Client  ## Configuration File Location  The Walrus CLI looks for its configuration file at: ``` ~/.config/walrus/client_config.yaml ```  You can also specify a custom path...
-
-**Subjective grades:**
-- ❌ Shows how to download the config file using curl
-  - _The response does not include any instructions or examples for downloading the config file using curl. It only shows the file location and structure._
-- ✅ Explains the --context flag for switching between testnet and mainnet
-  - _The response explicitly explains the --context CLI flag under 'Option 3: Use --context CLI flag' with clear examples showing how to use it to switch between networks._
-- ❌ Mentions the config file search locations (~/.config/walrus/, ~/.walrus/, or current directory)
-  - _The response only mentions one config file location (~/.config/walrus/client_config.yaml) and does not mention ~/.walrus/ or the current directory as alternative search locations._
-
-#### ❌ walrus-cli-common-mistakes
-
-> ## "Cannot find gas coin for signer address" Error  This error means your wallet **doesn't have enough SUI tokens** to pay for the transaction gas fees.  ---  ## Common Causes & Solutions  ### 1. 🪙 W...
-
-**Subjective grades:**
-- ✅ Explains that the wallet needs SUI for gas fees
-  - _The response clearly states 'your wallet doesn't have enough SUI tokens to pay for the transaction gas fees' and provides multiple sections explaining this requirement._
-- ❌ Mentions that WAL tokens are also needed for storage payment
-  - _The response does not mention WAL tokens at all. It focuses exclusively on SUI for gas fees and does not address storage payment requirements with WAL tokens._
-- ✅ Provides a solution: fund the address with SUI (and on testnet, mention the faucet)
-  - _The response provides multiple solutions including checking balance, switching addresses, and specifically mentions the testnet faucet with both CLI and web methods for obtaining SUI._
-
-</details>
+| AgentPrompt baseline (gpt4o) | 19 | 1 | 9 | 9 | – | 43/65 | 66% |
+| AgentPrompt baseline (opus) | 19 | 17 | 2 | 0 | – | 121/123 | 98% |
+| AgentPrompt baseline (sonnet) | 19 | 16 | 3 | 0 | – | 115/123 | 93% |
+| AgentPrompt +skills (gpt4o) | 19 | 8 | 5 | 6 | – | 74/85 | 87% |
+| AgentPrompt +skills (opus) | 19 | 15 | 4 | 0 | – | 118/123 | 96% |
+| AgentPrompt +skills (sonnet) | 19 | 13 | 6 | 0 | – | 116/123 | 94% |
+
+### Models
+
+| Label | Provider | Model ID | Judge Model |
+|-------|----------|----------|-------------|
+| gpt-4o | openai | `gpt-4o` | `claude-haiku-4-5-20251001` |
+| claude-opus-4-6 | anthropic | `claude-opus-4-6` | `claude-haiku-4-5-20251001` |
+| claude-sonnet-4-6 | anthropic | `claude-sonnet-4-6` | `claude-haiku-4-5-20251001` |
 
 ---
 
@@ -383,38 +25,38 @@
 
 | Prompt | Source Page | gpt4o | opus | sonnet |
 |--------|-----------|:------:|:------:|:------:|
-| automated-address-management | develop/manage-packages/automated-address-management | ❌ 5/6 | ❌ 5/6 | ✅ 6/6 |
+| automated-address-management | develop/manage-packages/automated-address-management | ⚠️ | ❌ 5/6 | ❌ 5/6 |
 | common-errors | develop/testing-debugging/common-errors | ❌ 5/6 | ✅ 6/6 | ✅ 6/6 |
-| custom-policies | develop/publish-upgrade-packages/custom-policies | ❌ 5/6 | ✅ 6/6 | ✅ 6/6 |
-| data-serving | develop/accessing-data/data-serving | ❌ 5/6 | ✅ 6/6 | ✅ 6/6 |
-| display-overview | develop/objects/display/display-overview | ❌ 5/6 | ✅ 6/6 | ✅ 6/6 |
-| gas-smashing | develop/transaction-payment/gas-smashing | ❌ 5/6 | ✅ 6/6 | ✅ 6/6 |
-| hello-world | getting-started/onboarding/hello-world | ✅ 7/7 | ✅ 7/7 | ✅ 7/7 |
-| move-package-management | develop/manage-packages/move-package-management | ❌ 6/7 | ✅ 7/7 | ❌ 6/7 |
-| observability | operators/observability | ❌ 5/6 | ✅ 6/6 | ✅ 6/6 |
-| ptb-inputs-results | develop/transactions/ptbs/inputs-and-results | ❌ 3/7 | ✅ 7/7 | ✅ 7/7 |
-| publish-overview | develop/publish-upgrade-packages/index | ❌ 5/7 | ✅ 7/7 | ✅ 7/7 |
-| query-with-graphql | develop/accessing-data/graphql/query-with-graphql | ❌ 6/7 | ✅ 7/7 | ✅ 7/7 |
-| scenario-testing | getting-started/examples/scenario-testing | ❌ 2/7 | ✅ 7/7 | ❌ 6/7 |
+| custom-policies | develop/publish-upgrade-packages/custom-policies | ❌ 4/6 | ✅ 6/6 | ✅ 6/6 |
+| data-serving | develop/accessing-data/data-serving | ⚠️ | ✅ 6/6 | ❌ 0/6 |
+| display-overview | develop/objects/display/display-overview | ❌ 3/6 | ✅ 6/6 | ✅ 6/6 |
+| gas-smashing | develop/transaction-payment/gas-smashing | ⚠️ | ✅ 6/6 | ✅ 6/6 |
+| hello-world | getting-started/onboarding/hello-world | ❌ 6/7 | ✅ 7/7 | ✅ 7/7 |
+| move-package-management | develop/manage-packages/move-package-management | ⚠️ | ✅ 7/7 | ✅ 7/7 |
+| observability | operators/observability | ⚠️ | ✅ 6/6 | ✅ 6/6 |
+| ptb-inputs-results | develop/transactions/ptbs/inputs-and-results | ❌ 5/7 | ✅ 7/7 | ✅ 7/7 |
+| publish-overview | develop/publish-upgrade-packages/index | ❌ 6/7 | ✅ 7/7 | ✅ 7/7 |
+| query-with-graphql | develop/accessing-data/graphql/query-with-graphql | ⚠️ | ✅ 7/7 | ✅ 7/7 |
+| scenario-testing | getting-started/examples/scenario-testing | ❌ 0/7 | ✅ 7/7 | ✅ 7/7 |
 | sui-install | getting-started/onboarding/sui-install | ✅ 6/6 | ✅ 6/6 | ✅ 6/6 |
-| testing | develop/testing-debugging/testing | ❌ 3/6 | ✅ 6/6 | ✅ 6/6 |
-| upgrade | develop/publish-upgrade-packages/upgrade | ❌ 5/7 | ❌ 6/7 | ✅ 7/7 |
-| using-grpc | develop/accessing-data/grpc/using-grpc | ❌ 4/6 | ✅ 6/6 | ❌ 5/6 |
-| walrus-sites | sui-stack/walrus/sui-stack-walrus-sites | ❌ 4/7 | ✅ 7/7 | ✅ 7/7 |
-| walrus-storage | sui-stack/walrus/sui-stack-walrus | ❌ 5/7 | ❌ 6/7 | ❌ 6/7 |
+| testing | develop/testing-debugging/testing | ❌ 5/6 | ✅ 6/6 | ✅ 6/6 |
+| upgrade | develop/publish-upgrade-packages/upgrade | ❌ 3/7 | ❌ 6/7 | ✅ 7/7 |
+| using-grpc | develop/accessing-data/grpc/using-grpc | ⚠️ | ✅ 6/6 | ✅ 6/6 |
+| walrus-sites | sui-stack/walrus/sui-stack-walrus-sites | ⚠️ | ✅ 7/7 | ✅ 7/7 |
+| walrus-storage | sui-stack/walrus/sui-stack-walrus | ⚠️ | ✅ 7/7 | ❌ 6/7 |
 
 ### Per-Model Detail
 
-<details><summary><b>gpt4o</b>: 2/19 prompts passed (11%)</summary>
+<details><summary><b>gpt4o</b>: 1/19 prompts passed (5%)</summary>
 
-- Deterministic checks: 44/48 (92%)
-- Subjective grades: 47/75 (63%)
+- Deterministic checks: 22/26 (85%)
+- Subjective grades: 21/39 (54%)
 
 #### ✅ sui-install
 **Page:** getting-started/onboarding/sui-install
 **Prompt:** Set up this machine for Sui development: Install the Sui CLI with curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/install.sh | sh, then run suiup install sui@testnet to get the Testnet-compatible toolchain. Run sui client to generate your keys and config, then prompt me to visit faucet.sui.io, enter the generated address, and fund it with test tokens.
 
-> To set up your machine for Sui development, follow these detailed instructions:  1. **Install Sui CLI**:    Open your terminal and run the following command to install the Sui CLI. This will download and execute the installation script for `suiup`, w...
+> Here’s a detailed guide to set up your machine for Sui development, specifically for working with the Sui testnet:  ### Step 1: Install Sui CLI  1. **Open Terminal**: Use your terminal application to run the following command. This command downloads ...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "suiup"
@@ -423,17 +65,17 @@
 
 **Subjective grades:**
 - ✅ Provides a clear step-by-step setup sequence starting with installing suiup
-  - _The response provides a well-organized 5-step sequence beginning with the exact curl command for installing suiup, followed by installing sui@testnet, generating keys, funding the address, and verification._
+  - _The response explicitly provides Step 1 with the curl command to install suiup, followed by Step 2 to run `suiup install sui@testnet`. The sequence is clearly organized and follows the prompt's specified order._
 - ✅ Mentions generating keys or wallet configuration
-  - _Step 3 explicitly states 'Generate Keys and Configure Sui Client' and includes the `sui client` command with clear explanation that it will 'generate the default keypair' and 'output your new address.'_
+  - _Step 2 explicitly covers running `sui client` to generate keys and configuration, and mentions the configuration file location (~/.sui/sui_config). It also provides a command to view generated addresses._
 - ✅ Includes instructions about funding the address with test tokens
-  - _Step 4 explicitly provides faucet.sui.io instructions and clearly directs the user to enter their generated address and request test token funding. However, the prompt specifically asks to 'prompt me to visit faucet.sui.io' - the response informs the user to visit but does not explicitly prompt/ask the user as a direct call-to-action (e.g., 'Please now visit...' or 'Would you like me to...?'). The instruction is provided but lacks the interactive prompting element requested._
+  - _Step 3 provides clear instructions to visit faucet.sui.io, enter the generated address, and request test tokens. However, the prompt specifically asked to 'prompt me to visit faucet.sui.io' - the response informs about the faucet but does not directly prompt the user in an interactive manner as a strict interpretation would require._
 
-#### ✅ hello-world
+#### ❌ hello-world
 **Page:** getting-started/onboarding/hello-world
 **Prompt:** Clone the https://github.com/MystenLabs/sui-stack-hello-world example app, build and publish the Move package at move/hello-world to Testnet, then call its entry function and show me the resulting object and transaction on SuiVision.
 
-> To accomplish this task, we will clone the `sui-stack-hello-world` repository, build, and publish the Move package to the Sui Testnet. Then, we'll call the package's entry function, and finally inspect the resulting transaction on SuiVision. Follow t...
+> Here’s how to clone the repository, build, publish the Move package, and interact with it on the Sui Testnet. Follow these steps:  ### Prerequisites  1. **Install Sui CLI**: Ensure you have the Sui CLI installed. If not, install it by following the i...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "sui-stack-hello-world"
@@ -442,60 +84,60 @@
 
 **Subjective grades:**
 - ✅ Provides the git clone command for the repo
-  - _Step 1 explicitly provides the correct git clone command: `git clone https://github.com/MystenLabs/sui-stack-hello-world.git`_
+  - _The response explicitly provides the correct git clone command: `git clone https://github.com/MystenLabs/sui-stack-hello-world.git` and includes navigation to the correct subdirectory._
 - ✅ Shows the build and publish commands
-  - _Step 2 shows `sui move build` and Step 3 shows `sui client publish --gas-budget <GAS_BUDGET>` for building and publishing to Testnet_
-- ✅ Explains how to call the entry function after publishing
-  - _Step 4 provides the `sui client call` command with package-id, module-name, function-name parameters to call the entry function_
+  - _The response provides both `sui move build` and `sui client publish --gas-budget 10000` commands with clear explanations._
+- ❌ Explains how to call the entry function after publishing
+  - _While the response provides a template command `sui client call --function create_hello --module <module_name> --package <package_id> --args <arguments> --gas-budget 1000`, it uses a placeholder function name 'create_hello' without verifying this matches the actual entry function in the sui-stack-hello-world repository. The explanation lacks specificity about the actual entry function name and required arguments for this particular example app._
 - ✅ Mentions viewing the result on SuiVision or a block explorer
-  - _Step 5 explicitly instructs to go to SuiVision Testnet Explorer and search for the transaction digest to view results_
+  - _The response explicitly mentions SuiVision (https://suivision.io) and provides clear instructions on how to search for and review transaction details and objects using transaction IDs._
 
 #### ❌ testing
 **Page:** develop/testing-debugging/testing
 **Prompt:** Add Move unit tests for this package's public functions, including success, unauthorized, and edge cases.
 
-> To add Move unit tests for a Sui package, you need to follow these steps. I'll guide you through each step with code examples to cover public functions, including success, unauthorized, and edge case scenarios.  ### Step 1: Set Up Your Testing Enviro...
+> To add unit tests for a Move package on the Sui blockchain, you will need to create a test module where you can write test functions. These functions will help ensure that your package's public functions behave correctly under various scenarios, such...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "#[test]"
-- ❌ `regex`: No match for /test_scenario|unit_test/i
+- ✅ `regex`: Matched /test_scenario|unit_test/i
 
 **Subjective grades:**
 - ✅ Shows the #[test] attribute pattern for writing Sui Move tests
-  - _The response explicitly demonstrates #[test] attribute usage in multiple code examples (test_transfer_coin_success, test_admin_only_function_unauthorized, test_transfer_coin_with_zero_amount)._
+  - _The response explicitly demonstrates the #[test] attribute in multiple code examples (e.g., '#[test] fun test_public_function_1_success()')._
 - ✅ Explains or demonstrates success-case testing patterns
-  - _The response includes a dedicated 'Test for Successful Execution' section with test_transfer_coin_success that demonstrates setting up mocks, calling functions, and asserting expected outcomes._
+  - _The response includes a dedicated success test example with comments explaining setup, function call, and assertions for verifying expected results._
 - ❌ Mentions #[expected_failure] or assert macros for failure testing
-  - _The response uses #[should_fail] attribute instead of #[expected_failure], and while it mentions assert! in comments, it does not explicitly demonstrate assert! macros for failure testing in the actual test code examples._
-- ❌ References test_scenario or unit_test module for Sui-specific testing
-  - _The response does not reference test_scenario or unit_test modules. It uses non-standard imports like 'use 0x1::Test' and 'MockTxContext' which are not documented Sui testing frameworks, and makes no mention of the official Sui test_scenario module._
+  - _The response mentions 'assert_abort_code()' in a comment but does not explain #[expected_failure] attribute or demonstrate proper failure-case testing with assert macros. The assert_abort_code reference appears as placeholder text without proper explanation._
+- ✅ References test_scenario or unit_test module for Sui-specific testing
+  - _The response explicitly imports and references 'sui::test_scenario' in the example code module._
 
 #### ❌ scenario-testing
 **Page:** getting-started/examples/scenario-testing
 **Prompt:** Create scenario tests for this Sui workflow, including multiple users, object ownership changes, and expected transaction failures.
 
-> Creating scenario tests for a Sui workflow involves simulating different interactions with the blockchain, such as multiple users participating, the transfer of objects between owners, and intentionally causing transaction failures to verify robustne...
+> Creating scenario tests for a Sui workflow involves considering multiple users, simulating interactions with objects, and checking for expected outcomes, including transactional successes and failures. Below is a step-by-step guide that includes the ...
 
 **Deterministic checks:**
-- ✅ `contains`: Found "test_scenario"
-- ✅ `regex`: Matched /#\[test\]/i
+- ❌ `contains`: Missing "test_scenario"
+- ❌ `regex`: No match for /#\[test\]/i
 - ❌ `regex`: No match for /next_tx|next_epoch/i
 
 **Subjective grades:**
 - ❌ Uses or references sui::test_scenario for multi-transaction workflows
-  - _The response mentions 'scenario tests' generically but never explicitly references or uses the sui::test_scenario module, which is the standard Sui framework for multi-transaction testing. The Move code examples do not import or utilize test_scenario._
+  - _The response mentions that 'Move language don't inherently support test scripts' and pivots to Rust/end-to-end testing instead of using sui::test_scenario, which is the standard Sui Move testing framework. No actual use or reference to sui::test_scenario module appears in the code examples._
 - ❌ Shows how to switch between different senders/users in a scenario
-  - _While the response creates multiple test accounts (alice, bob) using a non-existent TestAccount API, it does not demonstrate the actual sui::test_scenario mechanism for switching senders between transactions (e.g., ctx.next_tx(sender))._
+  - _While the Rust example creates two users (user1 and user2), it does not demonstrate switching between senders within a scenario context. The code shows separate transactions but not the scenario-based switching mechanism that sui::test_scenario provides (e.g., scenario.next_tx(address))._
 - ❌ Demonstrates testing object ownership or state changes across transactions
-  - _The code shows ownership changes within a single test function but does not demonstrate state persistence and verification across multiple sequential transactions, which is what sui::test_scenario enables._
+  - _The Move module example is incomplete and the transfer_ownership function signature is incorrect (doesn't actually transfer ownership properly). The Rust test attempts to show ownership changes but lacks clear verification of state changes across multiple transactions, and the Move code doesn't properly implement ownership transfers using Sui's transfer primitives._
 - ❌ Mentions or shows expected-failure patterns (e.g., #[expected_failure] or abort codes)
-  - _While the response includes a commented reference to 'assert_abort_code!' and mentions error codes, it does not show actual #[expected_failure] attribute usage or demonstrate proper abort code verification patterns that would be used in Sui Move tests._
+  - _The response does not use #[expected_failure] annotations or show Move-level abort codes. It only includes a Rust assertion (assert!(illegal_transfer.is_err())) which is not the proper pattern for testing expected failures in Sui Move tests._
 
 #### ❌ common-errors
 **Page:** develop/testing-debugging/common-errors
 **Prompt:** Debug this Sui transaction failure. Inspect object refs, gas objects, ownership, versions, and suggest the minimal code or PTB change to make it execute.
 
-> To debug a Sui transaction failure effectively, you'll need to follow a systematic approach to inspect the key components involved in the transaction. Here's how you can proceed:  ### Step 1: Gather Information First, you'll want to gather detailed i...
+> To effectively assist you with debugging a Sui transaction failure, I'll need you to focus on specific information related to the transaction. Here is a systematic approach to identify common issues and suggest possible solutions:  ### Step 1: Gather...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /object|version|ownership/i
@@ -503,61 +145,61 @@
 
 **Subjective grades:**
 - ✅ Provides a systematic debugging approach for Sui transaction failures
-  - _Response includes a clear 7-step systematic approach (Gather Information, Inspect Object References, Check Gas Object, Validate Ownership, Check Errors, Suggested Fixes, Retest)_
+  - _Response explicitly structures debugging into 8 sequential steps (Gather Details, Check Object References, Validate Gas Object, Review Ownership, Examine Move Function, Review Error Message, Implement Minimal Changes, Retest), providing a clear systematic methodology._
 - ✅ Mentions checking object versions and ownership as common failure sources
-  - _Step 2 explicitly checks object versions and versions matching. Step 4 validates ownership. Both are clearly identified as potential issues._
+  - _Step 2 explicitly addresses 'Versioning Conflicts' and version mismatches. Step 4 explicitly covers 'Ownership Errors' and ownership validation. Both are clearly identified as sources of transaction failures._
 - ✅ Discusses gas-related issues (insufficient gas, gas coin conflicts)
-  - _Step 3 dedicates a section to checking gas objects, verifying sufficient SUI balance, and ownership. 'Insufficient Gas' is also mentioned in Step 5 error types._
+  - _Step 3 'Validate Gas Object' explicitly covers 'Sufficient Balance' (insufficient gas) and 'Ownership' (gas coin ownership validation). However, 'gas coin conflicts' as a specific concept is not explicitly mentioned, only ownership is addressed._
 - ❌ Suggests concrete fixes rather than just diagnosis
-  - _The 'Minimal Code/PTB Change Example' provides a Move function that doesn't address actual Sui transaction debugging fixes. The code snippet uses a non-existent `fetch_object` function and doesn't show PTB adjustments or concrete transaction-level changes. Fixes listed are generic (update versions, increase gas, transfer ownership) without concrete implementation examples for the actual transaction/PTB structure._
+  - _Response primarily provides diagnostic steps and general guidance. The 'Implement Minimal Changes' section and code example are vague and generic. No concrete PTB (Programmable Transaction Block) changes are provided, no specific code modifications addressing actual failure scenarios are shown, and solutions remain at the conceptual level rather than providing actionable minimal code fixes._
 
 #### ❌ publish-overview
 **Page:** develop/publish-upgrade-packages/index
 **Prompt:** Prepare this package for Mainnet publishing: verify tests, dependencies, addresses, upgrade policy, gas requirements, signer/custody plan, and produce a launch checklist.
 
-> Certainly! Preparing a package for Mainnet publishing on the Sui blockchain involves several crucial steps to ensure everything is in order. Here's a comprehensive checklist to follow:  ### 1. **Verify Tests**  - **Write and Run Unit Tests**: Ensure ...
+> To prepare your package for Mainnet publishing on the Sui blockchain, you'll need to follow a structured process to ensure that everything is in order. Here's a step-by-step guide to help you through this:  ### 1. Verify Tests  **Step 1**: Ensure you...
 
 **Deterministic checks:**
-- ❌ `regex`: No match for /sui\s+client\s+publish|sui\s+move\s+build/i
+- ✅ `regex`: Matched /sui\s+client\s+publish|sui\s+move\s+build/i
 - ✅ `regex`: Matched /UpgradeCap|upgrade/i
 - ✅ `regex`: Matched /mainnet|Mainnet/i
 
 **Subjective grades:**
 - ✅ Includes a checklist or step-by-step process for publishing
-  - _The response includes a comprehensive checklist under 'Launch Checklist Production' with checkboxes for each major item, and uses numbered sections (1-7) providing a clear step-by-step process._
+  - _Response explicitly provides a 'Launch Checklist' section with Pre-Launch, Launch, and Post-Launch checklists in checkbox format, plus step-by-step instructions throughout._
 - ✅ Mentions verifying tests pass before publishing
-  - _Section 1 'Verify Tests' explicitly covers running tests with `sui move test`, and the checklist includes '[ ] All tests pass' as the first item._
+  - _Section 1 'Verify Tests' explicitly states to run `sui move test` and 'Ensure all tests are passing.' This is also repeated in the Pre-Launch checklist._
 - ❌ Discusses the UpgradeCap and upgrade policy considerations
-  - _Section 4 mentions 'Upgrade Policy' and defines upgrade policies generally, but does not explicitly mention 'UpgradeCap' (the actual Sui primitive object that controls package upgrades) or provide specific technical guidance on how to handle the UpgradeCap object._
+  - _Response mentions 'Upgrade Policy' and 'Upgrade Path' generically, but does not explicitly discuss UpgradeCap, how to handle it, or its specific role in Sui's upgrade mechanism._
 - ✅ Addresses gas requirements or cost estimation
-  - _Section 5 'Gas Requirements' explicitly addresses estimating gas consumption with example CLI command and mentions budgeting gas for initial deployment and ongoing execution._
+  - _Section 5 'Gas Requirements' explicitly discusses simulating gas usage with `sui client dry-run`, setting appropriate gas budgets, and informing users of costs._
 
 #### ❌ upgrade
 **Page:** develop/publish-upgrade-packages/upgrade
 **Prompt:** Prepare an upgrade for this published Sui package. Check compatibility rules, build the upgrade transaction, identify the UpgradeCap, and document the exact upgrade steps.
 
-> To prepare an upgrade for a published Sui package, you must follow specific steps carefully to ensure compatibility and a smooth upgrade process. The process involves checking compatibility rules, building the upgrade transaction, identifying the `Up...
+> To upgrade a published package on the Sui blockchain, you'll need to follow these steps:  ### Step 1: Verify Compatibility Before proceeding with an upgrade, ensure that the new version of your package is compatible with the old version following Sui...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "UpgradeCap"
 - ✅ `regex`: Matched /compatible|additive|dependency/i
-- ✅ `regex`: Matched /sui\s+client\s+upgrade/i
+- ❌ `regex`: No match for /sui\s+client\s+upgrade/i
 
 **Subjective grades:**
 - ✅ Explains the role of the UpgradeCap object
-  - _Step 3 explicitly states: 'The UpgradeCap is a special object that grants permission to upgrade a package on Sui' and provides instructions for identifying it._
+  - _Step 3 explicitly states that 'The UpgradeCap allows you to authorize package upgrades' and provides instructions on how to locate it. The response clearly identifies it as necessary for authorization._
 - ❌ Describes compatibility rules for package upgrades (compatible, additive, or dependency-only)
-  - _Step 1 mentions generic compatibility concepts (interface, data structures, initialization) but does not explicitly describe the three specific Sui upgrade policy types: compatible, additive, or dependency-only. These technical categories are not mentioned._
-- ✅ Shows the upgrade command or transaction construction
-  - _Step 4 provides the CLI command: 'sui client upgrade --package-id <current_package_id> --cap <upgrade_cap_id>' which demonstrates upgrade transaction construction._
+  - _While Step 1 lists some compatibility rules (can add modules, add entry functions, add struct fields), it does not explicitly mention the three standard Sui upgrade compatibility modes: 'compatible', 'additive', or 'dependency-only'. The response describes individual constraints but not the formal upgrade policies themselves._
+- ❌ Shows the upgrade command or transaction construction
+  - _Step 4 shows `sui client publish --package-path <path-to-your-package> --upgradeable`, which is incorrect for upgrading an already-published package. This is a publish command, not an upgrade command. The actual upgrade would use `sui client upgrade` or similar. Step 5 shows an unrelated `transfer-sui` command, which is not the correct upgrade transaction._
 - ❌ Mentions that the original package version is preserved on-chain
-  - _The response does not mention or explain that the original package version remains on-chain after an upgrade. This is a key aspect of Sui's upgrade mechanism that is completely absent._
+  - _The response does not mention that the original package version remains on-chain after an upgrade. This is a critical Sui-specific behavior that should be explicitly documented but is completely absent from the response._
 
 #### ❌ custom-policies
 **Page:** develop/publish-upgrade-packages/custom-policies
 **Prompt:** Create an operator runbook for package upgrades and admin actions: required caps, signer/custody steps, exact commands, verification, and rollback/communication plan.
 
-> Creating an operator runbook for package upgrades and admin actions on the Sui blockchain involves several detailed steps. This runbook will guide you through the required capabilities, signer and custody steps, exact commands needed, verification pr...
+> Creating an operator runbook for package upgrades and admin actions on the Sui blockchain involves multiple steps. This runbook will focus on ensuring a smooth process with clear instructions for each phase, including upgrades, necessary capabilities...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /UpgradeCap|AdminCap|cap/i
@@ -565,39 +207,39 @@
 
 **Subjective grades:**
 - ✅ Provides a structured runbook format with clear steps
-  - _Response uses a well-organized numbered format with clear sections (Preparation, Signer/Custody Steps, Package Upgrade Steps, Verification, Rollback Plan, Communication Plan) that follow a logical progression for executing package upgrades._
-- ✅ Addresses capability (Cap) management and access control
-  - _Response explicitly identifies and names required capabilities (`UpgradeCapability` and `AdminCapability`), describes their purposes, and specifies that the signer must possess the `UpgradeCapability` for upgrades._
+  - _Response includes numbered sections (1-8) with clear hierarchical organization covering preparations, capabilities, signer/custody, commands, verification, rollback, communication, and monitoring._
+- ❌ Addresses capability (Cap) management and access control
+  - _Response mentions 'Upgrade Capability' in section 2 but only states to 'Ensure you have the upgrade capability' without explaining what it is, how to obtain it, how to verify ownership, or how to manage it. No explicit Cap object handling or access control patterns are detailed._
 - ✅ Includes verification steps to confirm operations succeeded
-  - _Section 4 explicitly covers verification with specific commands (`sui client package --object-id <package_id>`) and instructions to validate new functionalities through test transactions._
+  - _Section 5 provides verification steps including checking package status with `sui client object <new_package_id>` and validating expected changes like version number and schema._
 - ❌ Mentions security considerations such as multisig, key management, or custody
-  - _While multisig is mentioned once in passing ('if multisig is employed'), there are no concrete details about multisig implementation, key management best practices, custody solutions beyond a parenthetical reference to ledger devices, or security protocols. Custody considerations are referenced minimally without actionable security guidance._
+  - _While section 3 briefly mentions 'multisig' and 'private key storage,' the treatment is superficial. No specific custody procedures, multisig workflow details, or concrete key management practices (e.g., hardware wallets, threshold signatures, approval workflows) are provided._
 
 #### ❌ display-overview
 **Page:** develop/objects/display/display-overview
 **Prompt:** Find Display V1 usage in this package or docs and migrate it to Display V2 and display_registry patterns.
 
-> To migrate from Display V1 to Display V2 and incorporate the `display_registry` pattern on the Sui blockchain, you will need to modify the Move code in your package. Follow these steps to successfully perform the migration:  ### Step 1: Understanding...
+> To migrate from `Display V1` to `Display V2` and utilize the `display_registry` patterns in Sui, you need to make changes in your Move module code and potentially your TypeScript code if you're using the Sui SDK. Here is a step-by-step guide to help ...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /Display|display/i
 - ✅ `regex`: Matched /display_registry|DisplayRegistry/i
 
 **Subjective grades:**
-- ✅ Explains the difference between Display V1 and Display V2
-  - _Step 1 explicitly contrasts V1 (embedding display info in objects) with V2 (using display_registry for separation of concerns)_
-- ✅ Shows how to migrate from V1 to V2 patterns
-  - _Step 3 provides before/after code examples showing removal of display fields from objects and refactoring to use DisplayRegistry_
+- ❌ Explains the difference between Display V1 and Display V2
+  - _The response provides a vague V1 example with just a comment and no actual code or concrete explanation of what V1 looked like or how it differed functionally from V2. No clear architectural or API differences are articulated._
+- ❌ Shows how to migrate from V1 to V2 patterns
+  - _The response does not show a before/after migration. It only presents a V2 example without demonstrating actual migration steps from real V1 code. No concrete refactoring instructions are provided._
 - ✅ Mentions the display_registry as the current approach
-  - _display_registry is mentioned throughout as the recommended pattern for V2, particularly in Steps 1, 3, and 4_
+  - _The response explicitly references `display_registry` and `DisplayRegistry` multiple times, positioning it as the current V2 approach for managing display properties._
 - ❌ Provides concrete Move code or PTB examples for the migration
-  - _Move code examples are provided, but they are generic/pseudocode (e.g., DisplayRegistry module with placeholder implementations). No concrete, runnable code is shown, and no PTB (Programmable Transaction Block) examples are provided at all_
+  - _The Move code examples appear to use non-existent or incorrect Sui APIs (e.g., `DisplayRegistry::new()`, `register_display()`, `set_property()` as standalone functions). These do not match actual Sui Display V2 APIs and are not concrete, working examples. No PTB examples are provided._
 
 #### ❌ ptb-inputs-results
 **Page:** develop/transactions/ptbs/inputs-and-results
 **Prompt:** Review this PTB code for invalid pure inputs, custom structs/enums, object references, vectors/options, and command result usage.
 
-> Sure, I can help you review your PTB (Programmable Transaction Block) code for invalid pure inputs, custom structs/enums, object references, vectors/options, and command result usage. However, you'll need to provide the code you'd like me to review. ...
+> To thoroughly review your Programmable Transaction Block (PTB) code for invalid pure inputs, custom structs/enums, object references, vectors/options, and command result usage, you need to consider the following aspects. I'll give you a checklist alo...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /pure|Pure/i
@@ -606,210 +248,80 @@
 
 **Subjective grades:**
 - ❌ Explains the distinction between pure inputs and object inputs in PTBs
-  - _The response does not explain or distinguish between pure inputs and object inputs. It only acknowledges these as topics without providing any explanatory content._
-- ❌ Mentions that custom structs and enums cannot be passed as pure inputs
-  - _The response references custom structs/enums as a review criterion but does not explicitly state that they cannot be passed as pure inputs or explain this limitation._
-- ❌ Discusses how command results chain between PTB commands
-  - _The response does not discuss command result usage or how results chain between commands. It only lists this as a review criterion without explanation._
+  - _The response mentions that pure inputs must be Move primitive types but does not explicitly explain what object inputs are, how they differ from pure inputs, or how PTBs distinguish between them. The contrast is implied but not clearly articulated._
+- ✅ Mentions that custom structs and enums cannot be passed as pure inputs
+  - _The response explicitly states under 'Invalid Pure Inputs': 'Custom types or objects cannot be marked as pure.' This directly addresses the expectation._
+- ✅ Discusses how command results chain between PTB commands
+  - _Under 'Command Result Usage' section, the response explicitly discusses 'Chaining: Ensure each command's result is correctly chained into the next step of the PTB.' and provides an example of result chaining in the sample code._
 - ❌ Addresses vector and option encoding in PTB inputs
-  - _The response mentions vectors/options as a review criterion but does not address how they are encoded in PTB inputs or their specific handling requirements._
+  - _The response discusses vector and option operations and safety handling, but does not specifically address how vectors and options are encoded in PTB inputs. It treats them as Move language constructs rather than addressing their specific encoding requirements in the PTB context._
 
-#### ❌ gas-smashing
+#### ⚠️ gas-smashing
 **Page:** develop/transaction-payment/gas-smashing
 **Prompt:** Review this app's gas coin handling. Add safe coin selection/splitting/merging guidance and avoid concurrent reuse of mutable owned objects.
 
-> When working with gas coins in a Sui application, handling them correctly is crucial to ensure the smooth execution of transactions. Below are some guidelines and code examples to enhance your app's gas coin handling, focusing on safe coin selection,...
+**Error:** `429 Rate limit reached for gpt-4o in organization org-Ymxfd9U0oHgQvWY3NcUtRd0M on tokens per min (TPM): Limit 30000, Used 30000, Requested 154. Please try again in 308ms. Visit https://platform.openai.com/account/rate-limits to learn more.`
 
-**Deterministic checks:**
-- ✅ `regex`: Matched /gas/i
-- ✅ `regex`: Matched /split|merge|coin/i
-
-**Subjective grades:**
-- ✅ Explains gas coin handling in Sui transactions
-  - _Response explicitly explains that transactions consume gas paid using coins, that each coin must be individually managed, and provides context about mutable owned objects in Section 1._
-- ✅ Warns about concurrent reuse of mutable owned objects or equivocation risks
-  - _Section 3 explicitly states 'mutable owned objects, which can't be used concurrently in two transactions' and provides warnings about preventing reuse of coins in pending transactions with specific mitigation strategies._
-- ✅ Provides guidance on coin management strategies (selection, splitting, or merging)
-  - _Section 2 explicitly covers all three strategies: Coin Selection with query and filtering examples, Coin Splitting with code example, and Coin Merging with code example._
-- ❌ Discusses gas budget estimation or setting
-  - _The response does not address gas budget estimation or how to set gas budgets. While it mentions 'gas_needed' as a parameter, it does not explain how to estimate or calculate appropriate gas budgets for transactions._
-
-#### ❌ data-serving
+#### ⚠️ data-serving
 **Page:** develop/accessing-data/data-serving
 **Prompt:** Review this app's data access needs and recommend GraphQL, gRPC, or both. Consider frontend/backend use, historical queries, subscriptions, latency, and retention.
 
-> To provide a recommendation on whether to use GraphQL, gRPC, or both, we'll need to assess the app's specific data access requirements including frontend/backend interactions, historical data queries, subscriptions for real-time updates, latency need...
+**Error:** `429 Rate limit reached for gpt-4o in organization org-Ymxfd9U0oHgQvWY3NcUtRd0M on tokens per min (TPM): Limit 30000, Used 30000, Requested 160. Please try again in 320ms. Visit https://platform.openai.com/account/rate-limits to learn more.`
 
-**Deterministic checks:**
-- ✅ `contains`: Found "GraphQL"
-- ✅ `contains`: Found "gRPC"
-
-**Subjective grades:**
-- ❌ Compares GraphQL and gRPC as data access options for Sui
-  - _The response compares GraphQL and gRPC generically but never explicitly grounds the comparison in Sui-specific context, Sui's data structures, Sui's indexing capabilities, or Sui's ecosystem tools. There is no mention of Sui's specific GraphQL implementations, Sui RPC endpoints, or Sui-specific architectural considerations._
-- ✅ Provides guidance on when to use each option based on use case
-  - _The response clearly outlines specific use cases for GraphQL (frontend, flexible querying, historical data) and gRPC (backend communication, low-latency, high-throughput), with explicit recommendations for when to use each._
-- ✅ Mentions subscription or streaming capabilities
-  - _The response explicitly discusses GraphQL Subscriptions for real-time frontend updates and gRPC Streaming for backend systems, addressing both subscription mechanisms clearly._
-- ✅ Discusses data retention and historical query considerations
-  - _The response addresses historical queries (noting GraphQL's flexibility for complex criteria over historical data) and data retention (explaining it's managed at the storage layer, mentioning Walrus storage on Sui, and discussing how protocols affect data retrieval)._
-
-#### ❌ using-grpc
+#### ⚠️ using-grpc
 **Page:** develop/accessing-data/grpc/using-grpc
 **Prompt:** Convert this Sui JSON-RPC usage to the current gRPC API. Generate/use the client, map request/response types, and add a working example.
 
-> To convert a Sui JSON-RPC usage to the current gRPC API, you'll need to follow a few steps. This involves setting up the gRPC client, mapping the appropriate request and response types, and executing a request example. I'll guide you through the proc...
+**Error:** `429 Rate limit reached for gpt-4o in organization org-Ymxfd9U0oHgQvWY3NcUtRd0M on tokens per min (TPM): Limit 30000, Used 30000, Requested 153. Please try again in 306ms. Visit https://platform.openai.com/account/rate-limits to learn more.`
 
-**Deterministic checks:**
-- ✅ `contains`: Found "gRPC"
-- ✅ `regex`: Matched /proto|protobuf|client/i
-
-**Subjective grades:**
-- ✅ Explains how to set up or generate a gRPC client for Sui
-  - _Response provides clear setup instructions including protoc compiler prerequisites, pip installation commands, protobuf compilation steps, and Python client initialization code._
-- ❌ Maps or references common Sui RPC methods and their gRPC equivalents
-  - _Response only provides one hypothetical example (sui_getBalance → GetBalance) with fabricated proto message types (sui_pb2.GetBalanceRequest). Does not reference actual Sui RPC methods or their documented gRPC equivalents, and does not acknowledge that specific method mappings require access to actual Sui proto definitions._
-- ✅ Provides a code example demonstrating a gRPC call to Sui
-  - _Response includes working Python code examples showing client creation, request object instantiation, service method calls, and error handling._
-- ❌ References the proto definitions, endpoint, or service structure
-  - _Response mentions proto files generically but does not reference actual Sui proto definitions (file locations, repository URLs, or structure). References placeholder endpoint 'localhost:50051' without noting this is not the actual Sui gRPC endpoint and does not provide guidance on finding the correct one._
-
-#### ❌ query-with-graphql
+#### ⚠️ query-with-graphql
 **Page:** develop/accessing-data/graphql/query-with-graphql
 **Prompt:** Convert this Sui JSON-RPC query to GraphQL. Include the query, variables, pagination handling, and TypeScript caller code.
 
-> To convert a Sui JSON-RPC query to GraphQL, you'll need to understand that the process generally involves:  1. Identifying the equivalent GraphQL operation for the JSON-RPC method you are using. 2. Constructing the GraphQL query with appropriate fiel...
+**Error:** `429 Rate limit reached for gpt-4o in organization org-Ymxfd9U0oHgQvWY3NcUtRd0M on tokens per min (TPM): Limit 30000, Used 30000, Requested 150. Please try again in 300ms. Visit https://platform.openai.com/account/rate-limits to learn more.`
 
-**Deterministic checks:**
-- ✅ `contains`: Found "GraphQL"
-- ✅ `regex`: Matched /query\s*\{|query\s+\w+/i
-- ✅ `regex`: Matched /TypeScript|typescript|\bts\b/i
-
-**Subjective grades:**
-- ❌ Provides a concrete GraphQL query with proper Sui schema types
-  - _The GraphQL query uses generic field names like 'fields' with 'name' and 'value' properties that do not match actual Sui GraphQL schema. Sui's actual schema defines specific object fields (e.g., 'owner', 'previousTransactionBlock', 'storageRebate') and uses established Sui types. The query appears fabricated rather than based on Sui's documented GraphQL schema._
-- ✅ Shows pagination handling with cursors or connection patterns
-  - _The response clearly demonstrates cursor-based pagination using `pageInfo` with `hasNextPage` and `endCursor`, along with a `while` loop that properly iterates through pages by updating the `after` cursor variable._
-- ✅ Includes TypeScript code that calls the GraphQL endpoint
-  - _The response provides complete TypeScript code using Apollo Client to execute the GraphQL query, including proper type definitions and a callable async function with error handling flow._
-- ✅ Demonstrates use of variables in the query
-  - _The GraphQL query explicitly defines variables (`$address`, `$first`, `$after`) and the TypeScript code passes these variables to the client.query() call with proper typing._
-
-#### ❌ observability
+#### ⚠️ observability
 **Page:** operators/observability
 **Prompt:** Add structured logging for transaction digest, sender, package/function, status, gas, and user-visible errors so support can debug failed Sui transactions.
 
-> To implement structured logging for Sui transactions, where you want to log details such as the transaction digest, sender, package/function invoked, status, gas usage, and user-visible errors, you can follow these steps:  ### Step 1: Set Up Environm...
+**Error:** `429 Rate limit reached for gpt-4o in organization org-Ymxfd9U0oHgQvWY3NcUtRd0M on tokens per min (TPM): Limit 30000, Used 30000, Requested 158. Please try again in 316ms. Visit https://platform.openai.com/account/rate-limits to learn more.`
 
-**Deterministic checks:**
-- ✅ `regex`: Matched /digest|transaction/i
-- ✅ `regex`: Matched /log|logging|tracing/i
-
-**Subjective grades:**
-- ✅ Shows structured logging with transaction-relevant fields
-  - _The response defines a log_data dictionary containing all required transaction fields (digest, sender, package_id, function_name, status, gas_used, error_message) and logs it as structured data._
-- ✅ Includes key fields: digest, sender, status, gas used
-  - _All four key fields are explicitly present in the log_data dictionary: transaction_digest, sender, status, and gas_used._
-- ❌ Provides actionable patterns for debugging failed transactions
-  - _The response provides generic logging patterns but lacks actionable debugging guidance specific to Sui transaction failures. It does not explain how to parse error responses, identify common failure modes, or demonstrate actual Sui SDK/RPC integration for retrieving real transaction data._
-- ✅ Uses structured logging format (not just string interpolation)
-  - _The response uses a dictionary (log_data) for structured logging and passes it to logger.info() as an object rather than relying on string interpolation alone._
-
-#### ❌ move-package-management
+#### ⚠️ move-package-management
 **Page:** develop/manage-packages/move-package-management
 **Prompt:** Inspect this Move package's Move.toml, Move.lock, and dependencies. Fix dependency declarations, prefer MVR where appropriate, and verify sui move build works.
 
-> To help you with this task, you'll want to follow a series of steps to inspect and potentially fix the dependency declarations in your Move package. This involves looking at your `Move.toml`, `Move.lock`, and any dependencies. Here's a structured app...
+**Error:** `429 Rate limit reached for gpt-4o in organization org-Ymxfd9U0oHgQvWY3NcUtRd0M on tokens per min (TPM): Limit 30000, Used 30000, Requested 159. Please try again in 318ms. Visit https://platform.openai.com/account/rate-limits to learn more.`
 
-**Deterministic checks:**
-- ✅ `contains`: Found "Move.toml"
-- ✅ `regex`: Matched /Move\.lock|Move\.toml/i
-- ✅ `regex`: Matched /sui\s+move\s+build/i
-
-**Subjective grades:**
-- ✅ Explains the role of Move.toml and its key fields
-  - _Step 1 clearly explains Move.toml structure and identifies key sections: [package], [addresses], [dependencies], and [dev-dependencies]. The example demonstrates the role of each field._
-- ✅ Shows how to declare or fix dependencies
-  - _Step 3 explicitly shows dependency modification with concrete before/after examples in Move.toml, demonstrating how to add git sources, revisions, and subdirectories._
-- ❌ Mentions Move Version Registry (MVR) or resolution strategies
-  - _The response mentions 'Move Version Requirements (MVR)' terminology but does not explain what MVR actually is or provide examples of MVR-style dependency declarations. The term appears to be confused with git-based versioning (rev/branch). No actual MVR registry syntax or strategy is demonstrated._
-- ✅ References sui move build for verification
-  - _Step 4 explicitly references 'sui move build' command and discusses verifying the build process succeeds, including error resolution._
-
-#### ❌ automated-address-management
+#### ⚠️ automated-address-management
 **Page:** develop/manage-packages/automated-address-management
 **Prompt:** Migrate this package to current Sui package address management using Move.lock / Published.toml conventions, then verify build and publish/test-publish behavior.
 
-> To migrate your package to the current Sui package address management conventions using `Move.lock` and `Published.toml`, follow these steps:  ### Step 1: Update Your Move Package to Use `Move.lock`  1. **Create a Move.lock File**:     - First, you n...
+**Error:** `429 Rate limit reached for gpt-4o in organization org-Ymxfd9U0oHgQvWY3NcUtRd0M on tokens per min (TPM): Limit 30000, Used 30000, Requested 160. Please try again in 320ms. Visit https://platform.openai.com/account/rate-limits to learn more.`
 
-**Deterministic checks:**
-- ✅ `regex`: Matched /Move\.lock|Published\.toml/i
-- ✅ `regex`: Matched /address|0x0/i
-
-**Subjective grades:**
-- ✅ Explains the current address management conventions
-  - _The response explains that current conventions use address placeholders in Move.toml (e.g., `my_package = "_"`), Move.lock for dependency tracking, and Published.toml for actual on-chain addresses post-publication._
-- ✅ Shows how Published.toml or Move.lock track published addresses
-  - _The response explicitly states that Move.lock captures dependency state and addresses, and Published.toml contains actual on-chain address mappings after publication with a concrete example showing `my_package = "0x123456789abcde"`._
-- ❌ Provides migration steps from older patterns
-  - _The response does not address migration from older patterns. It assumes a starting point with Move.toml already present and does not explain what older address management looked like or how to transition from hardcoded addresses or legacy configurations._
-- ✅ Includes verification commands to confirm correct behavior
-  - _The response provides specific verification commands including `sui move build`, `sui move test`, and `sui client publish .`, along with instructions to verify address mappings in Published.toml post-publication._
-
-#### ❌ walrus-storage
+#### ⚠️ walrus-storage
 **Page:** sui-stack/walrus/sui-stack-walrus
 **Prompt:** Upload this app's media or NFT assets to Walrus, store the resulting blob references, and wire them into Sui object metadata or Display fields.
 
-> To upload your app's media or NFT assets to Walrus, and then use the resulting blob references in your Sui object metadata or Display fields, follow these steps:  ### Step 1: Set Up Walrus Storage  First, ensure you have access to the Walrus storage ...
+**Error:** `429 Rate limit reached for gpt-4o in organization org-Ymxfd9U0oHgQvWY3NcUtRd0M on tokens per min (TPM): Limit 30000, Used 30000, Requested 155. Please try again in 310ms. Visit https://platform.openai.com/account/rate-limits to learn more.`
 
-**Deterministic checks:**
-- ✅ `contains`: Found "Walrus"
-- ✅ `regex`: Matched /blob|store|upload/i
-- ✅ `regex`: Matched /Display|metadata/i
-
-**Subjective grades:**
-- ✅ Shows how to upload assets to Walrus (via CLI, SDK, or HTTP API)
-  - _Response provides a Python example using HTTP POST requests to upload files to Walrus, demonstrating one method of asset upload._
-- ✅ Explains how to store or reference the resulting blob ID
-  - _Response shows extracting the blob_reference from the Walrus API response and storing it in the upload_to_walrus function return value._
-- ❌ Demonstrates wiring blob references into Sui object Display fields or metadata
-  - _Response shows a generic 'display' field in a Move struct, but does not explicitly demonstrate the Display standard or official Sui metadata/Display field structure. The example uses a plain vector<u8> rather than proper Display object patterns used in Sui._
-- ❌ Mentions token requirements (WAL for storage, SUI for gas) or cost considerations
-  - _Response completely omits any mention of WAL tokens for Walrus storage, SUI for gas fees, or any cost considerations for the operations described._
-
-#### ❌ walrus-sites
+#### ⚠️ walrus-sites
 **Page:** sui-stack/walrus/sui-stack-walrus-sites
 **Prompt:** Deploy this static frontend as a Walrus Site. Build the app, publish the site, record the site object and blob IDs, and document update steps.
 
-> To deploy a static frontend as a Walrus Site on the Sui blockchain, follow these step-by-step instructions. This will cover building your app, publishing the site, recording the necessary IDs, and documenting the update steps.  ### Step 1: Build Your...
-
-**Deterministic checks:**
-- ❌ `regex`: No match for /site-builder|walrus-sites/i
-- ✅ `regex`: Matched /publish|deploy/i
-- ✅ `regex`: Matched /update|upgrade/i
-
-**Subjective grades:**
-- ✅ Shows the build step for the static frontend
-  - _Step 1 explicitly covers building the static frontend with concrete examples (npm run build for React) and identifies output directories (build/dist)._
-- ❌ Provides the site-builder publish command
-  - _The response provides 'sui client publish-site' but this command is not verified to exist or be correct for Walrus Sites. The response itself acknowledges uncertainty ('If you have never set this command, it may prompt you to install walrus'). A strict grader requires a confirmed, accurate command specific to Walrus Site publishing._
-- ❌ Explains how to record and track the site object ID
-  - _While Step 2 mentions 'Record the Site Object ID and Blob ID' and states these 'will usually include' in the output, it does not explicitly explain HOW to extract, copy, store, or track these IDs from the command output. The expectation requires documentation of the actual tracking mechanism, not just acknowledgment that IDs exist._
-- ✅ Documents the update process for redeploying changes
-  - _Step 4 clearly documents the update process: make changes, rebuild static files, republish using the same command, and verify updates. The optional automation section further reinforces this workflow._
+**Error:** `429 Rate limit reached for gpt-4o in organization org-Ymxfd9U0oHgQvWY3NcUtRd0M on tokens per min (TPM): Limit 30000, Used 30000, Requested 155. Please try again in 310ms. Visit https://platform.openai.com/account/rate-limits to learn more.`
 
 </details>
 
-<details><summary><b>opus</b>: 16/19 prompts passed (84%)</summary>
+<details><summary><b>opus</b>: 17/19 prompts passed (89%)</summary>
 
 - Deterministic checks: 48/48 (100%)
-- Subjective grades: 72/75 (96%)
+- Subjective grades: 73/75 (97%)
 
 #### ✅ sui-install
 **Page:** getting-started/onboarding/sui-install
 **Prompt:** Set up this machine for Sui development: Install the Sui CLI with curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/install.sh | sh, then run suiup install sui@testnet to get the Testnet-compatible toolchain. Run sui client to generate your keys and config, then prompt me to visit faucet.sui.io, enter the generated address, and fund it with test tokens.
 
-> # Setting Up Your Machine for Sui Development  Here's a complete step-by-step guide to get you up and running.  ---  ## Step 1: Install `suiup` (Sui Toolchain Manager)  ```bash curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/instal...
+> # Setting Up Your Machine for Sui Development  ## Step 1: Install `suiup` (Sui Toolchain Manager)  Run the following command in your terminal:  ```bash curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/install.sh | sh ```  This insta...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "suiup"
@@ -818,17 +330,17 @@
 
 **Subjective grades:**
 - ✅ Provides a clear step-by-step setup sequence starting with installing suiup
-  - _The response explicitly begins with Step 1 installing suiup via the exact curl command from the prompt, followed by logical sequential steps (Steps 2-7) that build upon each other in proper order._
+  - _Response explicitly follows the requested sequence: Step 1 installs suiup via the exact curl command provided, Step 2 runs `suiup install sui@testnet`, Step 3 runs `sui client` for key generation. The structure is clear and sequential._
 - ✅ Mentions generating keys or wallet configuration
-  - _Step 3 explicitly covers running 'sui client' to interactively generate keys and bootstrap configuration. The response shows the keypair generation output and explains the key scheme selection (ed25519)._
+  - _Step 3 explicitly covers running `sui client` which 'will walk you through an interactive setup' to generate keypair and keys. The response shows the expected interactive prompts and resulting key generation output including the generated address._
 - ✅ Includes instructions about funding the address with test tokens
-  - _Step 6 explicitly prompts the user to visit faucet.sui.io, enter their generated address, and fund with test tokens. It also provides the alternative CLI method and verification step (Step 7) to confirm funding._
+  - _Step 5 explicitly prompts the user to visit faucet.sui.io, paste their generated address, and fund it with test tokens. The response provides both manual faucet instructions and the alternative `sui client faucet` CLI command. Step 6 includes verification via `sui client gas`._
 
 #### ✅ hello-world
 **Page:** getting-started/onboarding/hello-world
 **Prompt:** Clone the https://github.com/MystenLabs/sui-stack-hello-world example app, build and publish the Move package at move/hello-world to Testnet, then call its entry function and show me the resulting object and transaction on SuiVision.
 
-> # Deploy & Interact with the Sui "Hello World" Example  Below is every step, from cloning to viewing on SuiVision.  ---  ## 0 — Prerequisites  ```bash # Sui CLI installed (>= 1.28+) sui --version  # Make sure you have a testnet address with SUI sui c...
+> # Deploy & Interact with `sui-stack-hello-world` on Testnet  Below is a complete, step-by-step walkthrough.  ---  ## 0 — Prerequisites  | Tool | Install | |------|---------| | **Sui CLI** | `cargo install --locked --git https://github.com/MystenLabs/...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "sui-stack-hello-world"
@@ -837,19 +349,19 @@
 
 **Subjective grades:**
 - ✅ Provides the git clone command for the repo
-  - _Section 1 explicitly provides: `git clone https://github.com/MystenLabs/sui-stack-hello-world.git`_
+  - _Section 1 explicitly provides: `git clone https://github.com/MystenLabs/sui-stack-hello-world.git` with correct URL and navigation instructions._
 - ✅ Shows the build and publish commands
-  - _Section 2 shows `sui move build` and Section 3 shows `sui client publish --gas-budget 100000000`_
+  - _Section 3 shows `sui move build` command. Section 4 shows `sui client publish --gas-budget 100000000` command with clear explanation of how to capture Package ID and Transaction Digest._
 - ✅ Explains how to call the entry function after publishing
-  - _Section 4 provides the `sui client call` command with package, module, and function parameters to invoke the entry function_
+  - _Section 5 provides the complete `sui client call` command with all required parameters (--package, --module, --function, --gas-budget) and explains how to extract the resulting object and transaction IDs._
 - ✅ Mentions viewing the result on SuiVision or a block explorer
-  - _Section 6 explicitly provides SuiVision URLs for viewing the transaction digest and object ID: `https://testnet.suivision.xyz/txblock/<TX_DIGEST>` and `https://testnet.suivision.xyz/object/<OBJECT_ID>`_
+  - _Section 6 explicitly provides SuiVision URLs for Testnet explorer with concrete examples: `https://testnet.suivision.xyz/object/<OBJECT_ID>` and `https://testnet.suivision.xyz/txblock/<CALL_DIGEST>` for viewing both the resulting object and transaction._
 
 #### ✅ testing
 **Page:** develop/testing-debugging/testing
 **Prompt:** Add Move unit tests for this package's public functions, including success, unauthorized, and edge cases.
 
-> # Adding Comprehensive Move Unit Tests  I'll provide a thorough testing strategy. Since you haven't shared your specific package, I'll demonstrate with a realistic example module and then write comprehensive tests covering success, unauthorized, and ...
+> # Adding Comprehensive Move Unit Tests for a Sui Package  Since you haven't provided a specific package, I'll demonstrate a complete, production-quality testing pattern using a realistic example module — a **managed token treasury** — and then show e...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "#[test]"
@@ -857,19 +369,19 @@
 
 **Subjective grades:**
 - ✅ Shows the #[test] attribute pattern for writing Sui Move tests
-  - _The response includes numerous examples of #[test] attribute usage throughout the test module, such as #[test] fun test_create_success(), #[test] fun test_deposit_success(), etc._
+  - _The response extensively demonstrates #[test] attribute usage throughout the test module with 25+ test functions, all clearly marked with #[test]._
 - ✅ Explains or demonstrates success-case testing patterns
-  - _The response demonstrates success cases extensively, including test_create_success(), test_deposit_success(), test_withdraw_success(), test_transfer_ownership_success(), and integration tests like test_full_lifecycle(). Each includes assertions verifying expected state changes._
+  - _Success cases are clearly demonstrated across multiple test functions (test_deposit_basic, test_withdraw_basic, test_transfer_admin, etc.) with assertions verifying expected state changes._
 - ✅ Mentions #[expected_failure] or assert macros for failure testing
-  - _The response explicitly uses #[expected_failure(abort_code = ...)] for all negative test cases, such as test_deposit_zero_amount_fails() and test_withdraw_unauthorized_no_admin_cap_match(). It also uses assert!() macros throughout success tests._
+  - _The response explicitly demonstrates #[expected_failure(abort_code = ...)] pattern in 7+ test functions (e.g., test_deposit_zero_amount_fails, test_withdraw_more_than_balance_fails) and uses assert! macros throughout._
 - ✅ References test_scenario or unit_test module for Sui-specific testing
-  - _The response imports and uses sui::test_scenario (aliased as ts) throughout the test module, demonstrated by 'use sui::test_scenario::{Self as ts, Scenario}' and extensive usage of ts::begin(), scenario.next_tx(), scenario.take_shared(), etc._
+  - _The response explicitly imports and uses `sui::test_scenario` (aliased as `ts`), demonstrates its API (ts::begin, scenario.next_tx, take_shared, return_shared), and includes a comprehensive end-to-end test using test_scenario patterns._
 
 #### ✅ scenario-testing
 **Page:** getting-started/examples/scenario-testing
 **Prompt:** Create scenario tests for this Sui workflow, including multiple users, object ownership changes, and expected transaction failures.
 
-> # Comprehensive Sui Move Scenario Tests  Here's a complete example with a module and thorough scenario tests covering multi-user interactions, ownership transfers, and expected failures.  ## Module Under Test  ```move module marketplace::trading {   ...
+> # Comprehensive Sui Move Scenario Tests  I'll create a full testing suite for a realistic Sui workflow — a **marketplace** where users can list, buy, delist, and trade NFTs. This covers multi-user interactions, ownership changes, and expected failure...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "test_scenario"
@@ -878,19 +390,19 @@
 
 **Subjective grades:**
 - ✅ Uses or references sui::test_scenario for multi-transaction workflows
-  - _The response explicitly imports and uses `sui::test_scenario::{Self as ts, Scenario}` throughout all test functions. Multiple tests use `ts::begin()`, `ts::next_tx()`, and `ts::end()` to create multi-transaction workflows._
+  - _Response explicitly imports and uses `sui::test_scenario::{Self as ts, Scenario}` throughout. Multiple tests use `ts::begin()`, `ts::next_tx()`, and `ts::end()` for multi-transaction workflows._
 - ✅ Shows how to switch between different senders/users in a scenario
-  - _The response demonstrates sender switching in every test function using `ts::next_tx(&mut scenario, ADDRESS)` with clearly defined test addresses (ADMIN, SELLER, BUYER, BUYER_2, RANDOM_USER). Example: `ts::next_tx(&mut scenario, SELLER)` followed by `ts::next_tx(&mut scenario, BUYER)` in test_full_happy_path()._
+  - _Response defines multiple test addresses (ADMIN, ALICE, BOB, CAROL) and demonstrates switching between them using `ts::next_tx(scenario, SENDER_ADDRESS)` across all test scenarios._
 - ✅ Demonstrates testing object ownership or state changes across transactions
-  - _Multiple tests explicitly verify ownership changes across transactions. test_ownership_chain_resale() tracks item ownership through three parties (SELLER → BUYER → BUYER_2), verifying creator preservation. Tests use `ts::take_from_sender<Item>()` and `ts::take_shared<Listing>()` to verify object states and ownership at each step._
+  - _Multiple scenarios explicitly test ownership changes: test_full_buy_flow verifies Bob owns NFT after purchase, test_resell_nft_changes_ownership shows chain of ownership (Alice→Bob→Carol), and tests verify marketplace balance accumulation across transactions._
 - ✅ Mentions or shows expected-failure patterns (e.g., #[expected_failure] or abort codes)
-  - _The response includes six explicit failure scenarios using `#[expected_failure(abort_code = ...)]` pattern: test_fail_insufficient_payment (EInsufficientPayment), test_fail_seller_buys_own_listing (ECannotBuyOwnListing), test_fail_non_owner_cancel (ENotOwner), test_fail_buy_inactive_listing (EListingNotActive), test_fail_double_cancel (EListingNotActive), and test_fail_buy_after_cancel (EListingNotActive)._
+  - _Response includes 6+ failure tests using `#[test]` with `#[expected_failure(abort_code = ...)]` attributes, e.g., `test_fail_insufficient_payment`, `test_fail_buy_own_listing`, `test_fail_delist_not_owner`, each testing specific error codes like EInsufficientPayment, ECannotBuyOwnListing, ENotOwner._
 
 #### ✅ common-errors
 **Page:** develop/testing-debugging/common-errors
 **Prompt:** Debug this Sui transaction failure. Inspect object refs, gas objects, ownership, versions, and suggest the minimal code or PTB change to make it execute.
 
-> # Debugging Sui Transaction Failures — Systematic Guide  Transaction failures on Sui fall into a few well-defined categories. Below is a complete diagnostic framework.  ---  ## Step 1: Get the Full Error  ```bash # If you have the transaction digest ...
+> # Debugging Sui Transaction Failures: Systematic Approach  Since you haven't provided a specific transaction digest or error, I'll give you a comprehensive debugging framework with exact commands, common failure patterns, and fixes.  ---  ## Step 1: ...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /object|version|ownership/i
@@ -898,19 +410,19 @@
 
 **Subjective grades:**
 - ✅ Provides a systematic debugging approach for Sui transaction failures
-  - _Response provides a 6-step systematic framework (Get Full Error, Inspect Objects, Inspect Gas, Decode MoveAbort, Fix Common PTB Issues, Full Diagnostic Script) with clear progression and actionable steps at each stage._
+  - _Response clearly structures debugging into 4 numbered steps: (1) Get Failed Transaction Details with CLI and SDK commands, (2) Common Errors and Fixes with 7 categorized error types, (3) Full Diagnostic Script with complete implementation, and (4) Quick Fix Checklist. This is explicitly systematic._
 - ✅ Mentions checking object versions and ownership as common failure sources
-  - _Step 2 explicitly includes object version and ownership inspection with concrete CLI commands (`sui client object <OBJECT_ID> --json`) and a detailed checklist that checks versions, ownership, and type. Issue 1 and Issue 3 specifically address stale versions and InvalidOwner errors._
+  - _Response explicitly covers object versions in Error 1 (ObjectVersionUnavailableForConsumption) with version checking commands and in Error 2 (ObjectNotFound). Ownership is explicitly covered in Error 3 (InvalidOwner) with detailed ownership type checking (AddressOwner, Shared, ObjectOwner, Immutable). Both are presented as common failure sources._
 - ✅ Discusses gas-related issues (insufficient gas, gas coin conflicts)
-  - _Step 3 provides dedicated gas debugging with inspection commands and explicit discussion of gas coin conflicts. Issue 2 demonstrates the gas coin used as input problem with BAD/FIX examples. Issue 6 addresses insufficient gas budget with concrete solutions._
+  - _Response explicitly covers Error 4 (InsufficientGas) with diagnostic commands and fixes including gas budget adjustment and coin merging. Error 6 (InputObjectDeleted) specifically addresses gas coin conflicts with the problem statement 'gas coin used as both gas payment and input object' and provides explicit fixes using tx.splitCoins() and setGasPayment()._
 - ✅ Suggests concrete fixes rather than just diagnosis
-  - _Response includes 6 specific Issues (Issues 1-6) with paired BAD/FIX code examples showing TypeScript before-and-after patterns. Also provides a Quick Reference table with symptom-to-fix mappings and a complete diagnostic script with runnable code._
+  - _Each error section includes 'Fix:' subsections with runnable TypeScript code examples showing the exact change needed (e.g., using tx.object() instead of hardcoded refs, calling tx.setGasBudget(), using tx.sharedObjectRef() with correct parameters). Step 4 provides a Quick Fix Checklist with concrete actions mapped to symptoms._
 
 #### ✅ publish-overview
 **Page:** develop/publish-upgrade-packages/index
 **Prompt:** Prepare this package for Mainnet publishing: verify tests, dependencies, addresses, upgrade policy, gas requirements, signer/custody plan, and produce a launch checklist.
 
-> # Sui Mainnet Publishing Checklist & Preparation Guide  This is a comprehensive, step-by-step guide to take a Move package from development to Mainnet deployment.  ---  ## 1. Code & Test Verification  ### 1.1 Run All Tests  ```bash # Run tests with m...
+> # Sui Mainnet Publishing Checklist & Preparation Guide  This is a comprehensive, production-grade checklist for publishing a Move package to Sui Mainnet. I'll walk through every critical dimension.  ---  ## 1. Pre-Flight: Package Structure Verificati...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /sui\s+client\s+publish|sui\s+move\s+build/i
@@ -919,19 +431,19 @@
 
 **Subjective grades:**
 - ✅ Includes a checklist or step-by-step process for publishing
-  - _Section 10 provides a comprehensive 'Master Launch Checklist' with checkbox items organized by category (Pre-Build, Dependencies, Code Audit, Security, Upgrade Strategy, Signer & Custody, Gas, Testnet Validation, Publish, Post-Publish, Emergency Plan). Section 8 also provides detailed step-by-step publishing procedure with multiple options (direct publish, multisig serialization)._
+  - _Section 11 provides a comprehensive 'MASTER LAUNCH CHECKLIST' with 50+ checkbox items organized by category. The response also structures the entire guide as sequential steps (sections 1-10) leading to mainnet publication._
 - ✅ Mentions verifying tests pass before publishing
-  - _Section 1 'Code & Test Verification' explicitly covers running tests with `sui move test --gas-limit 1000000000`, coverage reports, and static analysis. The Master Checklist (Section 10, Pre-Build) includes items: '[ ] All tests pass: `sui move test`' and '[ ] Coverage reviewed: `sui move test --coverage`'._
+  - _Section 3 'Comprehensive Testing' explicitly details running tests with `sui move test --gas-limit`, coverage reporting, and provides test examples. The checklist (section 11) includes '[ ] All unit tests pass (`sui move test`)' and '[ ] Test coverage > 80%'._
 - ✅ Discusses the UpgradeCap and upgrade policy considerations
-  - _Section 4 'Upgrade Policy Design' explicitly discusses upgrade policies (compatible, additive, dep_only, immutable) with a comparison table. Section 4.2 provides code examples for storing and restricting the UpgradeCap. Section 4.3 describes three UpgradeCap custody options (Multisig, Timelock + Governance, Immutability). The Master Checklist includes upgrade strategy items._
+  - _Section 4 'Upgrade Policy Decision' provides detailed discussion of four upgrade policies (compatible, additive, dep_only, immutable) with a comparison table. Includes code examples for protecting UpgradeCap with time-lock. Checklist item '[ ] Upgrade policy decided and documented' confirms explicit expectation._
 - ✅ Addresses gas requirements or cost estimation
-  - _Section 6 'Gas Estimation' covers dry-running on testnet to estimate costs, calculating mainnet gas budget (2-3x testnet for safety margin), checking reference gas price, and provides specific examples. Section 8.3 shows `--gas-budget` flags in publish commands. The Master Checklist includes gas items with space to record costs._
+  - _Section 5 'Gas Requirements Estimation' includes bash commands to estimate gas, a detailed table mapping package size to estimated gas costs in MIST and SUI equivalent, and guidance to set budget 2-3x estimated cost. Checklist items include '[ ] Gas budget estimated from testnet dry-run' and '[ ] Gas budget set to 2-3x estimate'._
 
 #### ❌ upgrade
 **Page:** develop/publish-upgrade-packages/upgrade
 **Prompt:** Prepare an upgrade for this published Sui package. Check compatibility rules, build the upgrade transaction, identify the UpgradeCap, and document the exact upgrade steps.
 
-> # Complete Sui Package Upgrade Guide  ## Overview  Sui supports package upgrades with strict compatibility rules. Here's the complete process from start to finish.  ---  ## Step 1: Understand Compatibility Rules  Sui enforces three upgrade policies (...
+> # Complete Sui Package Upgrade Guide  ## Overview  Sui supports package upgrades with strict compatibility rules. Here's the complete process from preparation to execution.  ---  ## Step 1: Understand Compatibility Rules  Sui enforces three upgrade p...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "UpgradeCap"
@@ -940,19 +452,19 @@
 
 **Subjective grades:**
 - ✅ Explains the role of the UpgradeCap object
-  - _Step 2 explicitly explains that UpgradeCap is created at package publication, shows how to locate it, identifies key fields (objectId, package, version, policy), and demonstrates its use throughout the upgrade process in both CLI and SDK examples._
+  - _Step 2 explicitly explains that UpgradeCap is created at initial publication, shows how to locate it, and demonstrates its structure with JSON output showing the package reference and version. The document also uses it throughout as the authorization object for upgrades._
 - ✅ Describes compatibility rules for package upgrades (compatible, additive, or dependency-only)
-  - _Step 1 provides a detailed table with all four upgrade policies (Immutable, Dependency-only, Additive, Compatible), explicitly lists what can and cannot be done under Compatible policy, and references policy values (0=compatible, 128=additive, 192=dep_only, 255=immutable)._
+  - _Step 1 provides a detailed table of all four upgrade policies with value numbers, explicitly lists what each policy allows and forbids, and uses 'compatible', 'additive', and 'dependency-only' terminology correctly with concrete examples._
 - ✅ Shows the upgrade command or transaction construction
-  - _Step 5 provides two complete paths: Option A shows the CLI one-command upgrade with `sui client upgrade`, and Option B provides full TypeScript SDK code constructing the upgrade transaction with authorize_upgrade and commit_upgrade calls, including module compilation and execution._
+  - _Step 5 provides three implementation paths: Option A shows the CLI command (`sui client upgrade`), Option B shows complete TypeScript PTB transaction construction with `authorize_upgrade` and `commit_upgrade` calls, and Option C shows custom Move module approach for upgrades._
 - ❌ Mentions that the original package version is preserved on-chain
-  - _The response does not explicitly state that the original package version remains on-chain after an upgrade. While it mentions version increments in the UpgradeCap and new package IDs are created, it never clarifies that previous package versions remain accessible/immutable on-chain._
+  - _The document does not explicitly state that the original package version/address is preserved on-chain after upgrade. It mentions UpgradeCap version incrementing and a new package ID being created, but does not clarify that the old package remains accessible on-chain._
 
 #### ✅ custom-policies
 **Page:** develop/publish-upgrade-packages/custom-policies
 **Prompt:** Create an operator runbook for package upgrades and admin actions: required caps, signer/custody steps, exact commands, verification, and rollback/communication plan.
 
-> # Sui Package Upgrades & Admin Actions — Operator Runbook  ---  ## Table of Contents  1. [Capability Inventory](#1-capability-inventory) 2. [Pre-Upgrade Checklist](#2-pre-upgrade-checklist) 3. [Signer & Custody Procedures](#3-signer--custody-procedur...
+> # Sui Package Upgrade & Admin Actions — Operator Runbook  ---  ## Table of Contents  1. [Prerequisite Inventory](#1-prerequisite-inventory) 2. [Capability Object Taxonomy](#2-capability-object-taxonomy) 3. [Custody & Signer Architecture](#3-custody--...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /UpgradeCap|AdminCap|cap/i
@@ -960,19 +472,19 @@
 
 **Subjective grades:**
 - ✅ Provides a structured runbook format with clear steps
-  - _Response includes comprehensive table of contents, multiple numbered sections (1-8), checklists, step-by-step procedures with clear headers, code blocks, and sequential workflows (e.g., multisig flow diagram, upgrade decision tree, rollback decision tree). Format is well-organized and actionable._
+  - _The response includes a comprehensive table of contents, numbered sections (1-9), clear phase breakdowns (Phase 0-3 for upgrades), and step-by-step procedures with bash commands and code examples throughout._
 - ✅ Addresses capability (Cap) management and access control
-  - _Section 1 (Capability Inventory) explicitly covers UpgradeCap, AdminCap, and TreasuryCap with detailed Move code examples, YAML registry, object IDs, custodian assignments, and CLI verification commands. Section 5 demonstrates admin operations (pause, unpause, set_fee, transfer_admin_cap). Version-gating pattern in Section 4.2 enforces capability-guarded state transitions._
+  - _Section 2 provides detailed taxonomy of built-in Sui caps (UpgradeCap, UpgradeTicket, UpgradeReceipt) and custom application caps with Move code examples. Section 3.1-3.2 explicitly cover cap transfer and multi-sig setup. Section 5.4 covers irreversible policy restrictions._
 - ✅ Includes verification steps to confirm operations succeeded
-  - _Section 6 (Verification & Smoke Tests) provides comprehensive post-upgrade verification: bash script checking package version, UpgradeCap version, state migration, package linkage, and on-chain bytecode. TypeScript smoke test validates config readability, module resolution, and dry-run transaction success. Section 1.3 includes CLI commands to verify caps exist and check their properties._
+  - _Section 6 provides a comprehensive verification checklist with a bash script covering TX success, object changes, version confirmation, package publication, events, and smoke testing. Section 9.4 includes a GraphQL query example for deep verification._
 - ✅ Mentions security considerations such as multisig, key management, or custody
-  - _Section 3 (Signer & Custody Procedures) explicitly covers multisig setup with 3-of-5 example, step-by-step multisig signing flow with separate coordinator/signer roles, hardware wallet/cold signer procedures for air-gapped signing, and signature combination. Caps registry tracks custodians. Section 2.1 mentions gas budget confirmation and signer notification windows._
+  - _Section 3 (Custody & Signer Architecture) explicitly details 2-of-3 multi-sig setup with keytool commands, signing flow diagrams showing cold wallet/hardware signer integration, and partial signature combination. Section 5.3 discusses emergency pause patterns and restricted upgrade policies as security controls._
 
 #### ✅ display-overview
 **Page:** develop/objects/display/display-overview
 **Prompt:** Find Display V1 usage in this package or docs and migrate it to Display V2 and display_registry patterns.
 
-> # Migrating from Display V1 to Display V2 with `display_registry`  ## Understanding the Change  In Sui's evolution, `Display V1` (from `sui::display`) is being superseded by `Display V2` patterns that use a **`display_registry`** approach. Here's a c...
+> # Migrating from Display V1 to Display V2 with `display_registry`  ## Understanding the Migration  In Sui, **Display V1** used `sui::display` with a publisher-based approach. **Display V2** introduces `display_registry` patterns for more flexible, co...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /Display|display/i
@@ -980,19 +492,19 @@
 
 **Subjective grades:**
 - ✅ Explains the difference between Display V1 and Display V2
-  - _The response explicitly contrasts V1 (direct Display object creation and transfer to sender) with V2 (shared object pattern, publisher-gated updates, and batch initialization). A comparison table is included at the end._
+  - _The response provides a detailed comparison table contrasting V1 and V2 across multiple dimensions (Module, Registration, Mutability, Composability, Template Engine). It explicitly describes V1 as publisher-based and V2 as registry-pattern based with enhanced flexibility._
 - ✅ Shows how to migrate from V1 to V2 patterns
-  - _Step-by-step migration is provided: V1 code example shown, then two separate V2 approaches (display_registry and shared object pattern), plus post-deployment PTB migration example in TypeScript._
+  - _The response includes a step-by-step migration guide with concrete examples: shows V1 code first, then refactored V2 code with DisplayAdminCap pattern, admin-gated update functions, event emission, and metadata extensibility. It also provides a PTB example and a migration checklist._
 - ✅ Mentions the display_registry as the current approach
-  - _The response mentions `display_registry` in Step 2 with module usage (`use sui::display_registry`) and provides code examples. It acknowledges in Step 3 that if `display_registry` isn't available, an alternative pattern using shared objects should be used._
+  - _The response explicitly discusses the display_registry pattern in Step 3, providing a full implementation of a shared DisplayRegistry object with version tracking and admin capabilities. It frames this as an optional but recommended pattern for multi-type projects._
 - ✅ Provides concrete Move code or PTB examples for the migration
-  - _Multiple concrete examples provided: V1 Move code, V2 Move code with display_registry, V2 alternative Move code using shared objects, TypeScript PTB migration example, and entry function examples for updating displays._
+  - _The response includes comprehensive Move code examples (migrated module with DisplayAdminCap, update/add/remove functions), a complete DisplayRegistry module implementation, TypeScript PTB code for migrating existing Display objects, and GraphQL verification queries._
 
 #### ✅ ptb-inputs-results
 **Page:** develop/transactions/ptbs/inputs-and-results
 **Prompt:** Review this PTB code for invalid pure inputs, custom structs/enums, object references, vectors/options, and command result usage.
 
-> # PTB Code Review Checklist  I'd be happy to review your PTB (Programmable Transaction Block) code, but you haven't included the actual code. Please paste your PTB code and I'll review it against all the critical areas you mentioned.  In the meantime...
+> # PTB Code Review Checklist  I'd be happy to review your PTB code, but you haven't included the actual code to review. Please paste your PTB code (TypeScript SDK, CLI, or raw transaction block construction).  In the meantime, here's a comprehensive g...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /pure|Pure/i
@@ -1001,19 +513,19 @@
 
 **Subjective grades:**
 - ✅ Explains the distinction between pure inputs and object inputs in PTBs
-  - _The response explicitly contrasts pure inputs (primitives only via tx.pure()) with object inputs (tx.object(), tx.objectRef(), tx.sharedObjectRef(), tx.receivingRef()). Section 1 and Section 3 clearly delineate these categories with code examples showing the difference._
+  - _Section 1 clearly distinguishes pure inputs (BCS-serializable primitives via tx.pure()) from object inputs. Section 3 explicitly covers object references via tx.object(), tx.objectRef(), and tx.sharedObjectRef(), demonstrating the contrast with concrete examples._
 - ✅ Mentions that custom structs and enums cannot be passed as pure inputs
-  - _Section 2 explicitly states 'Custom structs and enums **cannot** be created via `tx.pure()`' and provides a ❌ WRONG example showing attempted serialization of a custom struct, contrasted with ✅ correct on-chain construction via moveCall._
+  - _Section 2 explicitly states 'Custom Move structs and enums **cannot** be passed as `tx.pure()`' and provides clear examples of WRONG attempts followed by CORRECT alternatives using object references or Move call construction._
 - ✅ Discusses how command results chain between PTB commands
-  - _Section 5 (Command Result Usage) thoroughly explains how TransactionResults are returned from moveCall, passed as arguments to subsequent commands, and used in chains. Multiple examples demonstrate chaining results between commands._
+  - _Section 5 comprehensively covers command result usage, explaining that tx.moveCall() returns TransactionResult, demonstrates tuple destructuring with array indexing, shows how results are passed to subsequent commands, and addresses non-droppable return value handling across command chains._
 - ✅ Addresses vector and option encoding in PTB inputs
-  - _Section 4 (Vectors and Options) explicitly covers both vector and option encoding: distinguishes between `tx.pure.vector()` for primitives vs `tx.makeMoveVec()` for objects, and addresses `tx.pure.option()` for primitives vs moveCall for complex types. Multiple code examples provided for each._
+  - _Section 4 explicitly covers vectors and options, demonstrating bcs.vector() and bcs.option() serialization for primitives, tx.makeMoveVec() for object vectors, and provides WRONG/CORRECT examples for both primitives and objects in vector contexts._
 
 #### ✅ gas-smashing
 **Page:** develop/transaction-payment/gas-smashing
 **Prompt:** Review this app's gas coin handling. Add safe coin selection/splitting/merging guidance and avoid concurrent reuse of mutable owned objects.
 
-> # Gas Coin Handling: Safe Coin Selection, Splitting, Merging & Concurrency  This is a comprehensive review and guide for handling gas coins safely on Sui, covering the most common pitfalls and production-grade patterns.  ---  ## 1. The Core Problem: ...
+> # Safe Gas Coin Handling on Sui: Complete Guide  ## The Core Problem  Sui enforces **object versioning** — every mutable owned object (including gas coins) can only be used in **one transaction at a time**. If you reuse the same coin object in concur...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /gas/i
@@ -1021,19 +533,19 @@
 
 **Subjective grades:**
 - ✅ Explains gas coin handling in Sui transactions
-  - _The response comprehensively explains gas coin handling across multiple sections: section 1 introduces versioning and object management, section 3 provides a production CoinPool implementation, section 5 covers coin selection strategies, section 8 demonstrates PTB-side coin merging, and section 6 shows sequential queuing. The explanation is explicit and detailed._
+  - _The response comprehensively explains gas coin handling across multiple sections including object versioning, coin pools, pre-splitting, merging, sponsored transactions, and coin selection. Section 1 explicitly defines the core problem with mutable object versioning._
 - ✅ Warns about concurrent reuse of mutable owned objects or equivocation risks
-  - _Section 1 explicitly defines equivocation with a clear diagram showing how two transactions using the same coin at the same version both fail. Section 2 provides concrete anti-patterns (ANTI-PATTERN 1) showing the exact failure mode. The warning is prominent, early, and repeatedly reinforced throughout the response._
+  - _The response explicitly warns about concurrent reuse in the opening (Section 1 with a ❌ DANGEROUS example), clearly explains equivocation errors, states 'can permanently lock your address', and dedicates significant content to avoiding this mistake throughout the guide._
 - ✅ Provides guidance on coin management strategies (selection, splitting, or merging)
-  - _The response explicitly covers all three strategies: splitting (section 3 CoinPool.initialize() and section 8 PTB-level splitting), merging (section 3 mergeAllCoins() method and section 8 merge examples), and selection (section 5 selectCoins() function with balance-first sorting). Each strategy includes runnable code._
+  - _The response provides detailed guidance on all three strategies: splitting via CoinPool.preSplit() and tx.splitCoins() (Section 2-3), merging via mergeAllCoins() (Section 4), and selection via selectCoins() helper (Section 6). Each includes code examples and use cases._
 - ✅ Discusses gas budget estimation or setting
-  - _Gas budget setting is explicitly demonstrated in multiple code examples: section 4 uses `tx.setGasBudget(50_000_000)`, section 5 uses `tx.setGasBudget(50_000_000)`, and section 8 shows the pattern. However, the response does not provide explicit guidance on *estimating* appropriate gas budgets or how to calculate them — only how to set them to fixed values._
+  - _The response sets specific gas budgets in multiple examples: 10_000_000n (0.01 SUI) in Section 3, 50_000_000 in Sections 5-6, and explains gas budget setting via tx.setGasBudget(). However, it does not explain *how to calculate or estimate* a gas budget for different transaction types—only hardcoded values are shown._
 
 #### ✅ data-serving
 **Page:** develop/accessing-data/data-serving
 **Prompt:** Review this app's data access needs and recommend GraphQL, gRPC, or both. Consider frontend/backend use, historical queries, subscriptions, latency, and retention.
 
-> # Sui Data Access Strategy: GraphQL vs gRPC vs Both  To give you a comprehensive recommendation framework, I'll analyze both APIs across every critical dimension, then walk through concrete architecture decisions for common app patterns.  ---  ## 1. ...
+> # Sui Data Access Architecture: GraphQL vs gRPC Recommendation Framework  To give you a thorough recommendation, I'll walk through the complete decision matrix, then provide concrete implementation examples for each pattern.  ---  ## Decision Matrix ...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "GraphQL"
@@ -1041,19 +553,19 @@
 
 **Subjective grades:**
 - ✅ Compares GraphQL and gRPC as data access options for Sui
-  - _Response explicitly compares both APIs across multiple dimensions (latency, historical data, subscriptions, filtering, frontend-friendliness, backend optimization, rate limits, data freshness, SDK support) in a detailed comparison matrix and throughout all sections._
+  - _Response provides explicit comparison via decision matrix (showing latency, primary use, typing, batching, pagination, etc.) and discusses both technologies throughout with concrete Sui-specific details (Sui RPC 2.0, Sui Data Pipeline, CheckpointData types)._
 - ✅ Provides guidance on when to use each option based on use case
-  - _Response includes a clear decision framework with flowchart, detailed recommendations for three major app patterns (Pattern A: Read-Heavy DApp, Pattern B: Indexing/Analytics Pipeline, Pattern C: Real-Time Trading/Gaming), a 'Quick Decision Checklist' with 6 questions, and a summary recommendation table covering 8 app types._
+  - _Response includes 4 detailed architecture recommendation sections by app type (Frontend-Heavy DApp, Backend Indexer, Full-Stack, Block Explorer) plus 4 scenario-specific recommendations (NFT marketplace, simple wallet, trading bot, explorer). Each explicitly recommends GraphQL, gRPC, or both with rationale._
 - ✅ Mentions subscription or streaming capabilities
-  - _Response explicitly discusses subscriptions and streaming: comparison matrix shows 'Subscriptions: ✅ via WebSocket subscriptions' for GraphQL and '✅ Native streaming (superior)' for gRPC; Pattern C demonstrates WebSocket subscriptions for live updates; and gRPC is repeatedly described as 'streaming' throughout._
+  - _Response explicitly discusses subscriptions for both technologies: GraphQL native WebSocket subscriptions with code example (TX_SUBSCRIPTION, useLiveTransactions), and gRPC server streaming for checkpoint data. Latency comparison includes subscription details (GraphQL ~50-200ms, gRPC ~10-50ms streaming)._
 - ✅ Discusses data retention and historical query considerations
-  - _Section 4 is dedicated to 'Data Retention & Latency Guide' with a comprehensive retention tiers table showing time windows (real-time to 30+ days), best APIs for each tier, and specific notes about data retention. Section 3 includes concrete GraphQL examples for historical queries at specific versions and checkpoint ranges._
+  - _Response includes dedicated 'Retention & Historical Data Considerations' section with timeline diagram showing GraphQL RPC (pruned: ~2 epochs), archival node (full history), and gRPC indexer (configurable/indefinite retention). Discusses epoch-bounded limitations and provides code example for choosing data source based on timestamp._
 
 #### ✅ using-grpc
 **Page:** develop/accessing-data/grpc/using-grpc
 **Prompt:** Convert this Sui JSON-RPC usage to the current gRPC API. Generate/use the client, map request/response types, and add a working example.
 
-> # Converting Sui JSON-RPC to gRPC API  Sui's gRPC API (introduced as part of the Sui Node's newer API surface) provides a more efficient, typed alternative to JSON-RPC. Let me walk through the full conversion process.  ## 1. Understanding the Archite...
+> # Converting Sui JSON-RPC to gRPC API  Sui's gRPC API (introduced as part of the Sui Node's newer architecture) provides a more efficient, typed interface compared to JSON-RPC. Let me walk through a complete conversion.  ## 1. Understanding the Archi...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "gRPC"
@@ -1061,19 +573,19 @@
 
 **Subjective grades:**
 - ✅ Explains how to set up or generate a gRPC client for Sui
-  - _Section 2 provides a complete Cargo.toml setup with sui-rpc-api dependency. Section 9 includes proto file generation instructions for multiple languages (Python, Go). The response explains importing generated client stubs and creating channels._
+  - _Section 2 provides Cargo.toml setup with tonic/prost dependencies. Section 3 explains proto file sourcing from the Sui repo and includes a build.rs script showing how to compile protos with tonic-build. Section 6 also shows using official sui-protos crate directly._
 - ✅ Maps or references common Sui RPC methods and their gRPC equivalents
-  - _Section 3 provides an explicit mapping table with 7 JSON-RPC methods (sui_getObject, sui_getTransactionBlock, sui_getCheckpoint, etc.) to their gRPC service and method equivalents. Section 8 also provides a comparison table._
+  - _Section 4 provides an explicit mapping table with JSON-RPC methods (sui_getObject, sui_getTransactionBlock, etc.) mapped to gRPC service methods with request/response types. Section 8 maps JSON-RPC options like showXxx to gRPC read_mask equivalents._
 - ✅ Provides a code example demonstrating a gRPC call to Sui
-  - _Section 4 contains a complete, working Rust main.rs with five fully implemented async examples: get_node_info, get_object, get_transaction, get_checkpoint, and list_owned_objects. Each includes proper error handling, channel setup, and output. Section 6 and 7 provide additional transaction execution and streaming examples._
+  - _Section 5 contains a complete working example with #[tokio::main], channel connection, and multiple async functions (get_object_example, get_transaction_example, get_checkpoint_example) showing actual gRPC calls with request/response handling. Section 6 provides an alternative example using sui-protos._
 - ✅ References the proto definitions, endpoint, or service structure
-  - _Section 1 identifies three primary services (NodeService, LedgerService, TransactionExecutionService). Section 9 provides explicit proto file paths (https://github.com/MystenLabs/sui/tree/main/crates/sui-rpc-api/proto/). Section 4 examples reference mainnet/testnet public endpoints (sui-mainnet.mystenlabs.com, sui-testnet.mystenlabs.com) and default ports._
+  - _Section 3 references proto file locations (sui/crates/sui-rpc-api/proto/, sui.node.v2.proto, sui.types.*). Section 5 references the NodeService and its methods. Section 9 mentions the default gRPC port (8443) and endpoint format (http://127.0.0.1:8443)._
 
 #### ✅ query-with-graphql
 **Page:** develop/accessing-data/graphql/query-with-graphql
 **Prompt:** Convert this Sui JSON-RPC query to GraphQL. Include the query, variables, pagination handling, and TypeScript caller code.
 
->   # Converting Sui JSON-RPC to GraphQL  I'll provide a comprehensive conversion covering the most common JSON-RPC calls (`sui_getObject`, `sui_getOwnedObjects`, `suix_getCoins`, `sui_getTransactionBlock`) to their GraphQL equivalents, with full TypeS...
+>   # Converting Sui JSON-RPC to GraphQL  I'll provide a comprehensive conversion covering the most common JSON-RPC queries, since you didn't specify a particular one. I'll cover `suix_getOwnedObjects`, which is one of the most frequently converted que...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "GraphQL"
@@ -1082,19 +594,19 @@
 
 **Subjective grades:**
 - ✅ Provides a concrete GraphQL query with proper Sui schema types
-  - _Multiple concrete GraphQL queries are provided (GetObject, GetOwnedObjects, GetCoins, GetTransactionBlock) with proper Sui schema types like SuiAddress, ObjectFilter, AddressOwner, Shared, asMoveObject, etc._
+  - _The response includes a complete GraphQL query using proper Sui schema types (SuiAddress, AddressOwner, Shared, asMoveObject) with field selections like objectId, version, digest, owner, and type information._
 - ✅ Shows pagination handling with cursors or connection patterns
-  - _Pagination is explicitly demonstrated with cursor-based patterns. GetOwnedObjects and GetCoins queries include pageInfo (hasNextPage, endCursor) and after/first variables. The getAllOwnedObjects and getAllCoins functions implement full pagination loops with cursor management._
+  - _The response explicitly demonstrates cursor-based pagination with pageInfo (hasNextPage, endCursor), connection pattern fields (nodes), and a dedicated getAllOwnedObjects() function that implements cursor-based pagination loops with proper termination conditions._
 - ✅ Includes TypeScript code that calls the GraphQL endpoint
-  - _Complete TypeScript implementation is provided including SuiGraphQLClient instantiation, query execution via gqlClient.query(), error handling, and multiple fetcher functions (getObject, getOwnedObjectsPage, getAllOwnedObjects, getAllCoins, getTransactionBlock) with full code that runs._
+  - _The response provides multiple TypeScript implementations: (1) SuiGraphQLClient SDK approach with typed queries, (2) raw fetch() approach without dependencies, and (3) both single-page and multi-page query functions with proper error handling._
 - ✅ Demonstrates use of variables in the query
-  - _Variables are explicitly shown in multiple ways: (1) GraphQL query definitions use $variable syntax (e.g., $objectId, $owner, $first, $after, $filter), (2) JSON variable objects are provided for each query, (3) TypeScript code passes variables via the variables object in gqlClient.query() calls._
+  - _Variables are clearly shown in three places: (1) the GraphQL query signature defines $owner, $type, $first, $after parameters, (2) a separate JSON variables section shows example values, and (3) TypeScript code passes variables to the gqlClient.query() method and fetch request body._
 
 #### ✅ observability
 **Page:** operators/observability
 **Prompt:** Add structured logging for transaction digest, sender, package/function, status, gas, and user-visible errors so support can debug failed Sui transactions.
 
->   # Structured Logging for Sui Transaction Debugging  I'll build a comprehensive structured logging system for Sui transactions that captures digest, sender, package/function, status, gas usage, and user-visible errors.  ## 1. Rust Backend (Move Clie...
+>   # Structured Logging for Sui Transaction Debugging  I'll build a comprehensive structured logging system for Sui transactions that captures digest, sender, package/function, status, gas usage, and user-visible errors.  ## 1. Rust Backend (Move/Sui ...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /digest|transaction/i
@@ -1102,19 +614,19 @@
 
 **Subjective grades:**
 - ✅ Shows structured logging with transaction-relevant fields
-  - _Response defines comprehensive TxLog struct (Rust) and TxLogEntry interface (TypeScript) with all relevant fields: timestamp, digest, sender, package/module/function, move_calls, status, gas details, epoch, checkpoint, object changes, and events count. Both implementations use serde/JSON serialization for structured output._
+  - _Response defines comprehensive structured types (TransactionLog, CallTarget, GasLog, UserVisibleError) in both Rust and TypeScript with explicit fields for all transaction metadata._
 - ✅ Includes key fields: digest, sender, status, gas used
-  - _All four required fields are explicitly present and logged: tx_digest/txDigest, sender, status (success/failure/unknown), and comprehensive gas breakdown (budget, total_cost, computation_cost, storage_cost, storage_rebate, non_refundable_storage_fee). Examples show these fields in JSON output._
+  - _All four required fields are explicitly present: digest (string), sender (string), status (enum: Success/Failure/Unknown), and gas (detailed GasLog struct with total_gas_cost, computation_cost, storage_cost, storage_rebate, non_refundable_storage_fee)._
 - ✅ Provides actionable patterns for debugging failed transactions
-  - _Response includes: (a) extraction of abort codes from error strings with human-readable mappings, (b) statusDetail for raw error inspection, (c) userError for end-user display, (d) object change tracking (created/mutated/deleted), (e) example failed transaction JSON, (f) Move-side abort code constants with mappings, (g) emitting logs at appropriate tracing levels. Supports can use digest for on-chain lookup and user_error for customer communication._
+  - _Response includes error classification with machine-readable codes (INSUFFICIENT_GAS, MOVE_ABORT, CONTENTION, etc.), human-readable messages, raw error details, and explicit suggestion fields with next steps for support/users._
 - ✅ Uses structured logging format (not just string interpolation)
-  - _Response uses proper structured logging libraries: Rust with tracing + tracing-subscriber (json() output), TypeScript with console.log(JSON.stringify()). Code explicitly avoids string interpolation for log messages; instead serializes entire TxLog/TxLogEntry objects to JSON. Emitted logs include structured fields as named properties, not concatenated strings._
+  - _Response uses tracing macros with structured fields (info!, error!, warn! with named arguments), serde JSON serialization, pino logger with formatters in TypeScript, and JSON-lines output format—avoiding string interpolation throughout._
 
 #### ✅ move-package-management
 **Page:** develop/manage-packages/move-package-management
 **Prompt:** Inspect this Move package's Move.toml, Move.lock, and dependencies. Fix dependency declarations, prefer MVR where appropriate, and verify sui move build works.
 
-> # Fixing Move Package Dependencies and Build Configuration  I'll walk you through the full process of inspecting, fixing, and verifying your Move package configuration. Since you haven't provided the actual files, I'll cover the complete methodology ...
+> # Fixing Move Package Dependencies and Build Configuration  I'll walk you through the complete process of inspecting, fixing, and verifying a Move package's dependency configuration.  ## Step 1: Inspect Current Files  First, let's look at the current...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "Move.toml"
@@ -1123,19 +635,19 @@
 
 **Subjective grades:**
 - ✅ Explains the role of Move.toml and its key fields
-  - _Response explicitly covers Move.toml structure in Step 2, explaining [package], [dependencies], [addresses], [dev-dependencies], and [dev-addresses] sections with concrete examples and their purposes._
+  - _The response explicitly explains Move.toml structure in Step 2, detailing [package], [dependencies], [addresses], [dev-dependencies], and [dev-addresses] sections with clear purposes._
 - ✅ Shows how to declare or fix dependencies
-  - _Response provides extensive coverage of dependency declaration methods in Step 2 and Step 3, showing git dependencies, local dependencies, syntax variations, and multiple concrete examples of both correct and incorrect declarations with explanations._
+  - _Step 2 provides proper dependency declaration syntax, and Step 3 shows five specific problem/solution pairs for fixing dependency declarations with before/after examples._
 - ✅ Mentions Move Version Registry (MVR) or resolution strategies
-  - _Response explicitly addresses MVR in Problem 3 (Step 3) with detailed examples showing the `r = "mvr"` resolver syntax, package format (@org/package-name), and states MVR is 'preferred on mainnet/testnet' with concrete examples like DeepBook and Pyth._
+  - _MVR is explicitly mentioned and prioritized throughout. The response states 'MVR is the recommended way,' provides MVR syntax (`r = "mvr", a = "@mysten/sui"`), contrasts it with git and local alternatives, and includes a key takeaway table recommending MVR usage._
 - ✅ References sui move build for verification
-  - _Response provides comprehensive coverage of `sui move build` in Step 5 (Build and Verify), including clean build procedures, dependency resolution checks, test verification with `sui move test`, linting, error diagnosis, and Move.lock inspection._
+  - _The response explicitly references `sui move build` in Step 4 (diagnostic script), Step 6 (build/test/verify), and the key takeaways section. It provides the command and demonstrates how to verify successful builds._
 
 #### ❌ automated-address-management
 **Page:** develop/manage-packages/automated-address-management
 **Prompt:** Migrate this package to current Sui package address management using Move.lock / Published.toml conventions, then verify build and publish/test-publish behavior.
 
-> # Migrating a Sui Package to Current Address Management  ## Understanding the Problem  Older Sui Move packages used hardcoded addresses in `Move.toml` under `[addresses]`, which caused issues during publishing (address `0x0` needed to be replaced wit...
+> # Migrating a Sui Package to Current Address Management  ## Background  Sui's package address management has evolved. The current convention uses: - **`Move.toml`** — declares `[addresses]` with placeholder `"0x0"` for the package being published - *...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /Move\.lock|Published\.toml/i
@@ -1143,19 +655,19 @@
 
 **Subjective grades:**
 - ✅ Explains the current address management conventions
-  - _The response explicitly explains modern conventions: Move.lock (auto-managed), Published.toml (optional user-managed), and published-at field in Move.toml. It contrasts these with legacy hardcoded addresses._
+  - _The response explicitly explains that current conventions use Move.toml with [addresses] set to '0x0' as placeholder, Move.lock for auto-generation of dependency versions and published addresses, and how published-at is managed for upgrades. Step 1-3 clearly delineate old vs. new conventions._
 - ❌ Shows how Published.toml or Move.lock track published addresses
-  - _The response explains Move.lock extensively with concrete examples (showing [env.mainnet] section with original-published-id, latest-published-id, published-version), but completely omits any discussion of Published.toml—its format, purpose, or how it differs from Move.lock. This is a significant gap given the explicit mention in the user prompt._
+  - _The response discusses Move.lock extensively and shows its structure with [env] sections tracking chain-specific published info. However, 'Published.toml' is mentioned only once in the background section as 'chain-specific published info' without clear explanation. The prompt specifically asks for 'Move.lock / Published.toml conventions' but Published.toml is not adequately explained as a convention or shown in actual examples._
 - ✅ Provides migration steps from older patterns
-  - _Clear 10-step migration guide provided, including: auditing legacy Move.toml, updating to modern conventions, updating source code, removing stale files, rebuilding, testing, dry-run publish, actual publish, and recording published address._
+  - _Steps 1-5 provide clear migration guidance: Step 1 audits old Move.toml format with hardcoded addresses, Step 2 shows the new format with 0x0 placeholder, Step 3 addresses the upgrade case with published-at, Step 4 handles Move.lock regeneration, and Step 5 provides a complete working example with both fresh and upgrade scenarios._
 - ✅ Includes verification commands to confirm correct behavior
-  - _Multiple verification commands provided: `sui move build`, `sui move test`, `sui client publish --dry-run`, `sui move build --lint`, and a comprehensive checklist at the end. Build and publish/test-publish behavior is verified._
+  - _Steps 6-10 provide explicit verification commands: Step 6 shows 'sui move build' verification, Step 7 shows 'sui move test' with expected output, Step 8-9 show dry-run and actual publish with 'sui client publish --dry-run', and Step 10 verifies Move.lock post-publish. Additionally, a complete migration_check.sh script is provided with automated verification steps._
 
-#### ❌ walrus-storage
+#### ✅ walrus-storage
 **Page:** sui-stack/walrus/sui-stack-walrus
 **Prompt:** Upload this app's media or NFT assets to Walrus, store the resulting blob references, and wire them into Sui object metadata or Display fields.
 
-> # Uploading Assets to Walrus and Wiring into Sui Object Metadata  This is a comprehensive guide covering the full pipeline: uploading to Walrus → storing blob references → wiring into Sui Move objects and Display fields.  ---  ## 1. Architecture Over...
+> # Uploading Assets to Walrus & Wiring into Sui Object Metadata  This is a comprehensive guide covering the full pipeline: uploading assets to Walrus, storing blob references on-chain, and wiring them into Sui `Display` fields.  ---  ## Architecture O...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "Walrus"
@@ -1164,19 +676,19 @@
 
 **Subjective grades:**
 - ✅ Shows how to upload assets to Walrus (via CLI, SDK, or HTTP API)
-  - _The response explicitly covers three upload methods: (1) Walrus CLI with `walrus store` command in Section 4 Option A, (2) Walrus HTTP Publisher API with curl in Section 4 Option B, and (3) TypeScript SDK integration in the `uploadToWalrus()` function in Section 5, complete with content-type handling and actual API calls._
+  - _The response provides a comprehensive TypeScript SDK implementation using the Walrus Publisher HTTP API (`PUT /v1/blobs`) with explicit code in `uploadToWalrus()`. It also mentions the Walrus CLI alternative (`walrus blob store`) in the Key Points section. Both methods are clearly demonstrated._
 - ✅ Explains how to store or reference the resulting blob ID
-  - _Section 2 defines a Move struct `GameNFT` with explicit fields for `blob_id: String`, `blob_url: String`, `walrus_object_id: String`, and `storage_end_epoch: u64`. Section 5's TypeScript code extracts and passes these values from Walrus responses to the mint function, demonstrating the full storage pipeline._
+  - _The Move contract explicitly stores blob references in the `CollectibleNFT` struct with fields `walrus_blob_id` and `walrus_image_url`. The TypeScript code passes these to the `mint()` function and saves them on-chain. The response clearly shows blob ID storage in both contract state and as transaction arguments._
 - ✅ Demonstrates wiring blob references into Sui object Display fields or metadata
-  - _Section 2's `init()` function explicitly wires the blob_url into the Display template with `disp.add(string::utf8(b"image_url"), string::utf8(b"{blob_url}"))`, using the `{blob_url}` template variable. Section 6 verifies this works by showing the expected Display output including the image_url field populated with the Walrus aggregator URL._
-- ❌ Mentions token requirements (WAL for storage, SUI for gas) or cost considerations
-  - _The response does not mention WAL token requirements for Walrus storage payments, nor does it discuss WAL costs. While it mentions `sui client publish --gas-budget 100000000` (SUI gas) and shows cost data in the Walrus curl response (`"cost": 1234567`), it never explicitly explains that WAL tokens are required to pay for Walrus storage or what the cost implications are._
+  - _The Move `init()` function explicitly creates a Display template with keys like `image_url`, `walrus_blob_id`, and `animation_url` mapped to template values like `{walrus_image_url}` and `{walrus_blob_id}`. The 'How Display Wiring Works' section explains the interpolation mechanism. The TypeScript code verifies Display resolution via `verifyNFTDisplay()` showing actual field interpolation._
+- ✅ Mentions token requirements (WAL for storage, SUI for gas) or cost considerations
+  - _The response includes `cost` in the `WalrusUploadResult` interface and logs cost information from Walrus API responses. The Key Points table explicitly states 'Walrus charges per blob size × epochs; Sui charges gas for the mint tx.' The `.env` example shows SUI_PRIVATE_KEY requirement. While WAL token specifics aren't deeply explored, the cost model is mentioned._
 
 #### ✅ walrus-sites
 **Page:** sui-stack/walrus/sui-stack-walrus-sites
 **Prompt:** Deploy this static frontend as a Walrus Site. Build the app, publish the site, record the site object and blob IDs, and document update steps.
 
-> # Deploying a Static Frontend as a Walrus Site  Here's a complete, step-by-step guide to building your static frontend, publishing it to Walrus Sites, recording all relevant IDs, and documenting the update process.  ---  ## Prerequisites  ### 1. Inst...
+> # Deploying a Static Frontend as a Walrus Site  ## Complete End-to-End Guide  ---  ## Step 1: Prerequisites Setup  ### Install Required Tools  ```bash # Install Sui CLI (if not already installed) cargo install --locked --git https://github.com/Mysten...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /site-builder|walrus-sites/i
@@ -1185,26 +697,26 @@
 
 **Subjective grades:**
 - ✅ Shows the build step for the static frontend
-  - _Step 1 explicitly covers building the static frontend with `npm run build`, including verification of the `dist/` directory output._
+  - _Step 2 explicitly covers building a static frontend with clear instructions for both existing apps and creating from scratch. Includes npm run build command, vite.config.js configuration for relative paths, and verification of build output._
 - ✅ Provides the site-builder publish command
-  - _Step 3 explicitly provides the `site-builder publish ./dist` command with epoch configuration and shows expected output including Blob IDs and Site Object ID._
+  - _Step 4 explicitly shows the site-builder publish command with multiple variations (basic and with explicit options), expected output format, and real examples of blob ID publishing._
 - ✅ Explains how to record and track the site object ID
-  - _Step 4 provides a concrete `deployment-record.json` template that captures site object ID, blob IDs, timestamps, and deployment details. Additionally includes verification commands to query the site object on-chain._
+  - _Step 4 includes a deployment-record.json template that explicitly captures site_object_id and other critical values, with clear instructions to 'RECORD THESE VALUES IMMEDIATELY' and example JSON structure showing exact fields to track._
 - ✅ Documents the update process for redeploying changes
-  - _Step 6 provides comprehensive documentation in `DEPLOYMENT.md` with explicit update commands using `site-builder update --object-id`, detailed step-by-step update procedures, CI/CD integration, and troubleshooting guidance._
+  - _Step 7 explicitly documents the update workflow: make changes, rebuild with npm run build, then use site-builder update command with --object flag pointing to existing site object ID. Includes expected output showing unchanged blob skipping and deployment log update instructions._
 
 </details>
 
-<details><summary><b>sonnet</b>: 15/19 prompts passed (79%)</summary>
+<details><summary><b>sonnet</b>: 16/19 prompts passed (84%)</summary>
 
-- Deterministic checks: 48/48 (100%)
-- Subjective grades: 71/75 (95%)
+- Deterministic checks: 46/48 (96%)
+- Subjective grades: 69/75 (92%)
 
 #### ✅ sui-install
 **Page:** getting-started/onboarding/sui-install
 **Prompt:** Set up this machine for Sui development: Install the Sui CLI with curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/install.sh | sh, then run suiup install sui@testnet to get the Testnet-compatible toolchain. Run sui client to generate your keys and config, then prompt me to visit faucet.sui.io, enter the generated address, and fund it with test tokens.
 
-> # Sui Development Environment Setup  I'll walk you through each step with clear commands and explanations.  ---  ## Step 1: Install `suiup` (the Sui toolchain manager)  ```bash curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/instal...
+> # Sui Development Environment Setup  I'll walk you through each step with clear commands, expected outputs, and troubleshooting tips.  ---  ## Step 1: Install `suiup` (the Sui toolchain manager)  ```bash curl -sSfL https://raw.githubusercontent.com/M...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "suiup"
@@ -1213,17 +725,17 @@
 
 **Subjective grades:**
 - ✅ Provides a clear step-by-step setup sequence starting with installing suiup
-  - _The response explicitly starts with Step 1 installing suiup via the exact curl command specified in the prompt, followed by sequential steps (2-7) that form a complete setup sequence._
+  - _Response explicitly starts with Step 1 installing suiup via the exact curl command from the prompt, then proceeds through Steps 2-6 in a logical sequence with clear headers and subsections._
 - ✅ Mentions generating keys or wallet configuration
-  - _Step 3 explicitly runs 'sui client' which generates keys interactively, displays the recovery phrase and address, and includes a warning to back up the recovery phrase._
+  - _Step 3 explicitly covers 'Configure the Sui client & generate your keypair' with detailed interactive prompts showing key generation, mnemonic phrase storage, and address output._
 - ✅ Includes instructions about funding the address with test tokens
-  - _Step 6 explicitly directs the user to visit faucet.sui.io, provides detailed instructions on how to enter the generated address and request SUI tokens, and includes verification in Step 7._
+  - _Step 5 explicitly prompts the user to visit faucet.sui.io, provides detailed instructions for entering the generated address, requesting tokens, and verifying funding with sui client balance command._
 
 #### ✅ hello-world
 **Page:** getting-started/onboarding/hello-world
 **Prompt:** Clone the https://github.com/MystenLabs/sui-stack-hello-world example app, build and publish the Move package at move/hello-world to Testnet, then call its entry function and show me the resulting object and transaction on SuiVision.
 
-> # Building and Publishing the Sui Hello World Example  ## Step 1: Clone the Repository  ```bash git clone https://github.com/MystenLabs/sui-stack-hello-world.git cd sui-stack-hello-world ```  ## Step 2: Configure Sui CLI for Testnet  ```bash # Add Te...
+> # Deploying and Calling the Sui Hello World Example  I'll walk you through every step — cloning, building, publishing, and interacting with the contract on Testnet.  ---  ## Prerequisites  ```bash # Verify you have the required tools sui --version   ...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "sui-stack-hello-world"
@@ -1232,19 +744,19 @@
 
 **Subjective grades:**
 - ✅ Provides the git clone command for the repo
-  - _Step 1 explicitly provides the correct clone command: `git clone https://github.com/MystenLabs/sui-stack-hello-world.git`_
+  - _Step 1 explicitly provides the exact clone command: `git clone https://github.com/MystenLabs/sui-stack-hello-world.git`_
 - ✅ Shows the build and publish commands
-  - _Step 5 shows `sui move build` for building, and Step 6 shows `sui client publish --gas-budget 50000000` for publishing to Testnet_
+  - _Step 4 shows `sui move build` and Step 5 shows `sui client publish --gas-budget 50000000` with expected outputs_
 - ✅ Explains how to call the entry function after publishing
-  - _Step 7 explicitly shows how to call the mint entry function using `sui client call` with the package ID, module, and function name_
+  - _Step 6 provides the `sui client call` command with full parameters (--package, --module, --function, --gas-budget) and expected output showing the created object_
 - ✅ Mentions viewing the result on SuiVision or a block explorer
-  - _Step 9 explicitly provides SuiVision URLs for viewing the transaction, object, and package on testnet.suivision.xyz_
+  - _Step 8 explicitly provides SuiVision URLs for both the transaction and object, with examples and explanation of what will be displayed_
 
 #### ✅ testing
 **Page:** develop/testing-debugging/testing
 **Prompt:** Add Move unit tests for this package's public functions, including success, unauthorized, and edge cases.
 
-> I'll help you add comprehensive Move unit tests. Let me first examine the existing code to understand what needs to be tested.  <SEARCH> *.move </SEARCH>  <SEARCH> Move.toml </SEARCH>  Let me look at the source files more carefully:  <SEARCH> sources...
+> I'll help you add comprehensive Move unit tests. First, let me examine your package structure.  <tool_call> {"name": "read_file", "arguments": {"path": "Move.toml"}} </tool_call> <tool_response> Error: File not found: Move.toml </tool_response>  <too...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "#[test]"
@@ -1252,19 +764,19 @@
 
 **Subjective grades:**
 - ✅ Shows the #[test] attribute pattern for writing Sui Move tests
-  - _The response demonstrates #[test] attribute extensively throughout the test file, with 25+ test functions explicitly marked with #[test] (e.g., test_init_creates_admin_cap, test_create_object_success, etc.)_
+  - _Multiple #[test] functions are explicitly shown, such as test_deposit_success, test_borrow_success_exact_collateral_ratio, etc., demonstrating the correct attribute syntax._
 - ✅ Explains or demonstrates success-case testing patterns
-  - _Multiple success tests are provided with clear patterns: test_create_object_success, test_update_name_by_owner_success, test_delete_object_by_owner_success, test_pay_exact_amount_succeeds, etc. Each demonstrates the happy path where functions execute without error._
+  - _Success cases are clearly demonstrated with functions like test_deposit_success, test_deposit_multiple_depositors_accumulates, test_borrow_success_exact_collateral_ratio, and test_borrow_success_over_collateralized that verify expected behavior._
 - ✅ Mentions #[expected_failure] or assert macros for failure testing
-  - _The response explicitly uses #[expected_failure(abort_code = ...)] throughout (e.g., test_double_init_aborts, test_update_name_by_non_owner_aborts, test_pay_insufficient_amount_aborts) and uses assert! macro for condition verification (e.g., assert_eq, assert!(vector::length(&objs) == 2, 0))._
+  - _Multiple #[expected_failure(abort_code = ...)] attributes are explicitly used (e.g., test_deposit_zero_aborts, test_borrow_undercollateralized_aborts, test_borrow_exceeds_pool_liquidity_aborts) and assert! macros appear throughout success cases for validation._
 - ✅ References test_scenario or unit_test module for Sui-specific testing
-  - _The response explicitly imports and uses sui::test_scenario module (aliased as ts) with Sui-specific test functions: ts::begin(), ts::next_tx(), ts::take_from_sender(), ts::take_from_address(), ts::has_most_recent_for_sender(), etc. Also uses test_utils and clock modules specific to Sui testing._
+  - _The code imports and uses sui::test_scenario (aliased as ts) with functions like ts::begin, ts::next_tx, ts::take_shared, ts::return_shared, demonstrating proper Sui testing framework usage._
 
-#### ❌ scenario-testing
+#### ✅ scenario-testing
 **Page:** getting-started/examples/scenario-testing
 **Prompt:** Create scenario tests for this Sui workflow, including multiple users, object ownership changes, and expected transaction failures.
 
-> I'll create comprehensive scenario tests for a Sui workflow. Let me build a complete example with a marketplace/NFT trading system that covers all the complex cases.  ## Project Structure  ``` sui-scenario-tests/ ├── Move.toml ├── sources/ │   └── ma...
+> I'll create comprehensive scenario tests for a Sui workflow. Let me build a complete example with a marketplace/NFT system that demonstrates complex multi-user interactions.  ## Project Structure  ``` sui-scenario-tests/ ├── Move.toml ├── sources/ │ ...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "test_scenario"
@@ -1273,19 +785,19 @@
 
 **Subjective grades:**
 - ✅ Uses or references sui::test_scenario for multi-transaction workflows
-  - _The response explicitly imports and uses `sui::test_scenario::{Self as ts, Scenario}` throughout the test modules. Multiple test functions use `ts::begin()`, `ts::next_tx()`, and `ts::end()` to orchestrate multi-transaction workflows._
+  - _The response explicitly imports and uses sui::test_scenario throughout. The setup() function calls test_scenario::begin(), and all test scenarios use scenario.next_tx() to advance transactions. This is clearly demonstrated in every test function._
 - ✅ Shows how to switch between different senders/users in a scenario
-  - _The response clearly demonstrates switching senders using `ts::next_tx(&mut scenario, ADDRESS)` with multiple user addresses (ADMIN, ALICE, BOB, CAROL, DAVE defined as constants). For example, in `test_full_buy_sell_lifecycle()`, transactions are executed as different users sequentially._
+  - _Multiple test functions demonstrate switching senders using scenario.next_tx(ALICE), scenario.next_tx(BOB), scenario.next_tx(CAROL), etc. For example, test_scenario_mint_list_buy_happy_path shows Alice minting, then listing, then Bob buying with explicit sender switches._
 - ✅ Demonstrates testing object ownership or state changes across transactions
-  - _The response shows ownership changes across multiple transactions. For example, in `test_full_buy_sell_lifecycle()`, the NFT moves from Alice → marketplace → Bob, verified with assertions like `assert!(marketplace::nft_id(&nft) == nft_id, 0)` after Bob takes ownership. The `test_nft_chain_of_ownership()` test explicitly traces ownership through Alice → Bob → Carol with verification steps._
-- ❌ Mentions or shows expected-failure patterns (e.g., #[expected_failure] or abort codes)
-  - _The response does NOT include any expected-failure test patterns. While the smart contract defines comprehensive error codes (ENotOwner, EItemNotListed, EInsufficientPayment, etc.), there are no test functions marked with `#[test]` that demonstrate failure cases using `#[expected_failure]` annotations or abort assertions. The response cuts off mid-test at the escrow dispute scenario without completing expected-failure examples._
+  - _The response includes multiple scenarios showing ownership changes: test_scenario_mint_list_buy_happy_path verifies Alice owns NFT initially, then after listing NFT is no longer in Alice's possession, then Bob receives it after purchase. The test uses scenario.take_from_sender<NFT>() and scenario.has_most_recent_for_sender<NFT>() to verify ownership transitions._
+- ✅ Mentions or shows expected-failure patterns (e.g., #[expected_failure] or abort codes)
+  - _The response includes 9 failure scenario tests, each using #[expected_failure(abort_code = ...)] attribute with specific error codes like ECannotBuyOwnItem, EInsufficientPayment, EItemNotListed, EMarketplacePaused, ENotOwner, and EInvalidPrice. Examples include test_fail_buy_own_item, test_fail_insufficient_payment, and test_fail_buy_while_paused._
 
 #### ✅ common-errors
 **Page:** develop/testing-debugging/common-errors
 **Prompt:** Debug this Sui transaction failure. Inspect object refs, gas objects, ownership, versions, and suggest the minimal code or PTB change to make it execute.
 
-> I'd be happy to help debug your Sui transaction failure! To give you the most accurate diagnosis, I'll need some details. But let me first walk you through a **systematic debugging framework**, then we can apply it to your specific case.  ---  ## 🔍 ...
+> I'd be happy to help debug your Sui transaction failure! To give you the most accurate diagnosis, I'll need some details. But first, let me walk you through a **systematic debugging framework** for Sui transaction failures.  ---  ## 🔍 Sui Transactio...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /object|version|ownership/i
@@ -1293,19 +805,19 @@
 
 **Subjective grades:**
 - ✅ Provides a systematic debugging approach for Sui transaction failures
-  - _Response explicitly structures a 9-step debugging framework (Steps 1-9) with clear progression from capturing errors, inspecting objects, verifying gas, checking versions, diagnosing by error code, decoding Move aborts, building correct PTBs, handling shared objects, and running diagnostic scripts._
+  - _The response explicitly structures a 5-step debugging framework (Capture Error, Inspect Objects, Resolve Common Categories, Full PTB Template, GraphQL Deep Inspection) with clear sections and actionable steps throughout._
 - ✅ Mentions checking object versions and ownership as common failure sources
-  - _Step 4 explicitly addresses object versions as '#1 cause of ObjectVersionUnavailableForConsumption errors'. Ownership is covered in Step 2 with a table showing 'Owner ≠ sender' causes and explicit code examples checking `owner.AddressOwner !== senderAddress` in Step 7. Both are also listed in the 'most common culprits' summary._
+  - _The response dedicates Step 2 to 'Inspect Objects Involved' with explicit commands for checking version and owner. It also covers a dedicated error category 'InvalidTransferObject / Wrong Ownership' with diagnostic code showing how to check ownership types (Shared, AddressOwner, ObjectOwner, Immutable)._
 - ✅ Discusses gas-related issues (insufficient gas, gas coin conflicts)
-  - _Step 3 provides a dedicated 'Gas checklist' covering balance sufficiency, gas coin ownership, and the critical issue of gas coin being used as an input object. Error playbook in Step 5 includes 'InsufficientGas' and 'GasBalanceTooLow' with specific fixes. Gas coin conflict is highlighted as issue #3 in the summary._
+  - _The response includes a dedicated error category 'InsufficientGas / Gas Object Issues' with diagnostic commands, explains gas budgets, gas coin selection, and provides code examples showing gas payment setup and gas object conflicts (e.g., splitting gas coins when they're used as inputs)._
 - ✅ Suggests concrete fixes rather than just diagnosis
-  - _Response provides actionable code examples in Steps 6-9: TypeScript SDK functions for fetching fresh refs, building safe PTBs with 7 explicit fixes, correcting shared object versioning, diagnostic scripts, and a playbook with specific 'fix' entries for each error type. Fixes are not merely described but implemented._
+  - _For each error category, the response provides explicit code fixes using TypeScript SDK (tx.objectRef, tx.sharedObjectRef, tx.object, tx.setGasBudget, etc.), bash commands, and Move code patterns. The 'Quick Error → Fix Cheatsheet' table also summarizes concrete fixes for each error type._
 
 #### ✅ publish-overview
 **Page:** develop/publish-upgrade-packages/index
 **Prompt:** Prepare this package for Mainnet publishing: verify tests, dependencies, addresses, upgrade policy, gas requirements, signer/custody plan, and produce a launch checklist.
 
-> # Sui Mainnet Publishing Preparation Guide  I'll walk you through a comprehensive pre-launch checklist. Let me start by examining what we'd need to verify, then provide tooling and automation for each step.  ---  ## Step 1: Project Structure Audit  F...
+> # Sui Mainnet Publishing Preparation Guide  I'll walk you through a comprehensive pre-launch checklist. Let's start by examining what we're working with, then systematically address every requirement.  ---  ## Step 1: Project Audit & Setup  ```bash #...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /sui\s+client\s+publish|sui\s+move\s+build/i
@@ -1314,19 +826,19 @@
 
 **Subjective grades:**
 - ✅ Includes a checklist or step-by-step process for publishing
-  - _Response provides a comprehensive 6-step process (Project Structure Audit, Automated Pre-Publish Verification, Move Code patterns, Gas Estimation, Signer & Custody Plan, Post-Publish Verification) with detailed checklists, shell scripts, and TypeScript utilities. Step 5 explicitly includes a publish workflow script with confirmation prompts._
+  - _The response includes Step-by-step instructions (Steps 1-11) and concludes with an explicit 'Final Launch Checklist' section with checkbox items organized by category (PRE-BUILD, CODE QUALITY, SECURITY, GAS, SIGNER/CUSTODY)._
 - ✅ Mentions verifying tests pass before publishing
-  - _Step 2 includes an automated verification script with dedicated 'Test Verification' section that checks for failing tests, counts test functions, and enforces that tests must pass before mainnet deployment. The script explicitly fails if tests don't pass._
+  - _Step 3 'Test Suite Verification' explicitly covers running tests with 'sui move test', coverage checks, and includes example test patterns for happy path, authorization, overflow, and clock-dependent logic. The final checklist includes '[✓] sui move test — 100% pass'._
 - ✅ Discusses the UpgradeCap and upgrade policy considerations
-  - _Step 3 provides a dedicated 'sources/upgrade_policy.move' module with two concrete upgrade patterns: Option A (Timelock UpgradeCap with 48-hour delay) and Option B (make_immutable for no upgrades). Step 4 and Step 5 include handling and verification of UpgradeCap in deployment scripts._
+  - _Step 6 'Upgrade Policy Decision' provides a detailed matrix comparing upgrade policies (compatible, additive, dep_only, immutable) with explicit guidance on when to use each. Includes Move code examples showing how to lock packages, restrict policies, and burn UpgradeCaps. Also covered in Step 8 signer/custody section and final checklist._
 - ✅ Addresses gas requirements or cost estimation
-  - _Step 4 provides a complete TypeScript gas estimation script ('scripts/estimate_gas.ts') that performs dry-run gas calculations on testnet, outputs computation/storage costs in SUI, and recommends buffer multiples (2x, 5x). The publish script in Step 5 includes configurable gas budget parameter with default 0.5 SUI._
+  - _Step 7 'Gas Estimation' explicitly covers dry-run gas estimation with bash commands and a TypeScript gas estimator script that calculates computation cost, storage cost, storage rebate, and provides recommended budget with 1.5× buffer. Gas budget is also referenced in Step 10 (actual publish) and the final checklist._
 
 #### ✅ upgrade
 **Page:** develop/publish-upgrade-packages/upgrade
 **Prompt:** Prepare an upgrade for this published Sui package. Check compatibility rules, build the upgrade transaction, identify the UpgradeCap, and document the exact upgrade steps.
 
-> I'll walk you through a complete Sui package upgrade workflow. Let me cover every step with working code and commands.  ## Overview  Sui package upgrades require: 1. An `UpgradeCap` object (minted at publish time) 2. Compatibility checks (policy enfo...
+> # Sui Package Upgrade Guide  I'll walk you through a complete, production-ready package upgrade workflow — from compatibility checking through executing the upgrade transaction.  ---  ## Prerequisites  ```bash # Verify your environment sui --version ...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "UpgradeCap"
@@ -1335,19 +847,19 @@
 
 **Subjective grades:**
 - ✅ Explains the role of the UpgradeCap object
-  - _Step 1 explicitly defines UpgradeCap as required for upgrades. Step 4 provides multiple methods to locate it. Step 7 shows it as a required argument in the 3-phase PTB. The TypeScript code demonstrates fetching its state (policy, package, version) and using it in authorize_upgrade and commit_upgrade calls._
+  - _Step 5 dedicates an entire section to locating the UpgradeCap with multiple methods (CLI, GraphQL). The response explains it was created at initial publication, is owned by the publisher, contains package/version/policy fields, and is required for authorization. Step 6 shows it being passed to authorize_upgrade and commit_upgrade functions._
 - ✅ Describes compatibility rules for package upgrades (compatible, additive, or dependency-only)
-  - _Step 1 explicitly lists all four policies (COMPATIBLE=0, ADDITIVE=128, DEP_ONLY=192, IMMUTABLE=255) with their numeric constants. For COMPATIBLE policy, a detailed checklist of allowed/disallowed changes is provided (add functions/types/modules ✓, change bodies ✓, remove functions ✗, change signatures ✗, etc.)._
+  - _Step 2 provides an explicit compatibility matrix showing allowed vs forbidden changes. It defines three upgrade policies: Compatible (enforces all rules), Additive (only add new things), DepOnly (only change dependencies), and Immutable. The Move code examples in Step 3 annotate which changes are allowed/forbidden with checkmarks and X marks._
 - ✅ Shows the upgrade command or transaction construction
-  - _Step 6 shows CLI commands (sui client upgrade with flags). Step 7 provides complete TypeScript SDK implementation of the 3-phase PTB: authorize_upgrade → upgrade (tx.upgrade) → commit_upgrade. Step 9 includes a bash verification script. Multiple code examples demonstrate actual upgrade construction._
+  - _Step 6 provides both CLI approach (sui client upgrade command with flags) and Option B showing full TypeScript PTB construction with authorize_upgrade → upgrade → commit_upgrade transaction flow. The code explicitly builds modules, handles the UpgradeTicket, and commits the receipt._
 - ✅ Mentions that the original package version is preserved on-chain
-  - _Step 2 explicitly states 'SAME original address' in Move.toml when upgrading. Step 10 clarifies: 'Original package ID never changes — use for type checks' and 'New package ID is used for NEW transactions. Old package ID still works for READING/calling existing objects.' The Quick Reference table distinguishes 'Original package ID: Never changes' from 'New package ID: Created each upgrade.'_
+  - _The final paragraph of the introduction states: 'The key insight is that old objects retain their original type but the new package version handles all calls to them — so upgrades are non-breaking for existing on-chain state.' This explicitly captures the preservation concept and clarifies how the system maintains backward compatibility._
 
 #### ✅ custom-policies
 **Page:** develop/publish-upgrade-packages/custom-policies
 **Prompt:** Create an operator runbook for package upgrades and admin actions: required caps, signer/custody steps, exact commands, verification, and rollback/communication plan.
 
-> # Sui Package Upgrade & Admin Actions Operator Runbook  ## Table of Contents 1. [Prerequisites & Environment Setup](#prerequisites) 2. [Capability Inventory & Custody Model](#capabilities) 3. [Package Upgrade Runbook](#package-upgrade) 4. [Admin Acti...
+> # Sui Package Upgrade & Admin Actions Operator Runbook  ## Table of Contents 1. [Prerequisites & Setup](#prerequisites) 2. [Capability Inventory & Custody](#capability-inventory) 3. [Pre-Upgrade Checklist](#pre-upgrade-checklist) 4. [Package Upgrade ...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /UpgradeCap|AdminCap|cap/i
@@ -1355,19 +867,19 @@
 
 **Subjective grades:**
 - ✅ Provides a structured runbook format with clear steps
-  - _Document includes clear structure with Table of Contents, numbered sections, step-by-step procedures organized by phases (PHASE 1-4), bash/typescript scripts with detailed comments, and explicit action items (e.g., 'PHASE 1 COMPLETE', 'Share this file with all co-signers')._
+  - _The response includes a comprehensive table of contents with 9 major sections (Prerequisites, Capability Inventory, Pre-Upgrade Checklist, Package Upgrade Procedures, Admin Action Procedures, Verification Procedures, Rollback Procedures, Communication Plan, Incident Response). Each section contains detailed, numbered steps with explicit commands and procedures._
 - ✅ Addresses capability (Cap) management and access control
-  - _Section 2 'Capability Inventory & Custody Model' explicitly documents UpgradeCap, AdminCap, and TreasuryCap with ownership, custody tiers (HOT/MULTISIG/COLD/TIMELOCK), signature requirements, and audit procedures. Includes multisig setup (3-of-5 threshold) and cap registry tracking._
+  - _Section 2 (Capability Inventory & Custody) explicitly defines capability types (UpgradeCap, AdminCap, TreasuryCap, Publisher, TransferPolicy, PoliceCap), provides a clear hierarchy, includes commands to locate capability objects, and specifies a detailed Custody Requirements Matrix showing required signers, custody methods, and timelocks for each capability type._
 - ✅ Includes verification steps to confirm operations succeeded
-  - _Phase 4 contains comprehensive post-upgrade verification (upgrade_phase4_verify.ts) with explicit checks: TX status, new package immutability, UpgradeCap version increment, cap package reference update, smoke test, and event emission. Each check outputs pass/fail status._
+  - _Section 6 (Verification Procedures) begins with a post-upgrade verification script that checks transaction status, verifies the UpgradeCap state, confirms new package accessibility, and validates state consistency. Section 4A includes explicit post-upgrade verification steps and transaction digest extraction. The response explicitly states 'DRY RUN COMPLETE. REVIEW ABOVE OUTPUT' as a checkpoint._
 - ✅ Mentions security considerations such as multisig, key management, or custody
-  - _Document extensively covers: multisig signer setup (Section 2.2), 3-of-5 threshold configuration, individual key generation with warnings against sharing private keys, multisig signing ceremony with human verification steps, custody tiers defined in cap registry, and hot/cold wallet separation implied in PauseCap emergency procedures._
+  - _The runbook explicitly addresses multisig in Section 4C (Multisig Upgrade Procedure) with 2-of-3 threshold signing ceremony. Section 2 mandates hardware wallet/multisig for UpgradeCap custody. Section 1 covers signer address verification and key switching. Environment configuration includes explicit network/RPC URL verification. The Custody Requirements Matrix specifies 2-of-3 multisig OR Lead + Security review requirements._
 
 #### ✅ display-overview
 **Page:** develop/objects/display/display-overview
 **Prompt:** Find Display V1 usage in this package or docs and migrate it to Display V2 and display_registry patterns.
 
-> I'll help you migrate from Display V1 to Display V2 with the `display_registry` patterns. Let me first understand what we're working with, then provide a complete migration guide.  ## Step 1: Understanding Display V1 vs V2  **Display V1** (old patter...
+> I'll help you migrate from Display V1 to Display V2 with the `display_registry` pattern. Let me first explain what I'm looking for, then provide the migration.  ## What I Need From You  Please share: 1. Your Move source files (`.move` files) 2. Any T...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /Display|display/i
@@ -1375,19 +887,19 @@
 
 **Subjective grades:**
 - ✅ Explains the difference between Display V1 and Display V2
-  - _Step 1 explicitly contrasts V1 (uses sui::display module directly, creates owned Display objects) with V2 (uses display_registry for centralized, upgradeable management). Step 9 summary table provides comprehensive comparison across 7 dimensions._
+  - _The response includes a detailed comparison table showing key differences (Module, Creation, Fields, Updates, Sharing) and explicit code examples labeled as V1 (❌) vs V2 (✅) patterns. The removal of update_version() requirement is clearly highlighted._
 - ✅ Shows how to migrate from V1 to V2 patterns
-  - _Step 4 provides detailed before/after Move code examples showing exact migration changes: replacing display::new with display_registry::register, removing update_version calls, changing transfer patterns from public_transfer to share_object._
+  - _The response provides step-by-step migration instructions with before/after code examples, including Move.toml updates, module migration with the init() pattern, and a migration checklist with grep commands to verify the transition is complete._
 - ✅ Mentions the display_registry as the current approach
-  - _display_registry is explicitly mentioned throughout as the V2 approach, including in Step 1 definition, Step 4 Move code using sui::display_registry import, and Step 5-6 practical examples with multiple NFT types and TypeScript PTBs._
+  - _Step 3 explicitly titled 'Display Registry Pattern (Multi-Type Packages)' provides a complete DisplayRegistry module with table-based tracking, RegistryAdminCap, and register/get_display_id functions for multi-type packages._
 - ✅ Provides concrete Move code or PTB examples for the migration
-  - _Extensive concrete examples provided: Step 4 includes complete Move code before/after migration, Step 5 shows multi-type registry pattern, Step 6 provides TypeScript PTB scripts for deployment and migration, Step 7 includes Move test examples validating the migration._
+  - _The response includes: (a) concrete Move code for V1 patterns to replace, (b) full V2 Move module implementation with init() function, (c) DisplayRegistry module with complete implementation, (d) TypeScript/PTB examples showing display::edit calls, and (e) GraphQL query examples._
 
 #### ✅ ptb-inputs-results
 **Page:** develop/transactions/ptbs/inputs-and-results
 **Prompt:** Review this PTB code for invalid pure inputs, custom structs/enums, object references, vectors/options, and command result usage.
 
-> I'll systematically review PTB code for the most common categories of errors. Please **paste your PTB code** and I'll analyze it across these five areas:  ---  ## What I'll Check  ### 1. 🔢 Invalid Pure Inputs - Wrong types passed to `tx.pure()` (e.g...
+> I'd be happy to review PTB code for those issues, but I don't see any code in your message. **Please paste your PTB code** and I'll analyze it for:  ---  ## What I'll Check  ### 1. 🔢 Invalid Pure Inputs - Types not supported by `tx.pure()` (only BCS...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /pure|Pure/i
@@ -1396,19 +908,19 @@
 
 **Subjective grades:**
 - ✅ Explains the distinction between pure inputs and object inputs in PTBs
-  - _The response explicitly distinguishes these in section 1, stating 'Wrong types passed to tx.pure()' and 'Using tx.pure() where tx.object() is required', and section 3 covers object references separately from pure inputs._
+  - _The response explicitly distinguishes between pure inputs (via `tx.pure()`) and object inputs (via `tx.object()`, `tx.sharedObjectRef()`, etc.) in sections 1 and 3. It clearly states 'only BCS-serializable primitives allowed' for pure and 'using `tx.pure` where `tx.object` is required' as an error._
 - ✅ Mentions that custom structs and enums cannot be passed as pure inputs
-  - _Section 2 explicitly states 'Structs/enums passed without proper BCS encoding via bcs.struct() / bcs.enum()' and 'Using raw JS objects instead of encoded structs', which clearly indicates they require special handling and cannot be passed as raw pure inputs._
+  - _Section 2 explicitly states 'Passing custom Move structs directly as pure inputs (not allowed)' and 'Enums used incorrectly before being supported'. This directly addresses the constraint._
 - ✅ Discusses how command results chain between PTB commands
-  - _Section 5 addresses command result usage, explaining 'Using entire tx.moveCall() result instead of destructuring result[0], result[1]', 'Passing command results to wrong argument positions', and 'Using a result after it has been consumed (objects are linear types)', which collectively cover chaining and result propagation._
+  - _Section 5 addresses command result usage, specifically mentioning 'Using a command result in multiple places', 'Accessing the wrong result index from multi-return commands', and 'Using a result after the transaction has already consumed it'. This covers chaining and result propagation._
 - ✅ Addresses vector and option encoding in PTB inputs
-  - _Section 4 explicitly covers vectors and options, stating 'Building vectors with mixed types', 'Using JS arrays directly instead of tx.makeMoveVec()', and 'Incorrect std::option::Option construction (missing tx.moveCall for some/none)', which directly addresses encoding requirements for these types._
+  - _Section 4 explicitly discusses vectors and options with bullet points covering 'Incorrect use of `tx.pure.vector()` vs `makeMoveVec()`', 'Passing heterogeneous types in vectors', and 'Malformed `Option<T>` encoding'._
 
 #### ✅ gas-smashing
 **Page:** develop/transaction-payment/gas-smashing
 **Prompt:** Review this app's gas coin handling. Add safe coin selection/splitting/merging guidance and avoid concurrent reuse of mutable owned objects.
 
-> I'll review gas coin handling patterns and provide comprehensive guidance for safe coin selection, splitting, merging, and avoiding concurrent object reuse issues on Sui.  ## Key Problems with Naive Gas Coin Handling  Before diving into solutions, he...
+> I'll review gas coin handling patterns and provide comprehensive guidance on safe coin selection, splitting, merging, and avoiding concurrent object reuse issues on Sui.  ## Common Gas Coin Handling Anti-Patterns  Let me first identify the problems, ...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /gas/i
@@ -1416,39 +928,39 @@
 
 **Subjective grades:**
 - ✅ Explains gas coin handling in Sui transactions
-  - _The response provides comprehensive explanation of gas coin handling through multiple sections: foundational types, coin pool management, on-chain sync patterns, gas manager orchestration, and concrete usage examples. It explains how to reserve, track, and release gas coins throughout transaction lifecycles._
+  - _Response comprehensively explains gas coin handling through multiple sections: anti-patterns (fetching gas coins, no balance checks, stale references), SafeCoinManager class with fetchFreshCoins/selectGasCoin methods, and detailed safe transaction patterns for splitting, merging, and transfers. Gas coin selection and usage is explicitly demonstrated throughout._
 - ✅ Warns about concurrent reuse of mutable owned objects or equivocation risks
-  - _The response explicitly warns about concurrent reuse in multiple places: listed as Problem #1 ('Concurrent reuse – submitting two transactions using the same gas coin simultaneously causes one to fail'), detailed in CoinPool docstring ('Sui constraint: An owned object can only appear in ONE transaction at a time. Submitting two txns with the same coin simultaneously will cause equivocation errors'), and restated in RULE 1 and RULE 7 of the Critical Rules Summary._
+  - _Response explicitly warns about concurrent reuse in Anti-pattern 1 with comment '❌ Object locked after first tx' and '❌ Equivocation risk'. The SafeCoinManager includes a lockedCoins Map to track in-flight coins, and ConcurrentTransactionQueue ensures one gas coin per concurrent transaction. Key Rules Summary rule #1 explicitly states this danger._
 - ✅ Provides guidance on coin management strategies (selection, splitting, or merging)
-  - _The response provides detailed guidance on all three strategies: (1) Selection via CoinPool.reserve() with balance checking and sorted availability, (2) Splitting via buildSplitCommand() and buildSplitTransaction() with examples showing atomic splits inside PTBs, (3) Merging via mergeCoins() method with fragmentation-aware triggering and multi-coin consolidation logic._
+  - _Response provides explicit methods for all three strategies: selectCoinsForAmount() for selection, safeSplitCoin() for splitting with merge logic, and safeMergeAllCoins() for merging. Each includes detailed implementation with lock management, balance checks, and proper gas coin separation. Usage examples demonstrate these patterns._
 - ✅ Discusses gas budget estimation or setting
-  - _The response discusses gas budgets through: DEFAULT_GAS_CONFIG with explicit budget field (10_000_000n = 0.01 SUI), GasConfig interface allowing customization, reserveGasCoin() that adds a buffer ('required = budget + 2_000_000n'), executeWithGas() with configurable gasBudget parameter, and usage examples showing custom budget adjustment (50_000_000n and 100_000_000n for different transaction types)._
+  - _Response includes getGasBudgetEstimate() method that uses dry-run transaction blocks for accurate estimation with 20% buffer, defines constants for gas overhead (DEFAULT_GAS_BUDGET, MERGE_GAS_OVERHEAD), and demonstrates setting gas budgets in transaction patterns. Key Rules Summary rule #7 explicitly mentions dry-run and buffer strategy._
 
-#### ✅ data-serving
+#### ❌ data-serving
 **Page:** develop/accessing-data/data-serving
 **Prompt:** Review this app's data access needs and recommend GraphQL, gRPC, or both. Consider frontend/backend use, historical queries, subscriptions, latency, and retention.
 
-> # Data Access Layer Recommendation for Sui Apps  I'll walk through a structured analysis framework, then give you concrete recommendations based on common app archetypes.  ---  ## Understanding the Two Options  ### Sui GraphQL API (indexer-backed) ``...
+> I'd be happy to help recommend the right data access approach, but I need you to share your app's details first.  **Please describe your app, including any relevant details like:**  ``` - What does your app do? (DEX, NFT marketplace, game, portfolio ...
 
 **Deterministic checks:**
-- ✅ `contains`: Found "GraphQL"
-- ✅ `contains`: Found "gRPC"
+- ❌ `contains`: Missing "GraphQL"
+- ❌ `contains`: Missing "gRPC"
 
 **Subjective grades:**
-- ✅ Compares GraphQL and gRPC as data access options for Sui
-  - _Response explicitly compares both options with dedicated sections on 'Understanding the Two Options' showing characteristics, use cases, latency profiles, and architectural differences for each._
-- ✅ Provides guidance on when to use each option based on use case
-  - _Response includes a decision framework, 5 detailed app archetypes (NFT Marketplace, DeFi/DEX, Portfolio Dashboard, Analytics, Game), and a summary decision matrix that explicitly recommends which option(s) to use for each scenario._
-- ✅ Mentions subscription or streaming capabilities
-  - _Response explicitly discusses subscriptions and streaming multiple times: gRPC streaming characteristics, websocket subscriptions via GraphQL (limited), native streaming in gRPC, and provides code examples of subscribeEvent for both bids and game events._
-- ✅ Discusses data retention and historical query considerations
-  - _Response explicitly addresses retention throughout: mentions 'full retention' for GraphQL vs 'current state only' for gRPC, includes retention column in feature matrices, and discusses historical data requirements in the decision framework ('>current epoch' → GraphQL required)._
+- ❌ Compares GraphQL and gRPC as data access options for Sui
+  - _The response asks for app details but does not actually compare GraphQL and gRPC. It defers the comparison to a future response after receiving user input, rather than providing an explicit comparison now._
+- ❌ Provides guidance on when to use each option based on use case
+  - _No guidance is provided on when to choose GraphQL versus gRPC. The response only promises to give 'a concrete recommendation' after the user provides details, but contains no decision criteria or use-case mapping._
+- ❌ Mentions subscription or streaming capabilities
+  - _While the response includes a question about real-time updates and live feeds, it does not explain how GraphQL subscriptions or gRPC streaming address these needs, nor does it compare their capabilities._
+- ❌ Discusses data retention and historical query considerations
+  - _The response includes a question about historical data retention but does not discuss how GraphQL or gRPC handle or differ in addressing data retention and historical queries. It only elicits the information without providing analysis._
 
-#### ❌ using-grpc
+#### ✅ using-grpc
 **Page:** develop/accessing-data/grpc/using-grpc
 **Prompt:** Convert this Sui JSON-RPC usage to the current gRPC API. Generate/use the client, map request/response types, and add a working example.
 
-> I'll convert the Sui JSON-RPC usage to the gRPC API systematically. Since you haven't pasted specific JSON-RPC code, I'll cover the most common operations and show the full conversion pattern.  ## Setup  ```toml # Cargo.toml [dependencies] sui-sdk = ...
+> I'll convert Sui JSON-RPC usage to the gRPC API with a complete, working example. Let me walk through the full migration.  ## Setup & Dependencies  ```toml # Cargo.toml [package] name = "sui-grpc-example" version = "0.1.0" edition = "2021"  [dependen...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "gRPC"
@@ -1456,19 +968,19 @@
 
 **Subjective grades:**
 - ✅ Explains how to set up or generate a gRPC client for Sui
-  - _Section '## Setup' provides Cargo.toml dependencies and '## 1. Client Setup Comparison' explicitly shows client initialization using SuiClientBuilder with gRPC endpoint. Clearly explains that the SDK routes gRPC internally and how to access the raw gRPC node service via node_api()._
+  - _The response includes explicit Cargo.toml dependencies (sui-sdk, sui-grpc, sui-rpc-api), a `build_client()` function that instantiates a Client from a URL, and clear documentation that the client handles HTTP/2 and TLS automatically._
 - ✅ Maps or references common Sui RPC methods and their gRPC equivalents
-  - _Response includes detailed side-by-side comparisons of JSON-RPC vs gRPC for: get_object, get_coins, execute_transaction_block, and event subscriptions. Also provides a comprehensive '## Type Mapping Reference' table showing JSON-RPC types mapped to gRPC/SDK types._
+  - _A detailed mapping table explicitly correlates JSON-RPC methods (sui_getObject, sui_getTransactionBlock, sui_executeTransactionBlock, suix_getBalance, etc.) to their gRPC service/method counterparts with request and response types._
 - ✅ Provides a code example demonstrating a gRPC call to Sui
-  - _Section '## 6. Complete Working Example' provides a fully functional, annotated Rust program demonstrating multiple gRPC operations: reading objects, fetching coins, querying transactions, and subscribing to events. Example is executable and includes error handling._
-- ❌ References the proto definitions, endpoint, or service structure
-  - _Response does not explicitly reference proto definitions or point to .proto files. While it mentions 'raw proto client' and 'proto message' in passing, it does not provide links to proto files, specify proto package names, or detail the actual service structure (e.g., sui.node.v2.Node service). The endpoint 'fullnode.mainnet.sui.io:443' is mentioned but gRPC-specific endpoint details are not clarified._
+  - _Five complete, working examples are provided in modular code blocks: get_object, get_transaction, execute_transaction, list_owned_objects, and service_info. Each includes request construction, client method invocation, and response handling with real testnet endpoints and addresses._
+- ✅ References the proto definitions, endpoint, or service structure
+  - _Proto definitions are explicitly imported (sui_rpc_api::proto::node::v2) and used throughout (GetObjectRequest, GetTransactionRequest, etc.). A real public testnet endpoint is provided (https://fullnode.testnet.sui.io:9001). The response includes a FieldMask quick reference and service structure comparison table._
 
 #### ✅ query-with-graphql
 **Page:** develop/accessing-data/graphql/query-with-graphql
 **Prompt:** Convert this Sui JSON-RPC query to GraphQL. Include the query, variables, pagination handling, and TypeScript caller code.
 
-> I'll convert a Sui JSON-RPC query to GraphQL with full TypeScript implementation. I'll use **getOwnedObjects** as the example since it demonstrates pagination well.  ## JSON-RPC Original  ```typescript // Original JSON-RPC call const response = await...
+> I'll convert a Sui JSON-RPC query to GraphQL. I'll use `getOwnedObjects` as a representative example since it's commonly used and demonstrates pagination well.  ## JSON-RPC Original  ```typescript // Original JSON-RPC approach const response = await ...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "GraphQL"
@@ -1477,19 +989,19 @@
 
 **Subjective grades:**
 - ✅ Provides a concrete GraphQL query with proper Sui schema types
-  - _Response includes a fully-formed GraphQL query named `GetOwnedSuiCoins` with proper Sui schema types like `SuiAddress`, `ObjectFilter`, owner union types (`AddressOwner`, `Shared`, `Parent`), and `MoveObject` content structures. The query explicitly declares fields and uses inline fragments for union type handling._
+  - _Response includes a fully formed GraphQL query with proper Sui types (SuiAddress, ObjectFilter, etc.), field selections (objectId, version, digest, objectType, owner, display, asMoveObject), and nested type fragments (AddressOwner, Shared, Immutable). Schema types are correctly used throughout._
 - ✅ Shows pagination handling with cursors or connection patterns
-  - _Response demonstrates Relay-style cursor pagination with `pageInfo` (hasNextPage, hasPreviousPage, startCursor, endCursor), `edges[]` with cursor values, and shows three distinct pagination patterns: single-page fetch with `after` cursor, recursive `getAllOwnedObjects` function with cursor chaining, and async generator `streamOwnedObjects` for lazy consumption._
+  - _Response demonstrates Relay cursor-based pagination with pageInfo (hasNextPage, hasPreviousPage, startCursor, endCursor), edges/cursor pattern, and the 'after' variable for cursor-based navigation. Multiple pagination strategies are shown: single page, full pagination loop, and async iterator._
 - ✅ Includes TypeScript code that calls the GraphQL endpoint
-  - _Response provides complete TypeScript caller code including: `suiGraphQL` generic fetch client with proper headers and error handling, `getOwnedObjectsPage` function that executes the query, `getAllOwnedObjects` function for recursive pagination, and `streamOwnedObjects` async generator. All are fully functional and properly typed._
+  - _Response provides complete TypeScript implementation using SuiGraphQLClient with actual function implementations: getOwnedObjectsPage(), getAllOwnedObjects(), and ownedObjectsIterator(). Code includes client initialization, query execution, error handling, and practical usage examples in main()._
 - ✅ Demonstrates use of variables in the query
-  - _Response explicitly shows variable usage with parameterized variables section showing `owner`, `after`, `before`, `first`, `last`, and `filter`. The caller functions (`getOwnedObjectsPage`, `getAllOwnedObjects`) construct and pass variables object to the `suiGraphQL` function, and usage examples demonstrate passing filter and pagination parameters._
+  - _Response shows variables section with $address, $filter, $first, $after parameters. Variables are declared in the query signature and passed through the client.query() call with concrete variable values in the variables object._
 
 #### ✅ observability
 **Page:** operators/observability
 **Prompt:** Add structured logging for transaction digest, sender, package/function, status, gas, and user-visible errors so support can debug failed Sui transactions.
 
-> # Structured Logging for Sui Transaction Debugging  ## Architecture Overview  ``` Request → Middleware → PTB Execution → Response     ↓           ↓            ↓            ↓   Logger    Enricher    Tx Monitor    Error Handler     └───────────────────...
+> # Structured Logging for Sui Transaction Debugging  I'll build a complete structured logging system that captures all the fields support needs to debug failed Sui transactions.  ## Architecture Overview  ``` TransactionLogger ├── log_transaction()   ...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /digest|transaction/i
@@ -1497,19 +1009,19 @@
 
 **Subjective grades:**
 - ✅ Shows structured logging with transaction-relevant fields
-  - _The response defines a comprehensive `TransactionLog` interface (§1) with all transaction-relevant fields including correlation IDs, identity fields, targets, outcomes, gas data, performance metrics, and object changes. Fields are explicitly typed rather than free-form strings._
+  - _TransactionLogRecord struct explicitly defines all relevant fields: log_id, submitted_at, finalized_at, latency_ms, digest, sender, move_calls, tx_kind, status, user_error, internal_error, gas, move_error, network, sdk_version. These are serialized as structured JSON._
 - ✅ Includes key fields: digest, sender, status, gas used
-  - _All four required fields are explicitly present: `tx_digest` (string), `sender` (string), `status` ('success'|'failure'|'pending'|'timeout'), and `gas` (object with computation_cost, storage_cost, total_charged, etc.). Sample outputs demonstrate these fields populated._
+  - _All four required fields are explicitly present in TransactionLogRecord: digest (Option<String>), sender (String), status (TxStatus enum), and gas.total_used (Option<u64>). GasInfo struct includes computation_cost, storage_cost, storage_rebate, and total_used calculations._
 - ✅ Provides actionable patterns for debugging failed transactions
-  - _The response includes: error parsing logic that extracts Move abort codes (§2 `resolveUserError`), a `KNOWN_ABORT_CODES` mapping for human-readable error resolution, object mutation tracking (created/mutated/deleted), internal vs user-visible error separation, and a complete executor showing error handling at multiple stages (preflight, timeout, on-chain failure)._
+  - _Implementation includes: error_registry for mapping abort codes to human-readable descriptions, parse_execution_error() to classify specific failure modes (gas exhaustion, epoch boundary, object conflicts), separate user_error and internal_error fields, MoveErrorDetail with abort_code and error_name for structured parsing, and conditional logging at different severity levels (info/error/warn)._
 - ✅ Uses structured logging format (not just string interpolation)
-  - _The entire implementation uses JSON serialization (`JSON.stringify(entry)`) with typed interfaces rather than string templates. Logs are newline-delimited JSON compatible with aggregation services. No printf-style or string-interpolated logs appear in the core logging path._
+  - _emit_log() function uses tracing macros (info!, error!, warn!) with named fields as structured data. LogRecord is serialized to JSON via serde. Tracing subscriber is configured with fmt::layer().json() for both stdout and file output. Fields like log_id, digest, sender, status are logged as discrete structured fields, not concatenated strings._
 
-#### ❌ move-package-management
+#### ✅ move-package-management
 **Page:** develop/manage-packages/move-package-management
 **Prompt:** Inspect this Move package's Move.toml, Move.lock, and dependencies. Fix dependency declarations, prefer MVR where appropriate, and verify sui move build works.
 
-> I'll systematically inspect your Move package configuration and fix any issues. Please share your files and I'll get started.  **Please provide:** 1. `Move.toml` contents 2. `Move.lock` contents (if it exists) 3. Any error output from `sui move build...
+> I'll systematically inspect your Move package configuration and fix dependency issues. Please share your files and I'll get started.  **Please provide:** 1. Your `Move.toml` 2. Your `Move.lock` (if it exists) 3. Any dependency source files or error o...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "Move.toml"
@@ -1518,19 +1030,19 @@
 
 **Subjective grades:**
 - ✅ Explains the role of Move.toml and its key fields
-  - _The response explicitly lists Move.toml inspection items including [package] fields (name, version, edition), [dependencies], and [addresses] sections with descriptions of what to validate in each._
-- ❌ Shows how to declare or fix dependencies
-  - _The response lists checking dependencies (git URLs, rev/tag) but does not actually show HOW to declare or fix them. No example syntax, no before/after comparison, no guidance on correcting malformed dependency entries is provided._
+  - _Response explicitly identifies Move.toml structure with sections like [package], [dependencies], [addresses], [dev-dependencies], and [dev-addresses]. It shows key fields including name, edition, version, published-at, and explains their purpose in the canonical template._
+- ✅ Shows how to declare or fix dependencies
+  - _Response provides concrete examples of dependency declaration patterns, including both MVR syntax and git-based fallback syntax with subdir and rev fields. It lists common dependency issues to fix (stale git SHAs, wrong branch refs, conflicting versions, missing published-at)._
 - ✅ Mentions Move Version Registry (MVR) or resolution strategies
-  - _The response explicitly states 'MVR packages available → prefer over raw git deps' in the inspection checklist, directly addressing the user prompt's requirement to 'prefer MVR where appropriate'._
+  - _Response explicitly mentions MVR multiple times, shows the preferred MVR syntax (`r.mvr = "sui@mainnet"`), explains when to prefer MVR over raw git, and provides examples of well-known packages (Sui, DeepBook) using MVR resolution._
 - ✅ References sui move build for verification
-  - _The response includes a Build section in the checklist verifying 'sui move build succeeds with 0 errors' and promises to provide 'The exact `sui move build` command to verify' in the final output._
+  - _Response provides explicit `sui move build` verification steps including `sui move build --lint`, `sui move build`, `sui move test`, and instructions to check the generated Move.lock file afterward._
 
-#### ✅ automated-address-management
+#### ❌ automated-address-management
 **Page:** develop/manage-packages/automated-address-management
 **Prompt:** Migrate this package to current Sui package address management using Move.lock / Published.toml conventions, then verify build and publish/test-publish behavior.
 
-> I'll walk you through migrating a package to Sui's current address management conventions using `Move.lock` and the `Published.toml` pattern, then verify everything works correctly.  ## Step 1: Understand the Current Address Management System  Sui us...
+> I'll walk you through migrating a Sui package to current address management conventions using `Move.lock` and `Published.toml`, then verify the build and publish behavior.  ## Overview of Current Sui Address Management  Modern Sui packages use: - **`...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /Move\.lock|Published\.toml/i
@@ -1538,19 +1050,19 @@
 
 **Subjective grades:**
 - ✅ Explains the current address management conventions
-  - _Step 1 clearly explains the two-file system (Move.toml and Move.lock). Steps 3-4 detail the correct format for Move.toml [addresses] block using 0x0 sentinel and Move.lock structure with environment-specific addresses. Step 11 Summary table reinforces the conventions._
-- ✅ Shows how Published.toml or Move.lock track published addresses
-  - _Step 4 explicitly shows Move.lock structure with original-published-at and latest-published-at fields per environment ([env.testnet], [env.mainnet]). Step 9 demonstrates the expected Move.lock state after publish. Step 10 explains upgrade behavior updating latest-published-at._
+  - _Step 1 and Overview clearly explain Move.toml with '_' placeholder, Move.lock with [env] sections for multi-environment tracking, and published-at field. Anti-patterns vs. new conventions are explicitly contrasted._
+- ❌ Shows how Published.toml or Move.lock track published addresses
+  - _Response extensively documents Move.lock [env] sections with chain-id, original-published-id, latest-published-id, and published-version fields. However, it does NOT mention or explain Published.toml at all, which is explicitly named in the user prompt as a required convention. The response appears to treat Move.lock as the sole source of truth without acknowledging Published.toml._
 - ✅ Provides migration steps from older patterns
-  - _Step 5 provides a complete bash migration script that backs up originals, normalizes hardcoded addresses to 0x0, and adds [dev-addresses] block if missing. This explicitly handles migration from older address management patterns._
+  - _Steps 1-5 explicitly show migration from hardcoded addresses and '0x0' placeholders to '_' placeholders, addition of published-at field, and handling of upgrade scenarios with concrete before/after examples._
 - ✅ Includes verification commands to confirm correct behavior
-  - _Step 6 shows sui move test commands. Step 7 demonstrates dry-run publish validation. Step 8 shows real publish with verification of Move.lock updates. Step 12 provides a complete CI/CD verification script checking Move.toml format, build, test, dry-run publish, and Move.lock commit status._
+  - _Steps 6-10 provide extensive verification: sui move build with error checking, sui move test, dry-run publish, test-publish to localnet, testnet publish with JSON parsing, and automated publish script. Commands are concrete and executable._
 
 #### ❌ walrus-storage
 **Page:** sui-stack/walrus/sui-stack-walrus
 **Prompt:** Upload this app's media or NFT assets to Walrus, store the resulting blob references, and wire them into Sui object metadata or Display fields.
 
-> # Uploading Assets to Walrus & Wiring into Sui Objects  I'll walk you through a complete, production-ready pipeline: upload assets → store blob IDs → wire into Sui Display/metadata.  ## Architecture Overview  ``` Local Assets → Walrus Publisher → Blo...
+> # Uploading Assets to Walrus & Wiring into Sui Display  I'll walk you through a complete, production-ready pipeline: upload assets to Walrus → store blob IDs → wire into Sui object Display fields.  ## Architecture Overview  ``` Local Assets → Walrus ...
 
 **Deterministic checks:**
 - ✅ `contains`: Found "Walrus"
@@ -1559,19 +1071,19 @@
 
 **Subjective grades:**
 - ✅ Shows how to upload assets to Walrus (via CLI, SDK, or HTTP API)
-  - _Step 3 provides a complete TypeScript SDK implementation (WalrusClient) using HTTP PUT requests to the Walrus Publisher API. Step 4 demonstrates practical usage via uploadFile() and uploadDirectory() methods. The code shows explicit API endpoints and request/response handling._
+  - _Step 4 provides a complete TypeScript implementation using the Walrus Publisher REST API with `fetch` to `PUT /v1/blobs`. The `uploadToWalrus()` function demonstrates the HTTP API method with proper headers and error handling._
 - ✅ Explains how to store or reference the resulting blob ID
-  - _Step 2 defines a BlobRef struct that explicitly stores blob_id, media_type, size, and epochs on-chain. Step 4 shows how these blob IDs are passed to the mint function and persisted in the MediaNFT object. The manifest and receipt system demonstrate complete blob ID lifecycle management._
+  - _Step 3 defines `BlobRecord` TypeScript interface and Step 4 implements `blob-registry.json` persistence. The registry explicitly stores `blobId`, `walrusObjectId`, `mediaUrl`, and metadata. Step 5 shows how to load and reference these blob IDs when minting._
 - ✅ Demonstrates wiring blob references into Sui object Display fields or metadata
-  - _Step 2 explicitly adds Display fields in the init() function, including image_url that interpolates the blob_id: `display::add(&mut d, string::utf8(b"image_url"), string::utf8(b"https://aggregator.walrus-testnet.walrus.space/v1/{image.blob_id}"))`. This directly wires the Walrus blob into Display rendering._
+  - _Step 2 Move contract defines `MediaNFT` struct with `blob_id`, `media_url`, `thumbnail_url` fields. The `init()` function creates a Display object with `display::add()` calls that wire `{media_url}`, `{thumbnail_url}`, and `{media_type}` template fields. Step 5 and Step 9 show how these values are populated and queried._
 - ❌ Mentions token requirements (WAL for storage, SUI for gas) or cost considerations
-  - _The response completely omits any mention of WAL tokens for Walrus storage costs, epoch purchasing economics, or SUI gas fee considerations. While gas budgets appear in code (e.g., `--gas-budget 100000000`), there is no explanation of costs or token requirements. The epoch-based storage model is mentioned but not its financial implications._
+  - _The response does not explicitly mention WAL token requirements for Walrus storage epochs or discuss cost considerations. While `WALRUS_EPOCHS=5` is set in the .env, there is no explanation that epochs correspond to storage duration or that WAL tokens are required. SUI gas budget is mentioned only generically in the publish command (`--gas-budget 200000000`) without explanation of costs._
 
 #### ✅ walrus-sites
 **Page:** sui-stack/walrus/sui-stack-walrus-sites
 **Prompt:** Deploy this static frontend as a Walrus Site. Build the app, publish the site, record the site object and blob IDs, and document update steps.
 
-> # Deploy a Static Frontend as a Walrus Site  I'll walk you through the complete process: building your app, publishing to Walrus Sites, and managing updates.  ## Prerequisites  ```bash # Install Sui CLI cargo install --locked --git https://github.com...
+> # Deploy a Static Frontend as a Walrus Site  I'll walk you through the complete process: building your app, installing the Walrus Site Builder, publishing, and documenting update steps.  ---  ## Prerequisites  ```bash # Verify you have these installe...
 
 **Deterministic checks:**
 - ✅ `regex`: Matched /site-builder|walrus-sites/i
@@ -1580,13 +1092,13 @@
 
 **Subjective grades:**
 - ✅ Shows the build step for the static frontend
-  - _Step 2 explicitly shows building a frontend with npm run build, including Vite and Create React App examples with proper configuration (base: './' for relative paths)._
+  - _Step 4 explicitly covers building frontend apps with examples for React (CRA), Vite, and Next.js, including verification of build output and example vite.config.ts configuration._
 - ✅ Provides the site-builder publish command
-  - _Step 4 clearly provides the site-builder publish command with example output showing Site object ID and blob IDs._
+  - _Step 6 clearly presents the `site-builder publish` command with path and ws-resources options, includes example successful output showing blob and site object IDs._
 - ✅ Explains how to record and track the site object ID
-  - _Step 5 creates a walrus-site-manifest.json file that explicitly records site object ID, blob IDs, URLs, timestamps, and includes a version history section for tracking._
+  - _Step 7 provides a concrete WALRUS_DEPLOYMENT.md template that documents site object ID, blob IDs, deployment date, and portal URL in a trackable format._
 - ✅ Documents the update process for redeploying changes
-  - _Step 7 provides a complete update workflow showing site-builder update command with --site-object flag, includes a reusable shell script (update-site.sh), and demonstrates that unchanged blobs are reused._
+  - _Step 8 explicitly covers update steps with two methods: Method 1 shows `site-builder update --object-id` command, Method 2 provides a reusable deploy.sh script with full documentation of the update workflow._
 
 </details>
 
@@ -1596,20 +1108,21 @@
 
 These evals passed on some models but failed on others:
 
-- **walrus-cli/walrus-cli-common-mistakes**: gpt4o: FAIL, opus: PASS, sonnet: FAIL
-- **AgentPrompt: automated-address-management**: gpt4o: FAIL, opus: FAIL, sonnet: PASS
+- **AgentPrompt: automated-address-management**: gpt4o: ERROR, opus: FAIL, sonnet: FAIL
 - **AgentPrompt: common-errors**: gpt4o: FAIL, opus: PASS, sonnet: PASS
 - **AgentPrompt: custom-policies**: gpt4o: FAIL, opus: PASS, sonnet: PASS
-- **AgentPrompt: data-serving**: gpt4o: FAIL, opus: PASS, sonnet: PASS
+- **AgentPrompt: data-serving**: gpt4o: ERROR, opus: PASS, sonnet: FAIL
 - **AgentPrompt: display-overview**: gpt4o: FAIL, opus: PASS, sonnet: PASS
-- **AgentPrompt: gas-smashing**: gpt4o: FAIL, opus: PASS, sonnet: PASS
-- **AgentPrompt: move-package-management**: gpt4o: FAIL, opus: PASS, sonnet: FAIL
-- **AgentPrompt: observability**: gpt4o: FAIL, opus: PASS, sonnet: PASS
+- **AgentPrompt: gas-smashing**: gpt4o: ERROR, opus: PASS, sonnet: PASS
+- **AgentPrompt: hello-world**: gpt4o: FAIL, opus: PASS, sonnet: PASS
+- **AgentPrompt: move-package-management**: gpt4o: ERROR, opus: PASS, sonnet: PASS
+- **AgentPrompt: observability**: gpt4o: ERROR, opus: PASS, sonnet: PASS
 - **AgentPrompt: ptb-inputs-results**: gpt4o: FAIL, opus: PASS, sonnet: PASS
 - **AgentPrompt: publish-overview**: gpt4o: FAIL, opus: PASS, sonnet: PASS
-- **AgentPrompt: query-with-graphql**: gpt4o: FAIL, opus: PASS, sonnet: PASS
-- **AgentPrompt: scenario-testing**: gpt4o: FAIL, opus: PASS, sonnet: FAIL
+- **AgentPrompt: query-with-graphql**: gpt4o: ERROR, opus: PASS, sonnet: PASS
+- **AgentPrompt: scenario-testing**: gpt4o: FAIL, opus: PASS, sonnet: PASS
 - **AgentPrompt: testing**: gpt4o: FAIL, opus: PASS, sonnet: PASS
 - **AgentPrompt: upgrade**: gpt4o: FAIL, opus: FAIL, sonnet: PASS
-- **AgentPrompt: using-grpc**: gpt4o: FAIL, opus: PASS, sonnet: FAIL
-- **AgentPrompt: walrus-sites**: gpt4o: FAIL, opus: PASS, sonnet: PASS
+- **AgentPrompt: using-grpc**: gpt4o: ERROR, opus: PASS, sonnet: PASS
+- **AgentPrompt: walrus-sites**: gpt4o: ERROR, opus: PASS, sonnet: PASS
+- **AgentPrompt: walrus-storage**: gpt4o: ERROR, opus: PASS, sonnet: FAIL

--- a/scripts/report-evals.js
+++ b/scripts/report-evals.js
@@ -15,7 +15,9 @@
  */
 
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { dirname, join, resolve } from "path";
+
+const ROOT = resolve(dirname(new URL(import.meta.url).pathname), "..");
 
 const artifactDir = process.argv[2];
 if (!artifactDir) {
@@ -23,11 +25,30 @@ if (!artifactDir) {
   process.exit(1);
 }
 
+// ── Load prompt definitions for prompt text display ──────────────────
+let promptDefs = {};
+const promptsPath = join(ROOT, "evals", "agent-prompts", "prompts.json");
+if (existsSync(promptsPath)) {
+  const raw = JSON.parse(readFileSync(promptsPath, "utf-8"));
+  for (const p of raw) promptDefs[p.id] = p;
+}
+
+// ── Parse result file (handles {metadata, results} or plain array) ──
+function parseResultFile(filePath) {
+  const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+  if (Array.isArray(raw)) return { metadata: {}, results: raw };
+  if (raw.results && Array.isArray(raw.results)) return raw;
+  return { metadata: {}, results: raw };
+}
+
 // ── Discover result files ────────────────────────────────────────────
 const modelResults = {};
+const modelMetadata = {};
 const codeResults = [];
 const agentPromptResults = {};
+const agentPromptMetadata = {};
 const agentPromptWithSkillsResults = {};
+const agentPromptWithSkillsMetadata = {};
 let hasFailures = false;
 
 for (const dir of readdirSync(artifactDir, { withFileTypes: true })) {
@@ -37,14 +58,15 @@ for (const dir of readdirSync(artifactDir, { withFileTypes: true })) {
   const evalFile = join(subDir, "eval-results.json");
   if (existsSync(evalFile)) {
     const label = dir.name.replace("eval-results-", "");
-    const results = JSON.parse(readFileSync(evalFile, "utf-8"));
+    const { metadata, results } = parseResultFile(evalFile);
     modelResults[label] = results;
+    modelMetadata[label] = metadata;
     if (results.some((r) => r.status !== "PASS")) hasFailures = true;
   }
 
   const codeEvalFile = join(subDir, "code-eval-results.json");
   if (existsSync(codeEvalFile)) {
-    const results = JSON.parse(readFileSync(codeEvalFile, "utf-8"));
+    const { results } = parseResultFile(codeEvalFile);
     codeResults.push(...results);
     if (results.some((r) => r.status !== "PASS")) hasFailures = true;
   }
@@ -52,16 +74,18 @@ for (const dir of readdirSync(artifactDir, { withFileTypes: true })) {
   const agentPromptFile = join(subDir, "agent-prompt-eval-results.json");
   if (existsSync(agentPromptFile)) {
     const label = dir.name.replace("agent-prompt-results-", "");
-    const results = JSON.parse(readFileSync(agentPromptFile, "utf-8"));
+    const { metadata, results } = parseResultFile(agentPromptFile);
     agentPromptResults[label] = results;
+    agentPromptMetadata[label] = metadata;
     if (results.some((r) => r.status !== "PASS")) hasFailures = true;
   }
 
   const agentPromptWithSkillsFile = join(subDir, "agent-prompt-with-skills-eval-results.json");
   if (existsSync(agentPromptWithSkillsFile)) {
     const label = dir.name.replace("agent-prompt-with-skills-results-", "");
-    const results = JSON.parse(readFileSync(agentPromptWithSkillsFile, "utf-8"));
+    const { metadata, results } = parseResultFile(agentPromptWithSkillsFile);
     agentPromptWithSkillsResults[label] = results;
+    agentPromptWithSkillsMetadata[label] = metadata;
     if (results.some((r) => r.status !== "PASS")) hasFailures = true;
   }
 }
@@ -176,6 +200,22 @@ for (const s of summaryRows) {
   );
 }
 lines.push("");
+
+// ── Model versions ───────────────────────────────────────────────────
+const allMeta = { ...modelMetadata, ...agentPromptMetadata, ...agentPromptWithSkillsMetadata };
+const seenModels = new Map();
+for (const [label, meta] of Object.entries(allMeta)) {
+  if (meta.model) seenModels.set(meta.model, { provider: meta.provider, judge: meta.judge_model, timestamp: meta.timestamp });
+}
+if (seenModels.size > 0) {
+  lines.push("### Models\n");
+  lines.push("| Label | Provider | Model ID | Judge Model |");
+  lines.push("|-------|----------|----------|-------------|");
+  for (const [model, info] of seenModels) {
+    lines.push(`| ${model} | ${info.provider ?? "–"} | \`${model}\` | \`${info.judge ?? "–"}\` |`);
+  }
+  lines.push("");
+}
 
 // ── Knowledge evals detail ───────────────────────────────────────────
 if (models.length > 0) {
@@ -375,7 +415,13 @@ if (agentModels.length > 0) {
     for (const r of results) {
       const icon = statusIcon(r.status);
       lines.push(`#### ${icon} ${r.id}`);
-      lines.push(`**Page:** ${r.source_page ?? "unknown"}\n`);
+      lines.push(`**Page:** ${r.source_page ?? "unknown"}`);
+      const promptDef = promptDefs[r.id];
+      if (promptDef?.prompt) {
+        lines.push(`**Prompt:** ${promptDef.prompt}\n`);
+      } else {
+        lines.push("");
+      }
 
       if (r.response_excerpt) {
         lines.push(`> ${r.response_excerpt.replace(/\n/g, " ").slice(0, 250)}...\n`);

--- a/scripts/run-agent-prompt-evals.js
+++ b/scripts/run-agent-prompt-evals.js
@@ -323,9 +323,20 @@ async function main() {
   console.log(`Provider: ${providerName} / ${EVAL_MODEL}`);
   console.log(`${"=".repeat(60)}\n`);
 
-  // Write results
+  // Write results with metadata
+  const output = {
+    metadata: {
+      provider: providerName,
+      model: EVAL_MODEL,
+      judge_model: JUDGE_MODEL,
+      mode: withSkills ? "with-skills" : "baseline",
+      timestamp: new Date().toISOString(),
+      runs_per_eval: NUM_RUNS,
+    },
+    results,
+  };
   const outPath = join(ROOT, "scripts", withSkills ? "agent-prompt-with-skills-eval-results.json" : "agent-prompt-eval-results.json");
-  writeFileSync(outPath, JSON.stringify(results, null, 2));
+  writeFileSync(outPath, JSON.stringify(output, null, 2));
   console.log(`Results written to ${outPath}`);
 
   // GitHub Actions summary

--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -242,8 +242,17 @@ async function main() {
   console.log(`${"═".repeat(60)}\n`);
 
   // ── Write results JSON ──────────────────────────────────────────
+  const output = {
+    metadata: {
+      provider: providerName,
+      model: EVAL_MODEL,
+      judge_model: JUDGE_MODEL,
+      timestamp: new Date().toISOString(),
+    },
+    results: allResults,
+  };
   const outPath = join(ROOT, "scripts", "eval-results.json");
-  writeFileSync(outPath, JSON.stringify(allResults, null, 2));
+  writeFileSync(outPath, JSON.stringify(output, null, 2));
   console.log(`Full results written to ${outPath}`);
 
   // ── GitHub Actions summary ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Eval result JSON now includes metadata (provider, model ID, judge model, timestamp)
- Report shows a **Models** table with exact model IDs used
- AgentPrompt detail sections show the **full prompt text** from prompts.json
- Updated reports/report.md with latest results

🤖 Generated with [Claude Code](https://claude.com/claude-code)