### PR TITLE
Fix staleness across 7 skills

### DIFF
--- a/frontend-apps/SKILL.md
+++ b/frontend-apps/SKILL.md
@@ -23,7 +23,7 @@ Browser Sui apps fail for a consistent set of reasons:
 3. **Old provider stack.** Code often tries the v1 pattern: `QueryClientProvider` → `SuiClientProvider` → `WalletProvider`. That's gone. New pattern: `createDAppKit` factory + `DAppKitProvider` (or a non-React equivalent).
 4. **Dead hooks.** `useSuiClientQuery`, `useSuiClientInfiniteQuery`, `useSignAndExecuteTransaction` (mutation hook), `useConnectWallet`, `useDisconnectWallet`, `useSuiClient`, `useSuiClientContext` — **removed**. Replaced by `useCurrentClient` / `useCurrentNetwork` / `useDAppKit()` (imperative methods) + your own TanStack Query wrappers.
 5. **Skipping `waitForTransaction` between execute and refetch.** Fullnodes index transactions asynchronously — invalidating TanStack caches immediately after `signAndExecuteTransaction` refetches stale data.
-6. **Building PTBs in app code with `tx.build()` before handing to the wallet.** Defeats the wallet's gas selection. Always pass the `Transaction` instance (or `tx.serialize()`) to the wallet.
+6. **Building PTBs in app code with `tx.build()` before handing to the wallet.** Defeats the wallet's gas selection. Always pass the `Transaction` instance to the wallet.
 
 All patterns in this skill are derived from:
 - https://sdk.mystenlabs.com/dapp-kit (landing)
@@ -98,7 +98,7 @@ If unsure about any API, fetch from the relevant page — do not extrapolate fro
 5. **Do not use the removed hooks.** `useSuiClientQuery` / `useSuiClientInfiniteQuery` / `useSuiClientContext` / `useSuiClient` / `useSignAndExecuteTransaction` (mutation hook) / `useConnectWallet` / `useDisconnectWallet` — gone. Use `useCurrentClient` + `useQuery`/`useInfiniteQuery` + `useDAppKit()` imperative methods.
 6. **Null-check the current account.** `useCurrentAccount()` returns `null` before connection. Always `if (!account) return` / gate with `enabled: !!account` in queries.
 7. **`waitForTransaction` before cache invalidation.** `await client.waitForTransaction({ digest: result.Transaction.digest })` then `queryClient.invalidateQueries(...)`. Reversing this fetches stale data.
-8. **Pass the `Transaction` instance (or `tx.serialize()`) to the wallet, not `await tx.build(...)` bytes.** The wallet needs to own gas selection. Exception: sponsored flows that use `tx.build({ client, onlyTransactionKind: true })` — see `ptbs` skill.
+8. **Pass the `Transaction` instance to the wallet, not `await tx.build(...)` bytes.** The wallet needs to own gas selection. Exception: sponsored flows that use `tx.build({ client, onlyTransactionKind: true })` — see `ptbs` skill.
 9. **Check `result.$kind === 'FailedTransaction'` (or `result.FailedTransaction`).** Don't assume success. Don't use v1's `result.effects?.status?.status`.
 10. **Wallet-gated UI must client-render.** SSR without a client-side guard renders wallet buttons before wallets are detectable. Use `'use client'` / dynamic imports / effect-based hydration.
 11. **Vue: `useStore` returns a Vue ref — use `.value` in script code.** `const connection = useStore(dAppKit.stores.$connection)` returns a ref. Access state as `connection.value.account` in `<script setup>`. Vue auto-unwraps refs in templates, but always show the `.value` pattern in script examples.
@@ -128,7 +128,7 @@ When the user asks you to review a code snippet, do not stop at the first 2–3 
 
 **Transaction construction**
 - `tx.pure(value)` (untyped) — replace with the typed helper matching the Move type: `tx.pure.u64(n)`, `tx.pure.address(addr)`, `tx.pure.string(s)`, etc.
-- `tx.build()` before handing to the wallet — defeats wallet gas selection. Pass the `Transaction` instance (or `tx.serialize()`).
+- `tx.build()` before handing to the wallet — defeats wallet gas selection. Pass the `Transaction` instance directly.
 
 **Execute / wait / status**
 - `signAndExecuteTransactionBlock(...)` (v1 method) — replace with `signAndExecuteTransaction(...)`.

