### PR TITLE
fix: rename sui-cli to sui-networks-gas

### DIFF
--- a/scripts/sui-monorepo-watch.json
+++ b/scripts/sui-monorepo-watch.json
@@ -40,7 +40,7 @@
     "crates/sui-move",
     "crates/sui/src/sui_commands.rs"
   ],
-  "sui-cli": [
+  "sui-networks-gas": [
     "crates/sui/src"
   ],
   "sui-client": [

--- a/sui-networks-gas/SKILL.md
+++ b/sui-networks-gas/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sui-cli
+name: sui-networks-gas
 description: >
   Sui networks, gas costs, and epochs. Use when the user asks about Sui network
   environments (Mainnet, Testnet, Devnet, Localnet), gas cost calculations, gas

--- a/sui-networks-gas/evals/evals.json
+++ b/sui-networks-gas/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "sui-cli",
+  "skill_name": "sui-networks-gas",
   "source_constraint": "All facts in these evals must be verifiable against docs.sui.io. No third-party blogs, tutorials, or unofficial documentation.",
   "evals": [
     {

--- a/sui-overview/SKILL.md
+++ b/sui-overview/SKILL.md
@@ -18,7 +18,7 @@ description: >
 
 Sui is a scalable, performant layer 1 blockchain built around an object-centric data model. Unlike account-based blockchains (Ethereum) or UTXO-based chains (Bitcoin), Sui treats every piece of onchain state as a typed object with a unique ID. Transactions consume objects as inputs and produce modified versions as outputs.
 
-This skill covers the conceptual foundation of Sui and the broader Sui Stack. For implementation details, see the `sui-move`, `frontend-apps`, and `sui-cli` skills.
+This skill covers the conceptual foundation of Sui and the broader Sui Stack. For implementation details, see the `sui-move`, `frontend-apps`, and `sui-networks-gas` skills.
 
 ---
 


### PR DESCRIPTION
## Summary

- Renames `sui-cli/` directory to `sui-networks-gas/` to match the actual content (networks, gas costs, epochs)
- The original `sui-cli` skill covered all CLI operations but was narrowed during a [dedup pass](https://github.com/MystenLabs/skills/commit/b07c4845) that split content into `sui-client`, `sui-install`, and `sui-publish` — the directory name was never updated
- Updates `name` field in SKILL.md frontmatter
- Updates cross-references in `sui-overview/SKILL.md` and `scripts/sui-monorepo-watch.json`

## Breaking change

Existing installs using `--skill sui-cli` will need to use `--skill sui-networks-gas` instead.

## Test plan

- [ ] Verify `npx skills add mystenlabs/skills --skill sui-networks-gas` works
- [ ] Confirm evals still pass under the new directory name
- [ ] Check no other files reference `sui-cli/` as a path

🤖 Generated with [Claude Code](https://claude.com/claude-code)