--- a/frontend-apps/transactions.md
+++ b/frontend-apps/transactions.md
@@ -119,7 +119,7 @@ For type-filtered queries after a package upgrade, use `ORIGINAL_PACKAGE_IDS`:
 const originalId = ORIGINAL_PACKAGE_IDS[network];
 const objects = await client.core.listOwnedObjects({
   owner: account.address,
-  filter: { StructType: `${originalId}::nft::NFT` },
+  type: `${originalId}::nft::NFT`,
 });
 ```
 

--- a/object-model/dynamic-fields-and-collections.md
+++ b/object-model/dynamic-fields-and-collections.md
@@ -13,6 +13,8 @@ Dynamic fields attach key-value data to an object at runtime, beyond the fields 
 
 **When to use dynamic field:** When the stored value is a plain type (like `u64`, `String`, or a non-object struct), or when you do not need the child to be independently addressable.
 
+**Constraint:** Shared objects cannot be stored as dynamic fields — attempting to do so aborts with `ESharedObjectOperationNotSupported`.
+
 ## Field naming
 
 Dynamic field names accept any value with `copy`, `drop`, and `store` abilities. This includes primitives (`u64`, `address`, `String`) and custom structs with those abilities. This is more flexible than regular struct fields, which require Move identifiers.

--- a/object-model/patterns.md
+++ b/object-model/patterns.md
@@ -105,7 +105,7 @@ Key properties:
 | Independent ownership | Yes (owned, shared, party, immutable, or wrapped) | No (always owned by parent) |
 | Can receive objects | Yes | No |
 | Parallel access | Yes | Limited (sequenced through parent) |
-| Supports reclaiming | Yes (transfer back to any owner) | Yes (remove from parent) |
+| Supports reclaiming | Not currently supported | Yes (remove from parent) |
 | Supports deletion | Yes | Yes |
 
 Use derived objects for registries, per-user configurations, soulbound tokens, and cases where you need parallel access without bottlenecking through a parent.

--- a/object-model/transfers.md
+++ b/object-model/transfers.md
@@ -24,6 +24,10 @@ These can be called from any module, but the object must have the `store` abilit
 | `transfer::public_share_object(obj)` | Make the object shared |
 | `transfer::public_freeze_object(obj)` | Make the object immutable |
 
+## Sharing constraints
+
+`share_object` and `public_share_object` can only be called on objects created within the same transaction. An existing address-owned object cannot be converted to shared — there is no owned-to-shared conversion. Once shared, an object cannot be converted back to address-owned.
+
 ## Custom transfer rules
 
 Objects without `store` can only be transferred by their defining module. This lets you enforce preconditions:

--- a/ptbs/fundamentals.md
+++ b/ptbs/fundamentals.md
@@ -52,7 +52,7 @@ Commands reference values via four `Argument` kinds:
 - **`Input(u16)`** — input at index `u16` in the `inputs` vector.
 - **`GasCoin`** — the SUI coin paying for gas. **Always present in every transaction**, even when using address-balance payment. When paying with address balances, an ephemeral gas coin is created for the transaction and deleted at the end if not transferred. Special rules:
   - Can be used by `&` or `&mut` anywhere.
-  - Can be passed by value **only** to `TransferObjects` (or `sui::coin::send_funds` once available).
+  - Can be passed by value **only** to `TransferObjects` or `sui::coin::send_funds`.
   - To get an owned `Coin<SUI>` from the gas coin, split it first: `SplitCoins(GasCoin, [amount])`.
   - In sponsored transactions, the **sender** can still use the GasCoin (which belongs to the sponsor). Sponsors should validate submitted PTBs to ensure the gas coin is not misused.
 - **`Result(u16)`** — shorthand for `NestedResult(i, 0)`. Valid only when command `i` has exactly one return value.
@@ -107,7 +107,7 @@ For each argument position:
 
 - Every value created or returned by a Move command must be **consumed** by end of tx: transferred, destroyed, or passed into another command. Exception: values whose type has `drop` can be left to drop.
 - Shared objects **cannot** be transferred or frozen at tx end (the ops "succeed" during execution but the tx fails at commit).
-- Shared objects can be wrapped or converted to dynamic fields mid-execution, but must be re-shared or deleted before commit.
+- Shared objects **cannot** be wrapped or converted to dynamic fields mid-execution — doing so causes the transaction to fail. Shared objects must be re-shared or deleted before commit.
 - Gas coin returns to its owner; remaining budget refunded.
 
 ### Hot-potato cliques (non-public `entry` calls)

--- a/sui-cli/SKILL.md
+++ b/sui-cli/SKILL.md
@@ -47,7 +47,7 @@ Every transaction on Sui requires SUI tokens to pay gas. The total gas cost is:
 - **Storage cost:** The cost of storing new or expanded objects onchain. You pay for the bytes your objects occupy.
 - **Storage rebate:** When a transaction deletes objects or reduces their size, you receive a rebate for the storage freed. This incentivizes cleaning up unused state.
 
-The gas budget (`--gas-budget`) sets the maximum you are willing to pay. If the transaction exceeds the budget, it aborts. On Testnet and Devnet, tokens are free through faucets (see the `sui-client` skill for faucet methods). Gas prices can vary per epoch; query the current gas price through the RPC.
+The gas budget (`--gas-budget`) sets the maximum you are willing to pay. If the transaction exceeds the budget, it fails and a portion of the gas budget is still charged. On Testnet and Devnet, tokens are free through faucets (see the `sui-client` skill for faucet methods). Gas prices can vary per epoch; query the current gas price through the RPC.
 
 ## Epochs
 

--- a/sui-move/events-coins.md
+++ b/sui-move/events-coins.md
@@ -26,13 +26,13 @@ Event structs must have `copy` and `drop` abilities.
 
 > **IMPORTANT:** The function is `event::emit(...)`. There is NO `emit_event` function anywhere in the Sui framework. Never write `emit_event(...)`, `event::emit_event(...)`, or any variant — the only correct call is `event::emit(MyEventStruct { ... })`.
 
-Subscribe to events offchain using the Sui TypeScript SDK or GraphQL API, filtering by event type.
+Subscribe to events offchain using gRPC (`SubscribeEvents` for live streaming, `ListEvents` for paginated queries) or the GraphQL API, filtering by event type. The JSON-RPC event methods are deprecated.
 
 ## Coin operations
 
 The `sui::coin` module provides the standard fungible token implementation. Key operations:
 
-- `coin::create_currency(witness, decimals, symbol, name, description, icon_url, ctx)`: Creates a new currency using a One-Time Witness. Returns a `TreasuryCap` (for minting/burning) and `CoinMetadata`. **Warning:** Never freeze or share the `TreasuryCap` — doing so might allow malicious actors to call functions as the currency owner. Always transfer it to a controlled address.
+- `coin::create_currency(witness, decimals, symbol, name, description, icon_url, ctx)`: Creates a new currency using a One-Time Witness. Returns a `TreasuryCap` (for minting/burning) and `CoinMetadata`. **Warning:** `CoinMetadata` is planned for deprecation — the Coin standard itself is not affected, but avoid building new logic that depends on `CoinMetadata`. **Warning:** Never freeze or share the `TreasuryCap` — doing so might allow malicious actors to call functions as the currency owner. Always transfer it to a controlled address.
 - `coin::mint(treasury_cap, amount, ctx)`: Mint new coins.
 - `coin::burn(treasury_cap, coin)`: Burn coins.
 - `coin::split(coin, amount, ctx)`: Split a coin, returning a new coin with the specified amount.

--- a/sui-sdks/typescript.md
+++ b/sui-sdks/typescript.md
@@ -162,7 +162,7 @@ When using a concrete client like `SuiGrpcClient`, call methods directly:
 ```ts
 await client.getObject({ objectId, include: { content: true } });
 await client.getObjects({ objectIds: [...], include: { content: true } });
-await client.listOwnedObjects({ owner, filter: { StructType: '0xpkg::nft::NFT' }, limit: 50 });
+await client.listOwnedObjects({ owner, type: '0xpkg::nft::NFT', limit: 50 });
 await client.listCoins({ owner, coinType, limit: 50 });
 await client.listBalances({ owner });
 await client.getBalance({ owner, coinType: '0x2::sui::SUI' });


### PR DESCRIPTION
## Summary

Addresses issues flagged by the [source staleness check](https://github.com/MystenLabs/skills/actions/runs/32009320683). After investigating all 17 flagged skills, 10 were confirmed current and 7 had actual staleness (many were already fixed in PRs #37 and #41).

### Fixes by skill

| Skill | Fix | Severity |
|-------|-----|----------|
| `object-model` | Derived objects reclamation: "Yes" → "Not currently supported" | P0 |
| `frontend-apps` | Remove deprecated `tx.serialize()` refs; fix `StructType` → `type:` v2 param | P0 |
| `sui-sdks` | Fix `StructType` → `type:` v2 param in `listOwnedObjects` | P0 |
| `ptbs` | `send_funds` is live (remove "once available"); shared objects cannot be wrapped mid-execution | P1 |
| `sui-move` | Event API: gRPC is primary (JSON-RPC deprecated); `CoinMetadata` deprecation warning | P1 |
| `sui-cli` | Gas budget failure: portion is still charged, not just "aborts" | P1 |
| `object-model` | Add `share_object` freshly-created constraint; shared objects can't be dynamic fields | P2 |

### Skills confirmed NOT stale (no changes needed)

sui-overview, sui-move-project, sui-install, sui-build-test, sui-publish, sui-client, modern-move-syntax, naming-conventions, walrus-sites/portal, walrus-sites/publishing

## Test plan

- [ ] Verify each edit matches the upstream source cited in the staleness report
- [ ] Run evals for affected skills: `node scripts/run-evals.js --skill ptbs,frontend-apps,sui-sdks,object-model,sui-move,sui-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)