### PR TITLE
feat: add sui-ts-sdk-backend skill for agent/backend onboarding

### DIFF
--- a/sui-sdks/typescript.md
+++ b/sui-sdks/typescript.md
@@ -139,7 +139,7 @@ tx.transferObjects([coinWithBalance({ balance: 1_000_000 })], recipient);
 ### Manual commands (low-level)
 
 ```ts
-const [coin] = tx.splitCoins(tx.gas, [1000]);  // preferred for SUI transfers
+const [coin] = tx.splitCoins(tx.gas, [1000]);  // low-level; prefer tx.coin() above
 tx.mergeCoins(tx.object('0xDest'), [tx.object('0xSrc')]);
 tx.transferObjects([coin], '0x...');
 tx.moveCall({

--- a/sui-sdks/typescript.md
+++ b/sui-sdks/typescript.md
@@ -350,10 +350,10 @@ All `@mysten/*` packages are ESM-only:
 | Wrong | Right |
 |---|---|
 | `client.core.getBalance(...)` in user code | `client.getBalance(...)` — `.core` is for SDK internals only |
-| `tx.coin()` without `type` for SUI | `tx.splitCoins(tx.gas, [amount])` for SUI; `tx.coin({ balance, type })` for non-SUI |
+| `tx.splitCoins(tx.gas, [amount])` + `tx.transferObjects` | `tx.coin({ balance: amount })` or `tx.balance({ balance: amount })` |
 | `new Ed25519Keypair()` then signing transactions | `Ed25519Keypair.fromSecretKey(process.env.KEY!)` — random keys are unfunded |
 | Error handling before `waitForTransaction` | Call `waitForTransaction(result)` first, then check `$kind` |
 | `TransactionDataBuilder.fromBytes(bytes)` | `Transaction.from(bytes)` — `TransactionDataBuilder` is internal |
 | `sponsor.signAndExecuteTransaction({ signature })` | Parameter is `userSignature`, not `signature` |
 | Treating `FailedTransaction` as "not onchain" | It IS onchain, gas was charged, has effects. Do not retry. |
-| `splitCoins(tx.gas, ...)` when sender ≠ gas owner | Use `tx.coin({ balance, useGasCoin: false })` to source from sender's funds |
+| `splitCoins(tx.gas, ...)` in sponsored tx | Use `tx.coin({ balance, useGasCoin: false })` |

--- a/sui-sdks/typescript.md
+++ b/sui-sdks/typescript.md
@@ -100,13 +100,14 @@ tx.object.option({ type: '0xpkg::m::T', value: '0x...' });
 
 ### Coins and balances (recommended)
 
-`tx.coin()` and `tx.balance()` are the **recommended** methods. They automatically draw from both coin objects and address balances, preferring address balances to avoid versioned object dependencies.
+For **SUI transfers**, prefer `tx.splitCoins(tx.gas, [...])` — it works offline with no network resolution and supports both coin-object and address-balance gas. For **non-SUI tokens**, use `tx.coin()` / `tx.balance()` with an explicit `type`.
 
 ```ts
-// Get a Coin<T> for transfers
-tx.transferObjects([tx.coin({ balance: 1_000_000_000n })], recipient);
+// SUI transfer (preferred — works offline)
+const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
+tx.transferObjects([coin], recipient);
 
-// Non-SUI coin type
+// Non-SUI coin type (requires network resolution at build time)
 tx.transferObjects(
   [tx.coin({ balance: 1_000_000n, type: '0xPkg::module::USDC' })],
   recipient,
@@ -139,7 +140,7 @@ tx.transferObjects([coinWithBalance({ balance: 1_000_000 })], recipient);
 ### Manual commands (low-level)
 
 ```ts
-const [coin] = tx.splitCoins(tx.gas, [1000]);  // prefer tx.coin() above
+const [coin] = tx.splitCoins(tx.gas, [1000]);  // preferred for SUI transfers
 tx.mergeCoins(tx.object('0xDest'), [tx.object('0xSrc')]);
 tx.transferObjects([coin], '0x...');
 tx.moveCall({
@@ -350,10 +351,10 @@ All `@mysten/*` packages are ESM-only:
 | Wrong | Right |
 |---|---|
 | `client.core.getBalance(...)` in user code | `client.getBalance(...)` — `.core` is for SDK internals only |
-| `tx.splitCoins(tx.gas, [amount])` + `tx.transferObjects` | `tx.coin({ balance: amount })` or `tx.balance({ balance: amount })` |
+| `tx.coin()` without `type` for SUI | `tx.splitCoins(tx.gas, [amount])` for SUI; `tx.coin({ balance, type })` for non-SUI |
 | `new Ed25519Keypair()` then signing transactions | `Ed25519Keypair.fromSecretKey(process.env.KEY!)` — random keys are unfunded |
 | Error handling before `waitForTransaction` | Call `waitForTransaction(result)` first, then check `$kind` |
 | `TransactionDataBuilder.fromBytes(bytes)` | `Transaction.from(bytes)` — `TransactionDataBuilder` is internal |
 | `sponsor.signAndExecuteTransaction({ signature })` | Parameter is `userSignature`, not `signature` |
 | Treating `FailedTransaction` as "not onchain" | It IS onchain, gas was charged, has effects. Do not retry. |
-| `splitCoins(tx.gas, ...)` in sponsored tx | Use `tx.coin({ balance, useGasCoin: false })` |
+| `splitCoins(tx.gas, ...)` when sender ≠ gas owner | Use `tx.coin({ balance, useGasCoin: false })` to source from sender's funds |

--- a/sui-sdks/typescript.md
+++ b/sui-sdks/typescript.md
@@ -100,14 +100,13 @@ tx.object.option({ type: '0xpkg::m::T', value: '0x...' });
 
 ### Coins and balances (recommended)
 
-For **SUI transfers**, prefer `tx.splitCoins(tx.gas, [...])` — it works offline with no network resolution and supports both coin-object and address-balance gas. For **non-SUI tokens**, use `tx.coin()` / `tx.balance()` with an explicit `type`.
+`tx.coin()` and `tx.balance()` are the **recommended** methods. They automatically draw from both coin objects and address balances, preferring address balances to avoid versioned object dependencies.
 
 ```ts
-// SUI transfer (preferred — works offline)
-const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
-tx.transferObjects([coin], recipient);
+// Get a Coin<T> for transfers
+tx.transferObjects([tx.coin({ balance: 1_000_000_000n })], recipient);
 
-// Non-SUI coin type (requires network resolution at build time)
+// Non-SUI coin type
 tx.transferObjects(
   [tx.coin({ balance: 1_000_000n, type: '0xPkg::module::USDC' })],
   recipient,

--- a/sui-ts-sdk-backend/SKILL.md
+++ b/sui-ts-sdk-backend/SKILL.md
@@ -96,9 +96,10 @@ If unsure about any API, fetch the relevant page before answering. Do not guess 
 - Always use `SuiGrpcClient` as the default client. Use `SuiGraphQLClient` only when you need flexible relational queries.
 - Always check `result.$kind` after transaction execution. A result that is not `Rejected` can still be `FailedTransaction` (executed on-chain but aborted — gas is still consumed).
 - Always call `await client.waitForTransaction({ result })` before reading state that depends on a transaction's effects.
-- Never hardcode gas coin object IDs. Use `tx.coin()` / `tx.balance()` or let the SDK resolve gas automatically.
-- Use `tx.coin({ balance, type })` and `tx.balance({ balance, type })` instead of manual `splitCoins` / `mergeCoins` when possible. They handle address balance + coin object resolution automatically.
-- For sponsored transactions, set `useGasCoin: false` when the sender is transferring tokens, to prevent the SDK from splitting the sponsor's gas coin.
+- For SUI transfers, prefer `tx.splitCoins(tx.gas, [...])` over `tx.coin()`. The gas coin (`tx.gas`) works with both coin-object gas and address-balance gas (`setGasPayment([])`), requires no network access, and enables fully offline transaction builds.
+- Use `tx.coin({ balance, type })` and `tx.balance({ balance, type })` for non-SUI tokens. These require network access at build time for balance resolution.
+- With address-balance gas (`setGasPayment([])`), the protocol materializes a synthetic GasCoin from the sender's or sponsor's address balance. `tx.gas` references this synthetic coin and can be borrowed by reference or consumed by value through `TransferObjects` or `coin::send_funds`.
+- For sponsored transactions where the sender needs to transfer tokens, set `useGasCoin: false` on `tx.coin()` / `tx.balance()` calls to prevent the SDK from sourcing from the sponsor's gas coin. Alternatively, use `tx.splitCoins(tx.gas, ...)` only when the sender is the gas owner.
 - For scale, use `SerialTransactionExecutor` or `ParallelTransactionExecutor` instead of manual gas management loops.
 - For production backends, use AWS KMS or GCP KMS signers instead of storing raw private keys.
 
@@ -107,6 +108,6 @@ If unsure about any API, fetch the relevant page before answering. Do not guess 
 - **Storing raw private keys in environment variables for production.** Use AWS KMS or GCP KMS signers. Raw keys are acceptable for development/testing only.
 - **Not waiting for indexing after a transaction.** Read APIs may not immediately reflect transaction effects. Always `waitForTransaction` before dependent reads.
 - **Assuming `result` means success.** Check `result.$kind !== 'FailedTransaction'`. A `FailedTransaction` was executed on-chain (gas consumed) but the Move call aborted.
-- **Using `splitCoins(tx.gas, ...)` for sponsored transactions.** The gas coin belongs to the sponsor, not the sender. Use `tx.coin()` with `useGasCoin: false` instead.
+- **Using `splitCoins(tx.gas, ...)` when the sender is not the gas owner.** In sponsored transactions, `tx.gas` belongs to the sponsor. If the sender needs to transfer their own tokens, use `tx.coin()` with `useGasCoin: false` to source from the sender's balance instead.
 - **Running multiple `ParallelTransactionExecutor` instances on the same address.** This causes gas coin conflicts. Use a single executor per address.
 - **Building transactions with fully-specified object refs when using executors.** Use unresolved object IDs (`tx.object('0x...')`) so the executor can leverage its object cache.

--- a/sui-ts-sdk-backend/SKILL.md
+++ b/sui-ts-sdk-backend/SKILL.md
@@ -96,10 +96,10 @@ If unsure about any API, fetch the relevant page before answering. Do not guess 
 - Always use `SuiGrpcClient` as the default client. Use `SuiGraphQLClient` only when you need flexible relational queries.
 - Always check `result.$kind` after transaction execution. A result that is not `Rejected` can still be `FailedTransaction` (executed on-chain but aborted — gas is still consumed).
 - Always call `await client.waitForTransaction({ result })` before reading state that depends on a transaction's effects.
-- For SUI transfers, prefer `tx.splitCoins(tx.gas, [...])` over `tx.coin()`. The gas coin (`tx.gas`) works with both coin-object gas and address-balance gas (`setGasPayment([])`), requires no network access, and enables fully offline transaction builds.
-- Use `tx.coin({ balance, type })` and `tx.balance({ balance, type })` for non-SUI tokens. These require network access at build time for balance resolution.
+- For transfers, prefer `balance::send_funds` over `transferObjects`. It deposits directly into the recipient's address balance, avoids versioned coin objects on the receiving side, and enables concurrent spending by the recipient.
+- For SUI in Move call arguments, prefer `tx.splitCoins(tx.gas, [...])` — it works offline with no network resolution. For non-SUI tokens, use `tx.coin({ balance, type })` or `tx.balance({ balance, type })` with explicit `type`.
 - With address-balance gas (`setGasPayment([])`), the protocol materializes a synthetic GasCoin from the sender's or sponsor's address balance. `tx.gas` references this synthetic coin and can be borrowed by reference or consumed by value through `TransferObjects` or `coin::send_funds`.
-- For sponsored transactions where the sender needs to transfer tokens, set `useGasCoin: false` on `tx.coin()` / `tx.balance()` calls to prevent the SDK from sourcing from the sponsor's gas coin. Alternatively, use `tx.splitCoins(tx.gas, ...)` only when the sender is the gas owner.
+- For sponsored transactions where the sender needs to transfer their own tokens, set `useGasCoin: false` on `tx.coin()` / `tx.balance()` calls to source from the sender's balance instead of the sponsor's gas coin.
 - For scale, use `SerialTransactionExecutor` or `ParallelTransactionExecutor` instead of manual gas management loops.
 - For production backends, use AWS KMS or GCP KMS signers instead of storing raw private keys.
 

--- a/sui-ts-sdk-backend/SKILL.md
+++ b/sui-ts-sdk-backend/SKILL.md
@@ -96,9 +96,8 @@ If unsure about any API, fetch the relevant page before answering. Do not guess 
 - Always use `SuiGrpcClient` as the default client. Use `SuiGraphQLClient` only when you need flexible relational queries.
 - Always check `result.$kind` after transaction execution. A result that is not `Rejected` can still be `FailedTransaction` (executed on-chain but aborted — gas is still consumed).
 - Always call `await client.waitForTransaction({ result })` before reading state that depends on a transaction's effects.
-- For transfers, prefer `balance::send_funds` over `transferObjects`. It deposits directly into the recipient's address balance, avoids versioned coin objects on the receiving side, and enables concurrent spending by the recipient.
-- For SUI in Move call arguments, prefer `tx.splitCoins(tx.gas, [...])` — it works offline with no network resolution. For non-SUI tokens, use `tx.coin({ balance, type })` or `tx.balance({ balance, type })` with explicit `type`.
-- With address-balance gas (`setGasPayment([])`), the protocol materializes a synthetic GasCoin from the sender's or sponsor's address balance. `tx.gas` references this synthetic coin and can be borrowed by reference or consumed by value through `TransferObjects` or `coin::send_funds`.
+- Use `tx.coin()` and `tx.balance()` as the primary way to access funds. They automatically resolve from both address balances and coin objects. Specify `type` for non-SUI tokens.
+- For transfers, prefer `balance::send_funds` over `transferObjects`. It deposits directly into the recipient's address balance, avoiding versioned coin objects on the receiving side.
 - For sponsored transactions where the sender needs to transfer their own tokens, set `useGasCoin: false` on `tx.coin()` / `tx.balance()` calls to source from the sender's balance instead of the sponsor's gas coin.
 - For scale, use `SerialTransactionExecutor` or `ParallelTransactionExecutor` instead of manual gas management loops.
 - For production backends, use AWS KMS or GCP KMS signers instead of storing raw private keys.

--- a/sui-ts-sdk-backend/SKILL.md
+++ b/sui-ts-sdk-backend/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: sui-ts-sdk-backend
+description: >
+  Sui TypeScript SDK for backend services and autonomous agents. Use when
+  building a backend, agent, or service that interacts with Sui programmatically
+  without CLI — keypair creation, faucet funding, client setup, transaction
+  building and signing, package publishing from code, sponsored transactions,
+  running transactions at scale with executors, cloud KMS signing (AWS/GCP),
+  and multisig workflows. Also use when the user asks how to bootstrap a Sui
+  agent, build a backend signer service, or run high-throughput transaction
+  pipelines.
+
+  For frontend dApp development with wallets, see the `frontend-apps` skill.
+  For SDK selection (TS vs Rust vs community), see the `sui-sdks` skill.
+  For PTB semantics and command reference, see the `ptbs` skill.
+  For Move smart contract development, see the `sui-move` skill.
+---
+
+# Sui TypeScript SDK — Backend & Agent Patterns
+
+> **MCP tool:** When available in your environment, also query the Sui documentation MCP server (`https://sui.mcp.kapa.ai`) for up-to-date answers. Use it for verification and for details not covered by these reference files.
+
+> **Source constraint:** All information in this skill is sourced exclusively from [sdk.mystenlabs.com](https://sdk.mystenlabs.com). When extending or updating this skill, only pull from this source. Do not use third-party blogs, tutorials, or unofficial documentation.
+
+This skill covers using the Sui TypeScript SDK (`@mysten/sui` v2) for backend services and autonomous agents that cannot use the Sui CLI. It provides the end-to-end programmatic workflow: creating keypairs, funding addresses, connecting to networks, building and signing transactions, publishing packages, sponsoring transactions for users, running at scale, and signing with cloud KMS or multisig.
+
+All patterns in this skill are derived from:
+  https://sdk.mystenlabs.com
+
+If unsure about any API, fetch the relevant page before answering. Do not guess or extrapolate.
+
+---
+
+## Reference files
+
+### bootstrap — Keypair, Faucet, and Client Setup
+**Path:** `bootstrap.md`
+**Load when:** creating a keypair programmatically, funding an address from the faucet without CLI, configuring a `SuiGrpcClient` or `SuiGraphQLClient`, or bootstrapping an agent's first connection to Sui.
+**Covers:** keypair creation (random, mnemonic, import/export, Bech32 `suiprivkey` format), all three key types (Ed25519, Secp256k1, Secp256r1), programmatic faucet requests, client instantiation and network selection, client extensions, the complete bootstrap sequence.
+
+### transactions — Building, Coins, and Execution
+**Path:** `transactions.md`
+**Load when:** building transactions with `tx.coin()` or `tx.balance()`, handling address balances vs coin objects, signing and executing from a backend keypair, checking results, waiting for indexing, or handling gasless transactions.
+**Covers:** `tx.coin()` and `tx.balance()` (the recommended coin access pattern), address balances vs coin objects, splitting and merging coins, signing with keypairs directly, result handling (`FailedTransaction` checks), `waitForTransaction`, gasless stablecoin transfers.
+
+### publishing — Programmatic Package Publish and Upgrade
+**Path:** `publishing.md`
+**Load when:** publishing a Move package from TypeScript without CLI, upgrading a published package programmatically, or constructing Publish/Upgrade PTB commands.
+**Covers:** building Move bytecode, constructing Publish commands in PTBs, executing publish transactions, extracting package ID and UpgradeCap from results, programmatic upgrades with UpgradeCap, upgrade policies.
+
+### sponsorship — Sponsored Transactions
+**Path:** `sponsorship.md`
+**Load when:** sponsoring transactions for users, building a gas station backend, using the `@mysten-incubation/sponsor` SDK, or implementing address-balance or coin-based sponsorship flows.
+**Covers:** `@mysten-incubation/sponsor` package, client-builds flow (recommended), backend validation and co-signing, config endpoint pattern, coin-based vs address-balance sponsorship, `useGasCoin: false` for token transfers, result handling (Rejected vs FailedTransaction vs success).
+
+### executors — Running Transactions at Scale
+**Path:** `executors.md`
+**Load when:** running many transactions from one address, building a high-throughput pipeline, managing gas pools, or needing parallel or serial transaction execution without manual gas management.
+**Covers:** `SerialTransactionExecutor` (queuing, gas merging, object caching), `ParallelTransactionExecutor` (concurrent execution, gas pool, conflict detection), configuration options, best practices for unresolved object IDs.
+
+### signing — Cloud KMS and Multisig
+**Path:** `signing.md`
+**Load when:** signing with AWS KMS or GCP KMS, setting up multisig wallets, combining partial signatures, mixing keypair types (Ed25519 + zkLogin + passkey), or building a custody/signer service.
+**Covers:** Signer interface (shared across all signer types), AWS KMS signer (`@mysten/aws-kms-signer`), GCP KMS signer (`@mysten/gcp-kms-signer`), `MultiSigPublicKey` setup (threshold, weights), `MultiSigSigner`, combining partial signatures, hybrid multisig (keypairs + zkLogin + passkeys).
+
+---
+
+## Routing guide
+
+| Task | Load |
+|------|------|
+| Bootstrapping an agent from scratch | bootstrap |
+| Creating a keypair without CLI | bootstrap |
+| Getting testnet SUI without CLI | bootstrap |
+| Connecting to Mainnet/Testnet/Devnet | bootstrap |
+| Building a transaction with coin access | transactions |
+| Signing and executing from a backend | transactions |
+| Handling address balances vs coin objects | transactions |
+| Publishing a Move package from TypeScript | publishing |
+| Upgrading a package programmatically | publishing |
+| Sponsoring transactions for users | sponsorship |
+| Building a gas station backend | sponsorship |
+| Running many transactions efficiently | executors |
+| Building a high-throughput pipeline | executors |
+| Signing with AWS or GCP KMS | signing |
+| Setting up multisig | signing |
+| Building a custody service | signing |
+| Full backend service from scratch | **all reference files** |
+| Agent onboarding end-to-end | bootstrap + transactions |
+
+---
+
+## Rules
+
+- Always use `@mysten/sui` v2 (`@mysten/sui/grpc`, `@mysten/sui/keypairs/ed25519`, etc.). Never use the deprecated `@mysten/sui.js` v1.
+- Always use `SuiGrpcClient` as the default client. Use `SuiGraphQLClient` only when you need flexible relational queries.
+- Always check `result.$kind` after transaction execution. A result that is not `Rejected` can still be `FailedTransaction` (executed on-chain but aborted — gas is still consumed).
+- Always call `await client.waitForTransaction({ result })` before reading state that depends on a transaction's effects.
+- Never hardcode gas coin object IDs. Use `tx.coin()` / `tx.balance()` or let the SDK resolve gas automatically.
+- Use `tx.coin({ balance, type })` and `tx.balance({ balance, type })` instead of manual `splitCoins` / `mergeCoins` when possible. They handle address balance + coin object resolution automatically.
+- For sponsored transactions, set `useGasCoin: false` when the sender is transferring tokens, to prevent the SDK from splitting the sponsor's gas coin.
+- For scale, use `SerialTransactionExecutor` or `ParallelTransactionExecutor` instead of manual gas management loops.
+- For production backends, use AWS KMS or GCP KMS signers instead of storing raw private keys.
+
+## Common mistakes
+
+- **Storing raw private keys in environment variables for production.** Use AWS KMS or GCP KMS signers. Raw keys are acceptable for development/testing only.
+- **Not waiting for indexing after a transaction.** Read APIs may not immediately reflect transaction effects. Always `waitForTransaction` before dependent reads.
+- **Assuming `result` means success.** Check `result.$kind !== 'FailedTransaction'`. A `FailedTransaction` was executed on-chain (gas consumed) but the Move call aborted.
+- **Using `splitCoins(tx.gas, ...)` for sponsored transactions.** The gas coin belongs to the sponsor, not the sender. Use `tx.coin()` with `useGasCoin: false` instead.
+- **Running multiple `ParallelTransactionExecutor` instances on the same address.** This causes gas coin conflicts. Use a single executor per address.
+- **Building transactions with fully-specified object refs when using executors.** Use unresolved object IDs (`tx.object('0x...')`) so the executor can leverage its object cache.

--- a/sui-ts-sdk-backend/bootstrap.md
+++ b/sui-ts-sdk-backend/bootstrap.md
@@ -110,7 +110,7 @@ There is no faucet for Mainnet. For Mainnet, acquire SUI through an exchange or 
 
 ```typescript
 await requestSuiFromFaucetV2({
-  host: getFaucetHost('localnet'), // http://127.0.0.1:5003/v2/gas
+  host: getFaucetHost('localnet'), // http://127.0.0.1:9123/v2/gas
   recipient: keypair.toSuiAddress(),
 });
 ```

--- a/sui-ts-sdk-backend/bootstrap.md
+++ b/sui-ts-sdk-backend/bootstrap.md
@@ -1,0 +1,222 @@
+# Keypair, Faucet, and Client Setup
+
+> Source: [sdk.mystenlabs.com](https://sdk.mystenlabs.com/sui/cryptography/keypairs)
+
+This file covers the complete bootstrap sequence for an agent or backend service: create a keypair, fund it, and connect to Sui — all without CLI.
+
+---
+
+## Install
+
+```bash
+npm install @mysten/sui
+```
+
+---
+
+## Step 1: Create a keypair
+
+### Supported key types
+
+| Scheme | Class | Import |
+|--------|-------|--------|
+| Ed25519 | `Ed25519Keypair` | `@mysten/sui/keypairs/ed25519` |
+| ECDSA Secp256k1 | `Secp256k1Keypair` | `@mysten/sui/keypairs/secp256k1` |
+| ECDSA Secp256r1 | `Secp256r1Keypair` | `@mysten/sui/keypairs/secp256r1` |
+
+Ed25519 is the default and most common choice.
+
+### Generate a random keypair
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+
+const keypair = new Ed25519Keypair();
+const address = keypair.toSuiAddress();
+console.log('Address:', address);
+```
+
+### Derive from a mnemonic
+
+```typescript
+const keypair = Ed25519Keypair.deriveKeypair(
+  'result crisp session latin must fruit genuine question ...'
+);
+```
+
+### Import from a Bech32 secret key
+
+Sui private keys use the `suiprivkey` Bech32 prefix. This is the standard format for storing and exchanging keys.
+
+```typescript
+const keypair = Ed25519Keypair.fromSecretKey(
+  'suiprivkey1qzse89atw7d3zum8ujep76d2cxmgduyuast0y9fu23xcl0mpafgkktllhyc'
+);
+```
+
+### Import from raw hex bytes
+
+```typescript
+import { fromHex } from '@mysten/sui/utils';
+
+const keypair = Ed25519Keypair.fromSecretKey(fromHex('0xabcdef...'));
+```
+
+### Export a keypair
+
+```typescript
+const secretKey = keypair.getSecretKey(); // Returns Bech32 'suiprivkey...' string
+```
+
+### Detect key scheme from encoded key
+
+When loading a key from storage and you don't know the scheme:
+
+```typescript
+import { decodeSuiPrivateKey } from '@mysten/sui/cryptography';
+
+const { scheme, secretKey } = decodeSuiPrivateKey(encodedKey);
+// scheme is 'ED25519', 'Secp256k1', or 'Secp256r1'
+// Use the appropriate Keypair class based on scheme
+```
+
+### Get public key and address
+
+```typescript
+const publicKey = keypair.getPublicKey();
+const address = keypair.toSuiAddress();
+```
+
+---
+
+## Step 2: Fund the address (testnet/devnet)
+
+### Programmatic faucet request
+
+```typescript
+import { requestSuiFromFaucetV2, getFaucetHost } from '@mysten/sui/faucet';
+
+await requestSuiFromFaucetV2({
+  host: getFaucetHost('testnet'),
+  recipient: keypair.toSuiAddress(),
+});
+```
+
+Available networks for `getFaucetHost`: `'testnet'`, `'devnet'`, `'localnet'`.
+
+There is no faucet for Mainnet. For Mainnet, acquire SUI through an exchange or transfer from another address.
+
+### Local faucet (when running localnet)
+
+```typescript
+await requestSuiFromFaucetV2({
+  host: getFaucetHost('localnet'), // http://127.0.0.1:5003/v2/gas
+  recipient: keypair.toSuiAddress(),
+});
+```
+
+---
+
+## Step 3: Connect to a network
+
+### SuiGrpcClient (default — use this)
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+// Testnet
+const client = new SuiGrpcClient({ network: 'testnet' });
+
+// Mainnet
+const client = new SuiGrpcClient({ network: 'mainnet' });
+
+// Devnet
+const client = new SuiGrpcClient({ network: 'devnet' });
+
+// Localnet
+const client = new SuiGrpcClient({ network: 'localnet' });
+
+// Custom endpoint
+const client = new SuiGrpcClient({
+  network: 'mainnet',
+  baseUrl: 'https://your-custom-fullnode.example.com:443',
+});
+```
+
+`SuiGrpcClient` reads from a full node and is the only client with real-time streaming subscriptions.
+
+### SuiGraphQLClient (for flexible queries)
+
+```typescript
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
+
+const client = new SuiGraphQLClient({
+  network: 'mainnet',
+  url: 'https://graphql.mainnet.sui.io/graphql',
+});
+```
+
+`SuiGraphQLClient` reads from the indexer. Use it when you need relational queries or multi-entity joins.
+
+### Both clients share the same API
+
+Top-level methods and `client.core.*` methods work identically on both clients. Switching between them is mostly a constructor change.
+
+### Client extensions
+
+Extend a client with first-party SDK modules:
+
+```typescript
+import { deepbook } from '@mysten/deepbook-v3';
+import { walrus } from '@mysten/walrus';
+import { seal } from '@mysten/seal';
+
+const client = new SuiGrpcClient({ network: 'mainnet' })
+  .$extend(deepbook({ address: '0x...' }))
+  .$extend(walrus())
+  .$extend(seal());
+```
+
+---
+
+## Complete bootstrap example
+
+End-to-end: create a keypair, fund it on testnet, connect, and verify the balance.
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { requestSuiFromFaucetV2, getFaucetHost } from '@mysten/sui/faucet';
+
+// 1. Create keypair
+const keypair = new Ed25519Keypair();
+const address = keypair.toSuiAddress();
+console.log('Address:', address);
+
+// 2. Fund from faucet
+await requestSuiFromFaucetV2({
+  host: getFaucetHost('testnet'),
+  recipient: address,
+});
+
+// 3. Connect
+const client = new SuiGrpcClient({ network: 'testnet' });
+
+// 4. Verify balance
+const { balance } = await client.getBalance({ owner: address });
+console.log('Balance:', balance);
+```
+
+---
+
+## Loading a keypair from environment (production pattern)
+
+For production services, load keys from environment variables or a secrets manager:
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+
+const keypair = Ed25519Keypair.fromSecretKey(process.env.SUI_PRIVATE_KEY!);
+```
+
+For higher security, use AWS KMS or GCP KMS signers instead of raw keys. See the `signing.md` reference file.

--- a/sui-ts-sdk-backend/evals/evals.json
+++ b/sui-ts-sdk-backend/evals/evals.json
@@ -23,7 +23,7 @@
       "prompt": "How do I build a transaction that sends 1 SUI to another address, sign it with a keypair, and execute it from a backend? Show me the proper way to access coins and check the result.",
       "expected_output": "A transaction using tx.coin() for coin access, keypair.signAndExecuteTransaction() for signing, result.$kind check for error handling, and waitForTransaction before dependent reads.",
       "expectations": [
-        "The response uses tx.splitCoins(tx.gas, [...]) for SUI transfers, or tx.coin() with explicit type for non-SUI tokens",
+        "The response uses tx.coin({ balance: 1_000_000_000n }) or equivalent for coin access",
         "The response uses keypair.signAndExecuteTransaction({ transaction, client })",
         "The response checks result.$kind for FailedTransaction",
         "The response calls client.waitForTransaction({ result }) before reading updated state",

--- a/sui-ts-sdk-backend/evals/evals.json
+++ b/sui-ts-sdk-backend/evals/evals.json
@@ -1,0 +1,85 @@
+{
+  "skill_name": "sui-ts-sdk-backend",
+  "source_constraint": "All facts in these evals must be verifiable against sdk.mystenlabs.com. No third-party blogs, tutorials, or unofficial documentation.",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm building a backend service that needs to interact with Sui. I can't use the CLI. How do I create a keypair, get testnet SUI, and connect to the network — all from TypeScript?",
+      "expected_output": "A complete bootstrap sequence: create an Ed25519Keypair, request SUI from the faucet using requestSuiFromFaucetV2, and create a SuiGrpcClient connected to testnet.",
+      "expectations": [
+        "The response shows creating a keypair with new Ed25519Keypair() or Ed25519Keypair.fromSecretKey()",
+        "The response shows requestSuiFromFaucetV2 with getFaucetHost('testnet') for programmatic faucet access",
+        "The response shows creating a SuiGrpcClient with network: 'testnet'",
+        "The response does NOT suggest using the Sui CLI for any of these steps",
+        "The response shows how to get the address with keypair.toSuiAddress()"
+      ],
+      "sources": [
+        "https://sdk.mystenlabs.com/sui/cryptography/keypairs",
+        "https://sdk.mystenlabs.com/sui"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "How do I build a transaction that sends 1 SUI to another address, sign it with a keypair, and execute it from a backend? Show me the proper way to access coins and check the result.",
+      "expected_output": "A transaction using tx.coin() for coin access, keypair.signAndExecuteTransaction() for signing, result.$kind check for error handling, and waitForTransaction before dependent reads.",
+      "expectations": [
+        "The response uses tx.coin({ balance: 1_000_000_000n }) or equivalent for coin access",
+        "The response uses keypair.signAndExecuteTransaction({ transaction, client })",
+        "The response checks result.$kind for FailedTransaction",
+        "The response calls client.waitForTransaction({ result }) before reading updated state",
+        "The response does NOT manually split gas coins when tx.coin() suffices"
+      ],
+      "sources": [
+        "https://sdk.mystenlabs.com/sui/transactions/coins-and-balances",
+        "https://sdk.mystenlabs.com/sui/transactions/signing-and-execution"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I need to sponsor transactions for my users so they don't need SUI for gas. What's the recommended flow and what SDK should I use?",
+      "expected_output": "An explanation of the @mysten/sponsor package, the client-builds flow where the client builds transaction bytes and the backend validates and co-signs, and the three possible result types (Rejected, FailedTransaction, Transaction).",
+      "expectations": [
+        "The response recommends the client-builds approach where the client builds full transaction bytes",
+        "The response mentions setting empty gas payment and gas owner for address-balance sponsorship",
+        "The response shows both user and sponsor signing the transaction",
+        "The response explains the three result types: Rejected, FailedTransaction, and Transaction",
+        "The response mentions useGasCoin: false when the sender is transferring tokens"
+      ],
+      "sources": [
+        "https://sdk.mystenlabs.com/sponsor/basic-usage",
+        "https://sdk.mystenlabs.com/sponsor/best-practices"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "I need to run hundreds of transactions from one address as fast as possible for an airdrop. How do I avoid gas management issues?",
+      "expected_output": "An explanation of ParallelTransactionExecutor for concurrent execution with automatic gas pool management and conflict detection, or SerialTransactionExecutor for ordered execution with automatic gas merging.",
+      "expectations": [
+        "The response recommends ParallelTransactionExecutor for high-throughput batch operations",
+        "The response explains that the executor automatically maintains a gas coin pool",
+        "The response mentions conflict detection for transactions using the same objects",
+        "The response warns against running multiple executor instances on the same address",
+        "The response advises using unresolved object IDs (strings) rather than fully-specified refs"
+      ],
+      "sources": [
+        "https://sdk.mystenlabs.com/sui/executors"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "For our production backend, we don't want to store raw private keys. What are our options for signing Sui transactions securely, and how do we set up a 2-of-3 multisig?",
+      "expected_output": "An explanation of AWS KMS and GCP KMS signers that implement the same Signer interface as keypairs, plus MultiSigPublicKey setup with threshold and weights.",
+      "expectations": [
+        "The response recommends AWS KMS signer (@mysten/aws-kms-signer) or GCP KMS signer (@mysten/gcp-kms-signer)",
+        "The response explains that KMS signers implement the same Signer interface as keypairs",
+        "The response shows MultiSigPublicKey.fromPublicKeys with threshold and weighted public keys",
+        "The response shows how to combine partial signatures or use MultiSigSigner",
+        "The response notes maximum 10 accounts per multisig"
+      ],
+      "sources": [
+        "https://sdk.mystenlabs.com/sui/cryptography/signers",
+        "https://sdk.mystenlabs.com/sui/cryptography/signers/multisig"
+      ]
+    }
+  ]
+}

--- a/sui-ts-sdk-backend/evals/evals.json
+++ b/sui-ts-sdk-backend/evals/evals.json
@@ -23,11 +23,11 @@
       "prompt": "How do I build a transaction that sends 1 SUI to another address, sign it with a keypair, and execute it from a backend? Show me the proper way to access coins and check the result.",
       "expected_output": "A transaction using tx.coin() for coin access, keypair.signAndExecuteTransaction() for signing, result.$kind check for error handling, and waitForTransaction before dependent reads.",
       "expectations": [
-        "The response uses tx.coin({ balance: 1_000_000_000n }) or equivalent for coin access",
+        "The response uses tx.coin() or tx.balance() for coin access",
         "The response uses keypair.signAndExecuteTransaction({ transaction, client })",
         "The response checks result.$kind for FailedTransaction",
         "The response calls client.waitForTransaction({ result }) before reading updated state",
-        "The response does NOT use tx.coin() without a type argument for SUI-only transfers"
+        "The response prefers balance::send_funds for transfers over transferObjects"
       ],
       "sources": [
         "https://sdk.mystenlabs.com/sui/transactions/coins-and-balances",

--- a/sui-ts-sdk-backend/evals/evals.json
+++ b/sui-ts-sdk-backend/evals/evals.json
@@ -21,7 +21,7 @@
     {
       "id": 2,
       "prompt": "How do I build a transaction that sends 1 SUI to another address, sign it with a keypair, and execute it from a backend? Show me the proper way to access coins and check the result.",
-      "expected_output": "A transaction using tx.splitCoins(tx.gas, [...]) for SUI access (or tx.coin() for non-SUI tokens), keypair.signAndExecuteTransaction() for signing, result.$kind check for error handling, and waitForTransaction before dependent reads.",
+      "expected_output": "A transaction using tx.coin() for coin access, keypair.signAndExecuteTransaction() for signing, result.$kind check for error handling, and waitForTransaction before dependent reads.",
       "expectations": [
         "The response uses tx.splitCoins(tx.gas, [...]) for SUI transfers, or tx.coin() with explicit type for non-SUI tokens",
         "The response uses keypair.signAndExecuteTransaction({ transaction, client })",

--- a/sui-ts-sdk-backend/evals/evals.json
+++ b/sui-ts-sdk-backend/evals/evals.json
@@ -37,7 +37,7 @@
     {
       "id": 3,
       "prompt": "I need to sponsor transactions for my users so they don't need SUI for gas. What's the recommended flow and what SDK should I use?",
-      "expected_output": "An explanation of the @mysten/sponsor package, the client-builds flow where the client builds transaction bytes and the backend validates and co-signs, and the three possible result types (Rejected, FailedTransaction, Transaction).",
+      "expected_output": "An explanation of the @mysten-incubation/sponsor package and createSponsor, the client-builds flow where the client builds transaction bytes and the backend validates and co-signs, and the three possible result types (Rejected, FailedTransaction, Transaction).",
       "expectations": [
         "The response recommends the client-builds approach where the client builds full transaction bytes",
         "The response mentions setting empty gas payment and gas owner for address-balance sponsorship",

--- a/sui-ts-sdk-backend/evals/evals.json
+++ b/sui-ts-sdk-backend/evals/evals.json
@@ -21,13 +21,13 @@
     {
       "id": 2,
       "prompt": "How do I build a transaction that sends 1 SUI to another address, sign it with a keypair, and execute it from a backend? Show me the proper way to access coins and check the result.",
-      "expected_output": "A transaction using tx.coin() for coin access, keypair.signAndExecuteTransaction() for signing, result.$kind check for error handling, and waitForTransaction before dependent reads.",
+      "expected_output": "A transaction using tx.splitCoins(tx.gas, [...]) for SUI access (or tx.coin() for non-SUI tokens), keypair.signAndExecuteTransaction() for signing, result.$kind check for error handling, and waitForTransaction before dependent reads.",
       "expectations": [
-        "The response uses tx.coin({ balance: 1_000_000_000n }) or equivalent for coin access",
+        "The response uses tx.splitCoins(tx.gas, [...]) for SUI transfers, or tx.coin() with explicit type for non-SUI tokens",
         "The response uses keypair.signAndExecuteTransaction({ transaction, client })",
         "The response checks result.$kind for FailedTransaction",
         "The response calls client.waitForTransaction({ result }) before reading updated state",
-        "The response does NOT manually split gas coins when tx.coin() suffices"
+        "The response does NOT use tx.coin() without a type argument for SUI-only transfers"
       ],
       "sources": [
         "https://sdk.mystenlabs.com/sui/transactions/coins-and-balances",
@@ -39,11 +39,12 @@
       "prompt": "I need to sponsor transactions for my users so they don't need SUI for gas. What's the recommended flow and what SDK should I use?",
       "expected_output": "An explanation of the @mysten-incubation/sponsor package and createSponsor, the client-builds flow where the client builds transaction bytes and the backend validates and co-signs, and the three possible result types (Rejected, FailedTransaction, Transaction).",
       "expectations": [
+        "The response recommends @mysten-incubation/sponsor and createSponsor for the backend",
         "The response recommends the client-builds approach where the client builds full transaction bytes",
         "The response mentions setting empty gas payment and gas owner for address-balance sponsorship",
-        "The response shows both user and sponsor signing the transaction",
         "The response explains the three result types: Rejected, FailedTransaction, and Transaction",
-        "The response mentions useGasCoin: false when the sender is transferring tokens"
+        "The response mentions application-specific validation (authentication, allowlists, rate limits) beyond defaults()",
+        "The response mentions useGasCoin: false when the sender is transferring their own tokens"
       ],
       "sources": [
         "https://sdk.mystenlabs.com/sponsor/basic-usage",

--- a/sui-ts-sdk-backend/executors.md
+++ b/sui-ts-sdk-backend/executors.md
@@ -1,0 +1,143 @@
+# Running Transactions at Scale
+
+> Source: [sdk.mystenlabs.com/sui/executors](https://sdk.mystenlabs.com/sui/executors)
+
+The SDK provides two executor classes for efficiently managing multiple transactions from a single address without manual gas management.
+
+---
+
+## SerialTransactionExecutor
+
+For sequential execution from a single address (wallets, backend services with ordered operations).
+
+### How it works
+
+1. Selects all of the sender's SUI coins for the first transaction, which merges them into a single coin.
+2. That single coin is reused as gas payment for all subsequent transactions.
+3. Maintains an internal object version cache to speed execution when reusing objects.
+4. Queues transactions internally — no need to await previous transactions before submitting the next.
+
+### Setup
+
+```typescript
+import { SerialTransactionExecutor } from '@mysten/sui/transactions';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+
+const client = new SuiGrpcClient({ network: 'testnet' });
+const keypair = Ed25519Keypair.fromSecretKey('suiprivkey1...');
+
+const executor = new SerialTransactionExecutor({
+  client,
+  signer: keypair,
+  defaultGasBudget: 50_000_000n, // default
+});
+```
+
+### Execute transactions
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+tx.moveCall({ target: '0x...::module::function', arguments: [...] });
+
+const result = await executor.executeTransaction(tx);
+```
+
+Queue multiple transactions without awaiting each one:
+
+```typescript
+const results = await Promise.all([
+  executor.executeTransaction(tx1),
+  executor.executeTransaction(tx2),
+  executor.executeTransaction(tx3),
+]);
+```
+
+The executor queues them internally and executes them in order.
+
+### Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `client` | required | `SuiGrpcClient` or `SuiGraphQLClient` |
+| `signer` | required | Keypair or any Signer |
+| `defaultGasBudget` | `50_000_000n` | Gas budget per transaction |
+
+---
+
+## ParallelTransactionExecutor (experimental)
+
+For concurrent execution from a single address (high-throughput pipelines, batch operations).
+
+### How it works
+
+1. Automatically maintains and refills a pool of gas coins.
+2. Detects which objects each transaction uses and schedules transactions to avoid conflicts between transactions using the same object IDs.
+3. Transactions that touch different objects execute in parallel.
+
+### Setup
+
+```typescript
+import { ParallelTransactionExecutor } from '@mysten/sui/transactions';
+
+const executor = new ParallelTransactionExecutor({
+  client,
+  signer: keypair,
+  coinBatchSize: 20,        // Gas coins to create per batch
+  initialCoinBalance: 200_000_000n,  // Starting balance per gas coin
+  minimumCoinBalance: 50_000_000n,   // Refill threshold
+  maxPoolSize: 50,           // Maximum gas coins in pool
+});
+```
+
+### Execute transactions
+
+```typescript
+const result = await executor.executeTransaction(tx);
+```
+
+The executor handles gas coin selection, conflict detection, and scheduling automatically.
+
+### Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `client` | required | `SuiGrpcClient` or `SuiGraphQLClient` |
+| `signer` | required | Keypair or any Signer |
+| `coinBatchSize` | `20` | Number of gas coins created per batch |
+| `initialCoinBalance` | `200_000_000n` | Balance for each new gas coin |
+| `minimumCoinBalance` | `50_000_000n` | When a coin drops below this, it's refilled |
+| `maxPoolSize` | `50` | Maximum number of gas coins maintained |
+
+### Limitations
+
+- **Single executor per address.** Do not run multiple `ParallelTransactionExecutor` instances on the same address — they will conflict over gas coins.
+- **No external transactions.** While the executor is active, do not execute transactions from the same address outside the executor.
+- **Experimental.** The API may change in future releases.
+
+---
+
+## Best practices for both executors
+
+### Use unresolved object IDs
+
+Pass object IDs as strings rather than fully-specified `{ objectId, version, digest }` refs. This lets the executor use its internal object cache for the latest version and digest:
+
+```typescript
+// Good — executor resolves the latest version
+tx.object('0xABC...');
+
+// Avoid — pins to a specific version that may be stale
+tx.objectRef({ objectId: '0xABC...', version: '5', digest: '...' });
+```
+
+### Choose the right executor
+
+| Scenario | Executor |
+|----------|----------|
+| Wallet or single-user backend | `SerialTransactionExecutor` |
+| Batch processing (airdrops, migrations) | `ParallelTransactionExecutor` |
+| Multiple concurrent users from one hot wallet | `ParallelTransactionExecutor` |
+| Transactions that must execute in strict order | `SerialTransactionExecutor` |

--- a/sui-ts-sdk-backend/executors.md
+++ b/sui-ts-sdk-backend/executors.md
@@ -110,6 +110,7 @@ The executor handles gas coin selection, conflict detection, and scheduling auto
 | `initialCoinBalance` | `200_000_000n` | Balance for each new gas coin |
 | `minimumCoinBalance` | `50_000_000n` | When a coin drops below this, it's refilled |
 | `maxPoolSize` | `50` | Maximum number of gas coins maintained |
+| `gasMode` | `'coins'` | `'coins'` or `'addressBalance'`. Use `'addressBalance'` to pay gas from the address balance instead of coin objects — pairs well with address-balance sponsorship. |
 
 ### Limitations
 

--- a/sui-ts-sdk-backend/publishing.md
+++ b/sui-ts-sdk-backend/publishing.md
@@ -61,12 +61,11 @@ if (result.$kind === 'FailedTransaction') {
   throw new Error(result.FailedTransaction.status.error?.message);
 }
 
-// The package ID is in the created objects
-const createdObjects = result.Transaction.effects.created;
-const publishedPackage = createdObjects?.find(
-  obj => obj.owner?.$kind === 'Immutable'
+// In v2, effects use changedObjects with outputState
+const publishedPackage = result.Transaction.effects.changedObjects.find(
+  (obj) => obj.outputState === 'PackageWrite'
 );
-const packageId = publishedPackage?.reference.objectId;
+const packageId = publishedPackage?.objectId;
 console.log('Published package:', packageId);
 ```
 

--- a/sui-ts-sdk-backend/publishing.md
+++ b/sui-ts-sdk-backend/publishing.md
@@ -61,11 +61,12 @@ if (result.$kind === 'FailedTransaction') {
   throw new Error(result.FailedTransaction.status.error?.message);
 }
 
-// In v2, effects use changedObjects with outputState
-const publishedPackage = result.Transaction.effects.changedObjects.find(
-  (obj) => obj.outputState === 'PackageWrite'
+// The package ID is in the created objects
+const createdObjects = result.Transaction.effects.created;
+const publishedPackage = createdObjects?.find(
+  obj => obj.owner?.$kind === 'Immutable'
 );
-const packageId = publishedPackage?.objectId;
+const packageId = publishedPackage?.reference.objectId;
 console.log('Published package:', packageId);
 ```
 

--- a/sui-ts-sdk-backend/publishing.md
+++ b/sui-ts-sdk-backend/publishing.md
@@ -1,0 +1,175 @@
+# Programmatic Package Publish and Upgrade
+
+> Source: [sdk.mystenlabs.com/sui/transactions/reference](https://sdk.mystenlabs.com/sui/transactions/reference)
+
+Publishing and upgrading Move packages from TypeScript without CLI.
+
+---
+
+## Prerequisites
+
+Publishing requires compiled Move bytecode (the `modules` bytes and `dependencies` list). There are two ways to get these:
+
+1. **Build locally with CLI, publish from SDK:** Run `sui move build` to produce bytecode in `build/`, then load the bytes in TypeScript and construct the Publish PTB.
+2. **Use a build service or pre-compiled bytes:** If an agent cannot run CLI at all, it needs pre-compiled module bytes provided by another service or stored as artifacts.
+
+The TypeScript SDK does not include a Move compiler. The `sui move build` step must happen somewhere — either locally, in CI, or via a build service.
+
+---
+
+## Publishing a package
+
+### Step 1: Load compiled modules and dependencies
+
+After `sui move build`, the compiled modules are in `build/<package_name>/bytecode_modules/`. Dependencies are package ID strings (e.g., `'0x1'`, `'0x2'`), not filesystem paths.
+
+```typescript
+import { readFileSync, readdirSync } from 'fs';
+import { Transaction } from '@mysten/sui/transactions';
+
+// Load compiled module bytes
+const modulesDir = './build/my_package/bytecode_modules';
+const modules = readdirSync(modulesDir)
+  .filter(f => f.endsWith('.mv'))
+  .map(f => Array.from(readFileSync(`${modulesDir}/${f}`)));
+
+// Dependencies: array of package IDs this package depends on
+// At minimum, include the Sui framework: '0x1' and '0x2'
+const dependencies = ['0x1', '0x2'];
+```
+
+### Step 2: Construct and execute the Publish transaction
+
+```typescript
+const tx = new Transaction();
+
+const [upgradeCap] = tx.publish({ modules, dependencies });
+
+// Transfer the UpgradeCap to the publisher
+tx.transferObjects([upgradeCap], keypair.toSuiAddress());
+
+const result = await keypair.signAndExecuteTransaction({
+  transaction: tx,
+  client,
+});
+```
+
+### Step 3: Extract the package ID from results
+
+```typescript
+if (result.$kind === 'FailedTransaction') {
+  throw new Error(result.FailedTransaction.status.error?.message);
+}
+
+// The package ID is in the created objects
+const createdObjects = result.Transaction.effects.created;
+const publishedPackage = createdObjects?.find(
+  obj => obj.owner?.$kind === 'Immutable'
+);
+const packageId = publishedPackage?.reference.objectId;
+console.log('Published package:', packageId);
+```
+
+---
+
+## Upgrading a package
+
+### Step 1: Fetch the UpgradeCap
+
+```typescript
+const upgradeCapId = '0x...'; // The UpgradeCap object ID from the original publish
+
+const upgradeCapObject = await client.getObject({
+  id: upgradeCapId,
+  options: { showContent: true },
+});
+```
+
+### Step 2: Construct the Upgrade transaction
+
+```typescript
+const tx = new Transaction();
+
+// Load new compiled modules
+const newModules = readdirSync(newModulesDir)
+  .filter(f => f.endsWith('.mv'))
+  .map(f => Array.from(readFileSync(`${newModulesDir}/${f}`)));
+
+const ticket = tx.moveCall({
+  target: '0x2::package::authorize_upgrade',
+  arguments: [
+    tx.object(upgradeCapId),
+    tx.pure.u8(0), // upgrade policy: 0 = Compatible
+    tx.pure('vector<u8>', [/* digest bytes */]),
+  ],
+});
+
+const receipt = tx.upgrade({
+  modules: newModules,
+  dependencies: ['0x1', '0x2'],
+  package: originalPackageId,
+  ticket,
+});
+
+tx.moveCall({
+  target: '0x2::package::commit_upgrade',
+  arguments: [tx.object(upgradeCapId), receipt],
+});
+
+const result = await keypair.signAndExecuteTransaction({
+  transaction: tx,
+  client,
+});
+```
+
+### Upgrade policies
+
+| Policy | Value | Effect |
+|--------|-------|--------|
+| Compatible | 0 | Can add functions, change implementations. Cannot remove public functions or change signatures. |
+| Additive | 128 | Can only add new modules/functions. Cannot modify existing code. |
+| Dependency-only | 192 | Can only change dependencies. |
+| Immutable | — | Call `0x2::package::make_immutable` on UpgradeCap to prevent all future upgrades. |
+
+---
+
+## Dry-run before publishing
+
+Use `simulateTransaction` to simulate a transaction without executing it:
+
+```typescript
+tx.setSender(keypair.toSuiAddress());
+const dryRunResult = await client.simulateTransaction({
+  transaction: tx,
+  include: { effects: true },
+});
+
+if (dryRunResult.$kind === 'FailedTransaction') {
+  console.error('Dry run failed:', dryRunResult.FailedTransaction.status.error?.message);
+}
+```
+
+---
+
+## Multi-network deployment pattern
+
+For deploying the same package to multiple networks:
+
+```typescript
+const networks = ['devnet', 'testnet'] as const;
+
+for (const network of networks) {
+  const client = new SuiGrpcClient({ network });
+  const tx = new Transaction();
+  const [upgradeCap] = tx.publish({ modules, dependencies });
+  tx.transferObjects([upgradeCap], keypair.toSuiAddress());
+
+  const result = await keypair.signAndExecuteTransaction({
+    transaction: tx,
+    client,
+  });
+
+  await client.waitForTransaction({ result });
+  console.log(`Published on ${network}:`, result.Transaction?.digest);
+}
+```

--- a/sui-ts-sdk-backend/signing.md
+++ b/sui-ts-sdk-backend/signing.md
@@ -174,7 +174,7 @@ const combinedSignature = multiSigPublicKey.combinePartialSignatures([
 // Execute
 const result = await client.executeTransaction({
   transaction: txBytes,
-  signatures: combinedSignature,
+  signatures: [combinedSignature],
 });
 ```
 
@@ -186,10 +186,9 @@ Wraps a subset of keypairs into a single signer that handles combination automat
 // Create a signer from one keypair (if its weight alone meets threshold)
 const signer = multiSigPublicKey.getSigner(kp3); // weight 2 meets threshold 2
 
-// Or create a signer and provide multiple keypairs for collective signing
-// You can provide a subset of signers so long as their combined weight
-// meets or exceeds the threshold
-const signer2 = multiSigPublicKey.getSigner(kp1);
+// Or provide multiple keypairs whose combined weight meets threshold
+// getSigner takes rest params (...signers)
+const signer2 = multiSigPublicKey.getSigner(kp1, kp2); // weight 1+1=2 meets threshold
 // Use like any other signer
 const result = await signer.signAndExecuteTransaction({
   transaction: tx,
@@ -204,8 +203,7 @@ You can provide any subset of signers, as long as their combined weight meets th
 Combine traditional keypairs with zkLogin public identifiers for recovery:
 
 ```typescript
-import { toZkLoginPublicIdentifier, genAddressSeed } from '@mysten/sui/zklogin';
-import { decodeJwt } from 'jose';
+import { toZkLoginPublicIdentifier, genAddressSeed, decodeJwt } from '@mysten/sui/zklogin';
 
 const kp1 = new Ed25519Keypair();
 const decodedJwt = decodeJwt(jwtToken);

--- a/sui-ts-sdk-backend/signing.md
+++ b/sui-ts-sdk-backend/signing.md
@@ -1,0 +1,272 @@
+# Cloud KMS and Multisig
+
+> Source: [sdk.mystenlabs.com/sui/cryptography/signers](https://sdk.mystenlabs.com/sui/cryptography/signers)
+
+Production backends should use cloud KMS signers instead of storing raw private keys. For shared custody, use multisig.
+
+---
+
+## The Signer interface
+
+All signers — keypairs, KMS, multisig — implement the same `Signer` interface:
+
+```typescript
+signer.getPublicKey()           // Returns PublicKey
+signer.toSuiAddress()           // Returns Sui address string
+signer.signPersonalMessage(msg) // Returns { signature }
+signer.signTransaction(bytes)   // Returns { signature }
+signer.signAndExecuteTransaction({ transaction, client }) // Build, sign, execute
+```
+
+Because every signer extends the same base class, they are interchangeable. Code that works with a keypair works identically with a KMS signer or multisig signer.
+
+---
+
+## AWS KMS Signer
+
+### Install
+
+```bash
+npm install @mysten/aws-kms-signer
+```
+
+### Supported key types
+
+- Ed25519
+- Secp256k1 (`ECC_SECG_P256K1`)
+- Secp256r1 (`ECC_NIST_P256`)
+
+### Setup
+
+```typescript
+import { AwsKmsSigner } from '@mysten/aws-kms-signer';
+
+const signer = await AwsKmsSigner.fromKeyId(AWS_KMS_KEY_ID, {
+  region: AWS_REGION,
+  accessKeyId: AWS_ACCESS_KEY_ID,
+  secretAccessKey: AWS_SECRET_ACCESS_KEY,
+});
+
+const address = signer.getPublicKey().toSuiAddress();
+```
+
+### Sign and execute
+
+```typescript
+const result = await client.signAndExecuteTransaction({
+  transaction: tx,
+  signer,
+});
+```
+
+The signer is passed to the client method. All signers work interchangeably with this pattern.
+
+---
+
+## GCP KMS Signer
+
+### Install
+
+```bash
+npm install @mysten/gcp-kms-signer
+```
+
+### Supported key types
+
+- Secp256k1 (`EC_SIGN_SECP256K1_SHA256`)
+- Secp256r1 (`EC_SIGN_P256_SHA256`)
+
+### Setup
+
+```typescript
+import { GcpKmsSigner } from '@mysten/gcp-kms-signer';
+
+const signer = await GcpKmsSigner.fromOptions({
+  projectId: 'your-google-project-id',
+  location: 'your-google-location',
+  keyRing: 'your-google-keyring',
+  cryptoKey: 'your-google-key-name',
+  cryptoKeyVersion: 'your-google-key-version',
+});
+
+const address = signer.getPublicKey().toSuiAddress();
+```
+
+### Sign and execute
+
+```typescript
+const result = await client.signAndExecuteTransaction({
+  transaction: tx,
+  signer,
+});
+```
+
+---
+
+## When to use KMS vs keypair
+
+| | Raw Keypair | AWS/GCP KMS |
+|--|------------|-------------|
+| Key storage | In-memory / env var | Cloud HSM |
+| Key extraction | Private key is accessible | Private key never leaves KMS |
+| Signing speed | Fastest | Network round-trip per sign |
+| Audit trail | None | Cloud audit logs |
+| Use case | Development, testing | Production backends |
+
+---
+
+## Multisig
+
+Multisig allows multiple signers to collectively authorize transactions when their combined signature weight meets a threshold.
+
+### Install
+
+Multisig is built into `@mysten/sui`:
+
+```typescript
+import { MultiSigPublicKey } from '@mysten/sui/multisig';
+```
+
+### Setup: define threshold and weights
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { MultiSigPublicKey } from '@mysten/sui/multisig';
+
+const kp1 = new Ed25519Keypair();
+const kp2 = new Ed25519Keypair();
+const kp3 = new Ed25519Keypair();
+
+const multiSigPublicKey = MultiSigPublicKey.fromPublicKeys({
+  threshold: 2,
+  publicKeys: [
+    { publicKey: kp1.getPublicKey(), weight: 1 },
+    { publicKey: kp2.getPublicKey(), weight: 1 },
+    { publicKey: kp3.getPublicKey(), weight: 2 },
+  ],
+});
+
+const multisigAddress = multiSigPublicKey.toSuiAddress();
+```
+
+In this configuration:
+- `kp1` alone (weight 1) cannot sign — below threshold of 2
+- `kp1 + kp2` (weight 1+1=2) can sign — meets threshold
+- `kp3` alone (weight 2) can sign — meets threshold
+
+Maximum 10 accounts per multisig configuration.
+
+### Option A: Manual signature combination
+
+Collect individual signatures from each participant, then combine:
+
+```typescript
+// Each participant signs independently
+const { signature: sig1 } = await kp1.signTransaction(txBytes);
+const { signature: sig2 } = await kp2.signTransaction(txBytes);
+
+// Combine (only need enough weight to meet threshold)
+const combinedSignature = multiSigPublicKey.combinePartialSignatures([
+  sig1,
+  sig2,
+]);
+
+// Execute
+const result = await client.executeTransaction({
+  transaction: txBytes,
+  signatures: combinedSignature,
+});
+```
+
+### Option B: MultiSigSigner (recommended)
+
+Wraps a subset of keypairs into a single signer that handles combination automatically:
+
+```typescript
+// Create a signer from one keypair (if its weight alone meets threshold)
+const signer = multiSigPublicKey.getSigner(kp3); // weight 2 meets threshold 2
+
+// Or create a signer and provide multiple keypairs for collective signing
+// You can provide a subset of signers so long as their combined weight
+// meets or exceeds the threshold
+const signer2 = multiSigPublicKey.getSigner(kp1);
+// Use like any other signer
+const result = await signer.signAndExecuteTransaction({
+  transaction: tx,
+  client,
+});
+```
+
+You can provide any subset of signers, as long as their combined weight meets the threshold.
+
+### Hybrid multisig: keypairs + zkLogin
+
+Combine traditional keypairs with zkLogin public identifiers for recovery:
+
+```typescript
+import { toZkLoginPublicIdentifier, genAddressSeed } from '@mysten/sui/zklogin';
+import { decodeJwt } from 'jose';
+
+const kp1 = new Ed25519Keypair();
+const decodedJwt = decodeJwt(jwtToken);
+const userSalt = BigInt('123');
+const addressSeed = genAddressSeed(
+  userSalt,
+  'sub',
+  decodedJwt.sub!,
+  decodedJwt.aud as string,
+).toString();
+
+const pkZklogin = toZkLoginPublicIdentifier(addressSeed, decodedJwt.iss!);
+
+const multiSigPublicKey = MultiSigPublicKey.fromPublicKeys({
+  threshold: 1,
+  publicKeys: [
+    { publicKey: kp1.getPublicKey(), weight: 1 },
+    { publicKey: pkZklogin, weight: 1 },
+  ],
+});
+```
+
+This provides backup access to a zkLogin account through a traditional private key.
+
+### Hybrid multisig: keypairs + passkeys
+
+```typescript
+import { PasskeyKeypair, BrowserPasskeyProvider } from '@mysten/sui/keypairs/passkey';
+
+const passkeyKeypair = await PasskeyKeypair.getPasskeyInstance(
+  new BrowserPasskeyProvider('My App', { /* options */ }),
+);
+
+const multiSigPublicKey = MultiSigPublicKey.fromPublicKeys({
+  threshold: 1,
+  publicKeys: [
+    { publicKey: kp1.getPublicKey(), weight: 1 },
+    { publicKey: passkeyKeypair.getPublicKey(), weight: 1 },
+  ],
+});
+```
+
+### Multisig with KMS signers
+
+KMS signers implement the same `Signer` interface, so they work with `MultiSigSigner`:
+
+```typescript
+const kmsSigner = await AwsKmsSigner.fromKeyId('arn:aws:kms:...');
+const localKeypair = new Ed25519Keypair();
+
+const multiSigPublicKey = MultiSigPublicKey.fromPublicKeys({
+  threshold: 2,
+  publicKeys: [
+    { publicKey: kmsSigner.getPublicKey(), weight: 1 },
+    { publicKey: localKeypair.getPublicKey(), weight: 1 },
+  ],
+});
+
+// Both sign
+const { signature: kmsSig } = await kmsSigner.signTransaction(txBytes);
+const { signature: localSig } = await localKeypair.signTransaction(txBytes);
+
+const combined = multiSigPublicKey.combinePartialSignatures([kmsSig, localSig]);
+```

--- a/sui-ts-sdk-backend/sponsorship.md
+++ b/sui-ts-sdk-backend/sponsorship.md
@@ -64,19 +64,20 @@ const { signature: userSignature } = await userKeypair.signTransaction(bytes);
 
 ```typescript
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { createSponsor, defaults, gasBudget } from '@mysten-incubation/sponsor';
 
 const sponsorKeypair = Ed25519Keypair.fromSecretKey(process.env.SPONSOR_KEY!);
 
-// Validate the transaction (check target, amounts, etc.)
-// ...
+const sponsor = createSponsor({
+  signer: sponsorKeypair,
+  client,
+  validate: [defaults(), gasBudget({ max: 50_000_000n })],
+});
 
-// Co-sign
-const { signature: sponsorSignature } = await sponsorKeypair.signTransaction(bytes);
-
-// Execute with both signatures
-const result = await client.executeTransaction({
+// Validate, co-sign, and execute in one call
+const result = await sponsor.signAndExecuteTransaction({
   transaction: bytes,
-  signatures: [userSignature, sponsorSignature],
+  userSignature,
 });
 ```
 
@@ -158,15 +159,18 @@ Backend receives one of three outcomes:
 | `FailedTransaction` | Executed on-chain but Move call aborted; sponsor still pays gas | Log failure, return error |
 | `Transaction` | Successful execution | Return digest to user |
 
-Always check:
+Always check using `$kind`:
 
 ```typescript
-if (result.$kind === 'Rejected') {
-  // Never executed
-} else if (result.$kind === 'FailedTransaction') {
-  // Executed but failed — gas was consumed
-} else {
-  // Success
-  console.log('Digest:', result.Transaction.digest);
+switch (result.$kind) {
+  case 'Rejected':
+    // Never executed on-chain
+    throw new Error(result.issues.map((i) => i.message).join('; '));
+  case 'FailedTransaction':
+    // Executed but aborted — sponsor still paid gas
+    throw new Error(`Aborted: ${result.FailedTransaction.digest}`);
+  case 'Transaction':
+    // Success
+    console.log('Digest:', result.Transaction.digest);
 }
 ```

--- a/sui-ts-sdk-backend/sponsorship.md
+++ b/sui-ts-sdk-backend/sponsorship.md
@@ -71,7 +71,12 @@ const sponsorKeypair = Ed25519Keypair.fromSecretKey(process.env.SPONSOR_KEY!);
 const sponsor = createSponsor({
   signer: sponsorKeypair,
   client,
-  validate: [defaults(), gasBudget({ max: 50_000_000n })],
+  validate: [
+    defaults(),
+    gasBudget({ max: 50_000_000n }),
+    allowedFunctions(['0xYourPkg::module::allowed_fn']),
+    // Add application-specific validators as needed
+  ],
 });
 
 // Validate, co-sign, and execute in one call
@@ -80,6 +85,42 @@ const result = await sponsor.signAndExecuteTransaction({
   userSignature,
 });
 ```
+
+---
+
+## Sponsor security: validation is not optional
+
+`defaults()` and `gasBudget()` alone still permit arbitrary Move calls — an attacker could drain sponsor funds through gas. **Always layer application-specific validators:**
+
+- **Authentication:** Verify the user's identity before co-signing (JWT, session token, API key).
+- **Rate limits / quotas:** Cap transactions per user per time window.
+- **Function allowlists:** Use `allowedFunctions([...])` to restrict which Move functions the sponsor will co-sign. Only allow your application's entry points.
+- **Recipient allowlists:** Restrict `TransferObjects` targets to known addresses.
+- **Amount caps:** Limit the value that can be transferred per transaction.
+
+```typescript
+import { createSponsor, defaults, gasBudget, allowedFunctions } from '@mysten-incubation/sponsor';
+
+const sponsor = createSponsor({
+  signer: sponsorKeypair,
+  client,
+  validate: [
+    defaults(),
+    gasBudget({ max: 50_000_000n }),
+    allowedFunctions([
+      '0xYourPkg::game::play',
+      '0xYourPkg::game::claim_reward',
+    ]),
+    // Custom validator for authentication + rate limiting
+    async (tx) => {
+      // Verify user identity and enforce quotas here
+      // Return { ok: false, issues: [...] } to reject
+    },
+  ],
+});
+```
+
+Without application-specific validation, your sponsor is an open gas faucet.
 
 ---
 
@@ -138,17 +179,33 @@ tx.transferObjects([coin], recipient);
 
 ### When the sponsor is paying for everything
 
-If the sponsor is both paying gas and funding the transfer (e.g., an airdrop), `tx.splitCoins(tx.gas, ...)` works because `tx.gas` belongs to the sponsor:
+If the sponsor is both paying gas and funding the transfer (e.g., an airdrop), `tx.splitCoins(tx.gas, ...)` works at the protocol level because `tx.gas` belongs to the sponsor. However, the `defaults()` validator includes `gasCoinNotUsed()`, which **rejects** transactions that consume the gas coin. To allow this pattern, use a custom policy without `gasCoinNotUsed()`:
 
 ```typescript
+import { createSponsor, gasBudget, allowedFunctions } from '@mysten-incubation/sponsor';
+
+// Custom policy that permits gas coin usage (for sponsor-funded airdrops)
+const sponsor = createSponsor({
+  signer: sponsorKeypair,
+  client,
+  validate: [
+    gasBudget({ max: 50_000_000n }),
+    allowedFunctions(['0xYourPkg::airdrop::claim']),
+    // Omit defaults() — it includes gasCoinNotUsed() which would reject this
+  ],
+});
+```
+
+```typescript
+// Transaction that splits from sponsor's gas coin
 const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
 tx.transferObjects([coin], recipient);
 ```
 
 ### Rule of thumb
 
-- `tx.gas` / `tx.splitCoins(tx.gas, ...)` — uses the gas owner's funds (the sponsor)
-- `tx.coin({ useGasCoin: false })` — uses the sender's funds
+- `tx.gas` / `tx.splitCoins(tx.gas, ...)` — uses the gas owner's funds (the sponsor). Rejected by `defaults()` unless you build a custom policy.
+- `tx.coin({ useGasCoin: false })` — uses the sender's funds. Works with `defaults()`.
 
 ---
 

--- a/sui-ts-sdk-backend/sponsorship.md
+++ b/sui-ts-sdk-backend/sponsorship.md
@@ -123,16 +123,32 @@ const { signature: sponsorSig } = await sponsorKeypair.signTransaction(fullBytes
 
 ---
 
-## Important: `useGasCoin: false`
+## Gas coin ownership in sponsored transactions
 
-When the sender is transferring tokens in a sponsored transaction, set `useGasCoin: false` on coin access calls:
+When `setGasPayment([])` is used, the protocol materializes a synthetic GasCoin from the **gas owner's** (sponsor's) address balance. `tx.gas` references this synthetic coin — it belongs to the sponsor, not the sender.
+
+### When the sender needs to transfer their own tokens
+
+Use `tx.coin()` with `useGasCoin: false` to source from the sender's balance instead of the sponsor's gas coin:
 
 ```typescript
 const coin = tx.coin({ balance: 1_000_000_000n, useGasCoin: false });
 tx.transferObjects([coin], recipient);
 ```
 
-This prevents the SDK from attempting to split the sponsor's gas coin for the sender's transfer.
+### When the sponsor is paying for everything
+
+If the sponsor is both paying gas and funding the transfer (e.g., an airdrop), `tx.splitCoins(tx.gas, ...)` works because `tx.gas` belongs to the sponsor:
+
+```typescript
+const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
+tx.transferObjects([coin], recipient);
+```
+
+### Rule of thumb
+
+- `tx.gas` / `tx.splitCoins(tx.gas, ...)` — uses the gas owner's funds (the sponsor)
+- `tx.coin({ useGasCoin: false })` — uses the sender's funds
 
 ---
 

--- a/sui-ts-sdk-backend/sponsorship.md
+++ b/sui-ts-sdk-backend/sponsorship.md
@@ -1,0 +1,172 @@
+# Sponsored Transactions
+
+> Source: [sdk.mystenlabs.com/sponsor](https://sdk.mystenlabs.com/sponsor/basic-usage)
+
+Sponsored transactions let a backend pay gas on behalf of users. The `@mysten-incubation/sponsor` package provides the recommended flow.
+
+---
+
+## Install
+
+```bash
+npm install @mysten-incubation/sponsor @mysten/sui
+```
+
+---
+
+## Recommended flow: client-builds, backend co-signs
+
+The recommended pattern is that the **client builds the full transaction bytes** and the **backend validates, co-signs, and executes**.
+
+### Why client-builds is preferred
+
+The sponsor sees the exact bytes it is co-signing before committing. This prevents the sponsor from unknowingly signing malicious transactions.
+
+> "Prefer services that expect already-built bytes plus the user's signature."
+
+### Flow
+
+```
+1. Client fetches sponsor address from backend /config endpoint
+2. Client builds transaction with sponsor as gas owner (empty gas payment)
+3. User signs the transaction bytes
+4. Client sends bytes + user signature to backend
+5. Backend validates, co-signs, and executes
+6. Backend returns result to client
+```
+
+---
+
+## Address-balance sponsorship (simpler)
+
+The sender can sign before the sponsor, enabling simpler async flows.
+
+### Client side
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+tx.moveCall({ target: '0x...::module::function', arguments: [...] });
+
+// Set empty gas payment to signal address-balance sponsorship
+tx.setGasPayment([]);
+tx.setSender(userAddress);
+tx.setGasOwner(sponsorAddress); // from /config endpoint
+
+const bytes = await tx.build({ client });
+const { signature: userSignature } = await userKeypair.signTransaction(bytes);
+
+// Send bytes + userSignature to backend
+```
+
+### Backend side
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+
+const sponsorKeypair = Ed25519Keypair.fromSecretKey(process.env.SPONSOR_KEY!);
+
+// Validate the transaction (check target, amounts, etc.)
+// ...
+
+// Co-sign
+const { signature: sponsorSignature } = await sponsorKeypair.signTransaction(bytes);
+
+// Execute with both signatures
+const result = await client.executeTransaction({
+  transaction: bytes,
+  signatures: [userSignature, sponsorSignature],
+});
+```
+
+---
+
+## Coin-based sponsorship
+
+When address balances are not used, the sponsor provides specific coin objects for gas:
+
+### Flow
+
+```
+1. User builds transaction kind bytes (no gas info)
+2. Sponsor wraps with gas coin objects and gas owner address
+3. Both parties sign the full transaction bytes
+4. Either party executes with both signatures
+```
+
+```typescript
+// User side: build kind-only
+const tx = new Transaction();
+tx.moveCall({ target: '0x...::module::function', arguments: [...] });
+
+const kindBytes = await tx.build({ client, onlyTransactionKind: true });
+
+// Send kindBytes to sponsor
+```
+
+```typescript
+// Sponsor side: wrap with gas info
+const sponsoredTx = Transaction.fromKind(kindBytes);
+sponsoredTx.setSender(userAddress);
+sponsoredTx.setGasOwner(sponsorKeypair.toSuiAddress());
+sponsoredTx.setGasPayment([gasCoinsFromSponsor]);
+sponsoredTx.setGasBudget(50_000_000n);
+sponsoredTx.setGasPrice(1000n);
+
+const fullBytes = await sponsoredTx.build({ client });
+const { signature: sponsorSig } = await sponsorKeypair.signTransaction(fullBytes);
+
+// Return fullBytes + sponsorSig to user for their signature
+```
+
+---
+
+## Important: `useGasCoin: false`
+
+When the sender is transferring tokens in a sponsored transaction, set `useGasCoin: false` on coin access calls:
+
+```typescript
+const coin = tx.coin({ balance: 1_000_000_000n, useGasCoin: false });
+tx.transferObjects([coin], recipient);
+```
+
+This prevents the SDK from attempting to split the sponsor's gas coin for the sender's transfer.
+
+---
+
+## Config endpoint pattern
+
+Backends should expose a `/config` endpoint returning the current sponsor address. This allows dynamic sponsor address rotation without client redeployment:
+
+```typescript
+// Backend
+app.get('/config', (req, res) => {
+  res.json({ sponsorAddress: sponsorKeypair.toSuiAddress() });
+});
+```
+
+---
+
+## Result handling
+
+Backend receives one of three outcomes:
+
+| Result | Meaning | Action |
+|--------|---------|--------|
+| `Rejected` | Policy validation failed; transaction was never executed or signed | Return error to user |
+| `FailedTransaction` | Executed on-chain but Move call aborted; sponsor still pays gas | Log failure, return error |
+| `Transaction` | Successful execution | Return digest to user |
+
+Always check:
+
+```typescript
+if (result.$kind === 'Rejected') {
+  // Never executed
+} else if (result.$kind === 'FailedTransaction') {
+  // Executed but failed — gas was consumed
+} else {
+  // Success
+  console.log('Digest:', result.Transaction.digest);
+}
+```

--- a/sui-ts-sdk-backend/sponsorship.md
+++ b/sui-ts-sdk-backend/sponsorship.md
@@ -170,11 +170,17 @@ When `setGasPayment([])` is used, the protocol materializes a synthetic GasCoin 
 
 ### When the sender needs to transfer their own tokens
 
-Use `tx.coin()` with `useGasCoin: false` to source from the sender's balance instead of the sponsor's gas coin:
+Use `balance::send_funds` with `useGasCoin: false` to source from the sender's balance and deposit into the recipient's address balance:
 
 ```typescript
-const coin = tx.coin({ balance: 1_000_000_000n, useGasCoin: false });
-tx.transferObjects([coin], recipient);
+tx.moveCall({
+  target: '0x2::balance::send_funds',
+  typeArguments: ['0x2::sui::SUI'],
+  arguments: [
+    tx.balance({ balance: 1_000_000_000n, useGasCoin: false }),
+    tx.pure.address(recipient),
+  ],
+});
 ```
 
 ### When the sponsor is paying for everything
@@ -197,15 +203,19 @@ const sponsor = createSponsor({
 ```
 
 ```typescript
-// Transaction that splits from sponsor's gas coin
-const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
-tx.transferObjects([coin], recipient);
+// Transaction that sends from sponsor's gas coin via balance transfer
+tx.moveCall({
+  target: '0x2::balance::send_funds',
+  typeArguments: ['0x2::sui::SUI'],
+  arguments: [tx.balance({ balance: 1_000_000_000n }), tx.pure.address(recipient)],
+});
 ```
 
 ### Rule of thumb
 
-- `tx.gas` / `tx.splitCoins(tx.gas, ...)` — uses the gas owner's funds (the sponsor). Rejected by `defaults()` unless you build a custom policy.
-- `tx.coin({ useGasCoin: false })` — uses the sender's funds. Works with `defaults()`.
+- `tx.balance()` / `tx.coin()` (default `useGasCoin: true`) — sources from the gas owner's (sponsor's) funds. Rejected by `defaults()` unless you build a custom policy that omits `gasCoinNotUsed()`.
+- `tx.balance({ useGasCoin: false })` / `tx.coin({ useGasCoin: false })` — sources from the sender's funds. Works with `defaults()`.
+- For transfers, prefer `balance::send_funds` over `transferObjects` — it deposits into the recipient's address balance.
 
 ---
 

--- a/sui-ts-sdk-backend/transactions.md
+++ b/sui-ts-sdk-backend/transactions.md
@@ -1,0 +1,225 @@
+# Building, Coins, and Execution
+
+> Source: [sdk.mystenlabs.com/sui/transactions](https://sdk.mystenlabs.com/sui/transactions/basics)
+
+---
+
+## Coin access: `tx.coin()` and `tx.balance()`
+
+These are the recommended way to access funds in a transaction. They automatically resolve from both address balances and coin objects.
+
+### `tx.coin()` — produces a `Coin<T>`
+
+Use for transfers, Move functions that accept `Coin<T>`, and standard coin operations.
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+
+// Get 1 SUI (in MIST — 1 SUI = 1_000_000_000 MIST)
+const coin = tx.coin({ balance: 1_000_000_000n });
+
+// Get a specific coin type
+const usdcCoin = tx.coin({
+  balance: 1_000_000n,
+  type: '0x...::usdc::USDC',
+});
+
+// Transfer it
+tx.transferObjects([coin], '0xRecipientAddress');
+```
+
+### `tx.balance()` — produces a `Balance<T>`
+
+Use for Move functions that accept `Balance<T>` directly.
+
+```typescript
+const bal = tx.balance({ balance: 500_000_000n });
+// Pass to a Move function expecting Balance<SUI>
+tx.moveCall({
+  target: '0x...::my_module::deposit',
+  arguments: [someObject, bal],
+});
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `balance` | `bigint \| number` | required | Amount in base units |
+| `type` | `string` | `'0x2::sui::SUI'` | Coin type |
+| `useGasCoin` | `boolean` | `true` | Set `false` for sponsored transactions |
+
+### How resolution works at build time
+
+1. If the address balance alone is sufficient, the SDK uses a direct withdrawal (no versioned object inputs needed).
+2. Otherwise, it fetches coin objects and address balance in parallel, then merges and splits as needed.
+3. A zero-balance request resolves to `balance::zero` with no network lookups.
+
+---
+
+## Address balances vs coin objects
+
+Sui has two ways of holding fungible tokens:
+
+| | Coin Objects | Address Balances |
+|--|-------------|-----------------|
+| Structure | Individual on-chain objects with unique ID, version, and balance | Accumulator per address per coin type |
+| Concurrency | Each coin is a versioned object — using it requires the exact version | No versions — concurrent transactions from the same address work |
+| Management | Must manually split/merge | Deposits automatically merge |
+
+An address's total balance = sum of coin object balances + address balance.
+
+### Query balance
+
+```typescript
+const { balance } = await client.getBalance({ owner: address });
+// balance contains: balance (total), coinBalance, addressBalance (as strings)
+const total = BigInt(balance.balance);
+```
+
+### List individual coin objects
+
+```typescript
+const { objects } = await client.listCoins({
+  owner: address,
+});
+```
+
+---
+
+## Manual coin operations
+
+When you need explicit control over coin objects:
+
+### Split coins
+
+```typescript
+const [coin1, coin2] = tx.splitCoins('0xMyCoinId', [1_000_000n, 2_000_000n]);
+```
+
+### Merge coins
+
+```typescript
+tx.mergeCoins('0xCoin1', ['0xCoin2', '0xCoin3']);
+```
+
+### Deposit into address balance
+
+```typescript
+tx.moveCall({
+  target: '0x2::coin::send_funds',
+  arguments: [tx.object('0xMyCoinObjectId'), tx.pure.address('0xRecipientAddress')],
+  typeArguments: ['0x2::sui::SUI'],
+});
+```
+
+### Withdraw from address balance
+
+Use `tx.withdrawal()` to create a withdrawal input, then redeem via Move:
+
+```typescript
+const withdrawal = tx.withdrawal({ amount: 1_000_000_000n });
+tx.moveCall({
+  target: '0x2::coin::redeem_funds',
+  arguments: [withdrawal],
+  typeArguments: ['0x2::sui::SUI'],
+});
+```
+
+---
+
+## Signing and executing from a backend
+
+### Direct sign and execute (simplest)
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Transaction } from '@mysten/sui/transactions';
+
+const keypair = Ed25519Keypair.fromSecretKey('suiprivkey1...');
+const client = new SuiGrpcClient({ network: 'testnet' });
+
+const tx = new Transaction();
+tx.transferObjects(
+  [tx.coin({ balance: 1_000_000_000n })],
+  '0xRecipient',
+);
+
+const result = await keypair.signAndExecuteTransaction({
+  transaction: tx,
+  client,
+});
+```
+
+This automatically sets the sender to the keypair's address, builds the transaction, signs it, and executes it. Results include transaction data and effects by default.
+
+### Separate sign then execute
+
+Use when you need to inspect bytes before execution, or for multi-party signing:
+
+```typescript
+tx.setSender(keypair.toSuiAddress());
+const bytes = await tx.build({ client });
+const { signature } = await keypair.signTransaction(bytes);
+
+// Execute later
+const result = await client.executeTransaction({
+  transaction: bytes,
+  signatures: [signature],
+});
+```
+
+---
+
+## Result handling
+
+Transaction results are discriminated unions. Always check the outcome:
+
+```typescript
+if (result.$kind === 'FailedTransaction') {
+  // Executed on-chain but Move call aborted. Gas was still consumed.
+  console.error('Failed:', result.FailedTransaction.status.error?.message);
+} else {
+  // Success
+  console.log('Digest:', result.Transaction.digest);
+}
+```
+
+Always check for `FailedTransaction` — a successful execution does not mean the Move call succeeded.
+
+---
+
+## Waiting for indexing
+
+After a transaction executes, read APIs may not immediately reflect the effects. Always wait before dependent reads:
+
+```typescript
+await client.waitForTransaction({ result });
+
+// Now safe to read updated state
+const { balance } = await client.getBalance({ owner: address });
+```
+
+---
+
+## Gasless stablecoin transfers
+
+Qualified stablecoin transfers can execute with zero gas using `0x2::balance::send_funds`:
+
+```typescript
+const tx = new Transaction();
+tx.moveCall({
+  target: '0x2::balance::send_funds',
+  arguments: [tx.balance({ balance: 1_000_000n, type: USDC_TYPE }), tx.pure.address(recipient)],
+  typeArguments: [USDC_TYPE],
+});
+
+// gRPC/GraphQL transports automatically detect eligible transactions
+// and set gas price/budget to 0
+const result = await keypair.signAndExecuteTransaction({ transaction: tx, client });
+```
+
+The gRPC and GraphQL transports automatically detect and configure eligible gasless transactions. The sender does not need any SUI balance.

--- a/sui-ts-sdk-backend/transactions.md
+++ b/sui-ts-sdk-backend/transactions.md
@@ -28,12 +28,25 @@ import { Transaction } from '@mysten/sui/transactions';
 
 const tx = new Transaction();
 
-// Split SUI from gas coin — works offline, no network resolution needed
-const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
-tx.transferObjects([coin], '0xRecipientAddress');
+// Preferred: send SUI via balance transfer (deposits into recipient's address balance)
+tx.moveCall({
+  target: '0x2::balance::send_funds',
+  typeArguments: ['0x2::sui::SUI'],
+  arguments: [tx.balance({ balance: 1_000_000_000n }), tx.pure.address('0xRecipient')],
+});
 ```
 
-This is the simplest pattern for SUI transfers. It works with both traditional coin-object gas and address-balance gas (`setGasPayment([])`).
+Balance transfers via `send_funds` are preferred over `transferObjects` because they deposit directly into the recipient's address balance, avoiding versioned coin objects on the receiving side. This enables the recipient to spend concurrently without coin management.
+
+When you need the coin for Move call arguments before transferring, split from gas:
+
+```typescript
+// Split from gas, use in Move calls, then transfer
+const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
+tx.moveCall({ target: '0x...::module::use_coin', arguments: [coin] });
+// transferObjects is fine when the coin was used in prior commands
+tx.transferObjects([coin], '0xRecipient');
+```
 
 ### When to use `tx.gas` vs `tx.coin()`
 
@@ -44,7 +57,7 @@ This is the simplest pattern for SUI transfers. It works with both traditional c
 | Gas mode | Works with both coin-object and address-balance gas | Also works with both, but adds resolution overhead |
 | Use case | SUI transfers, Move calls needing SUI | Non-SUI tokens (USDC, custom coins) |
 
-**Prefer `tx.splitCoins(tx.gas, ...)` for SUI** — it's simpler, works offline, and avoids client-side balance resolution.
+**For SUI transfers**, prefer `balance::send_funds` — it deposits into the recipient's address balance and avoids versioned objects. **For SUI in Move calls**, prefer `tx.splitCoins(tx.gas, ...)` — it works offline with no network resolution.
 
 ---
 
@@ -55,11 +68,21 @@ Use these when you need tokens other than SUI. They automatically resolve from b
 ### `tx.coin()` — produces a `Coin<T>`
 
 ```typescript
+// Preferred: send non-SUI tokens via balance transfer
+tx.moveCall({
+  target: '0x2::balance::send_funds',
+  typeArguments: ['0x...::usdc::USDC'],
+  arguments: [
+    tx.balance({ balance: 1_000_000n, type: '0x...::usdc::USDC' }),
+    tx.pure.address('0xRecipientAddress'),
+  ],
+});
+
+// Alternative: get a Coin<T> for use in Move calls before transferring
 const usdcCoin = tx.coin({
   balance: 1_000_000n,
   type: '0x...::usdc::USDC',
 });
-tx.transferObjects([usdcCoin], '0xRecipientAddress');
 ```
 
 ### `tx.balance()` — produces a `Balance<T>`
@@ -180,8 +203,11 @@ const keypair = Ed25519Keypair.fromSecretKey('suiprivkey1...');
 const client = new SuiGrpcClient({ network: 'testnet' });
 
 const tx = new Transaction();
-const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
-tx.transferObjects([coin], '0xRecipient');
+tx.moveCall({
+  target: '0x2::balance::send_funds',
+  typeArguments: ['0x2::sui::SUI'],
+  arguments: [tx.balance({ balance: 1_000_000_000n }), tx.pure.address('0xRecipient')],
+});
 
 const result = await keypair.signAndExecuteTransaction({
   transaction: tx,

--- a/sui-ts-sdk-backend/transactions.md
+++ b/sui-ts-sdk-backend/transactions.md
@@ -4,90 +4,52 @@
 
 ---
 
-## The gas coin (`tx.gas`)
+## Coin access: `tx.coin()` and `tx.balance()`
 
-Every transaction has a gas coin, referenced via `tx.gas`. This is the primary way to access SUI funds in a transaction.
+These are the **recommended** way to access funds in a transaction. They automatically resolve from both address balances and coin objects, preferring address balances to avoid versioned object dependencies.
 
-### Synthetic gas coin with address-balance gas
+### `tx.coin()` — produces a `Coin<T>`
 
-When you call `tx.setGasPayment([])`, the protocol materializes a **synthetic GasCoin** from the sender's (or sponsor's) address balance. `tx.gas` still works — it refers to this synthetic coin. No coin objects are needed as transaction inputs, which means:
-
-- No versioned object references required
-- Concurrent transactions from the same address work without conflicts
-- Transactions can be built fully offline (no network lookups for gas)
-
-### Using `tx.gas`
-
-The gas coin can be:
-- **Borrowed by reference** — pass as `&Coin<SUI>` or `&mut Coin<SUI>` to Move calls
-- **Split** — use `tx.splitCoins(tx.gas, [...])` to create new coins from it
-- **Consumed by value** — only through permitted commands: `TransferObjects` or `coin::send_funds`
+Use for transfers, Move functions that accept `Coin<T>`, and standard coin operations.
 
 ```typescript
 import { Transaction } from '@mysten/sui/transactions';
 
 const tx = new Transaction();
 
-// Preferred: send SUI via balance transfer (deposits into recipient's address balance)
+// SUI transfer — deposits into recipient's address balance
 tx.moveCall({
   target: '0x2::balance::send_funds',
   typeArguments: ['0x2::sui::SUI'],
   arguments: [tx.balance({ balance: 1_000_000_000n }), tx.pure.address('0xRecipient')],
 });
-```
 
-Balance transfers via `send_funds` are preferred over `transferObjects` because they deposit directly into the recipient's address balance, avoiding versioned coin objects on the receiving side. This enables the recipient to spend concurrently without coin management.
-
-When you need the coin for Move call arguments before transferring, split from gas:
-
-```typescript
-// Split from gas, use in Move calls, then transfer
-const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
-tx.moveCall({ target: '0x...::module::use_coin', arguments: [coin] });
-// transferObjects is fine when the coin was used in prior commands
-tx.transferObjects([coin], '0xRecipient');
-```
-
-### When to use `tx.gas` vs `tx.coin()`
-
-| | `tx.splitCoins(tx.gas, ...)` | `tx.coin({ balance })` |
-|--|----------------------------|----------------------|
-| Coin type | SUI only | Any coin type |
-| Network access | Not required (works offline) | Required at build time (resolves balances) |
-| Gas mode | Works with both coin-object and address-balance gas | Also works with both, but adds resolution overhead |
-| Use case | SUI transfers, Move calls needing SUI | Non-SUI tokens (USDC, custom coins) |
-
-**For SUI transfers**, prefer `balance::send_funds` — it deposits into the recipient's address balance and avoids versioned objects. **For SUI in Move calls**, prefer `tx.splitCoins(tx.gas, ...)` — it works offline with no network resolution.
-
----
-
-## `tx.coin()` and `tx.balance()` — for non-SUI tokens
-
-Use these when you need tokens other than SUI. They automatically resolve from both address balances and coin objects, but require network access at build time.
-
-### `tx.coin()` — produces a `Coin<T>`
-
-```typescript
-// Preferred: send non-SUI tokens via balance transfer
+// Non-SUI transfer
 tx.moveCall({
   target: '0x2::balance::send_funds',
   typeArguments: ['0x...::usdc::USDC'],
   arguments: [
     tx.balance({ balance: 1_000_000n, type: '0x...::usdc::USDC' }),
-    tx.pure.address('0xRecipientAddress'),
+    tx.pure.address('0xRecipient'),
   ],
 });
 
-// Alternative: get a Coin<T> for use in Move calls before transferring
+// Get a Coin<T> for Move call arguments
+const coin = tx.coin({ balance: 1_000_000_000n });
+tx.moveCall({ target: '0x...::module::use_coin', arguments: [coin] });
+
+// Non-SUI coin for Move call arguments
 const usdcCoin = tx.coin({
   balance: 1_000_000n,
   type: '0x...::usdc::USDC',
 });
 ```
 
+For transfers, prefer `balance::send_funds` over `transferObjects` — it deposits directly into the recipient's address balance, avoiding versioned coin objects on the receiving side.
+
 ### `tx.balance()` — produces a `Balance<T>`
 
-Use for Move functions that accept `Balance<T>` directly. Always specify the `type` for non-SUI tokens — omitting it defaults to `Balance<SUI>`, which causes a type mismatch.
+Use for Move functions that accept `Balance<T>` directly. Specify `type` for non-SUI tokens — omitting it defaults to `Balance<SUI>`.
 
 ```typescript
 const bal = tx.balance({
@@ -115,7 +77,11 @@ tx.moveCall({
 2. Otherwise, it fetches coin objects and address balance in parallel, then merges and splits as needed.
 3. A zero-balance request resolves to `balance::zero` with no network lookups.
 
-Note: because resolution requires network access, `tx.coin()` / `tx.balance()` prevent fully offline transaction builds. For SUI, prefer `tx.splitCoins(tx.gas, ...)` instead.
+### The gas coin (`tx.gas`) — low-level
+
+Every transaction has a gas coin referenced via `tx.gas`. With address-balance gas (`setGasPayment([])`), the protocol materializes a synthetic GasCoin from the sender's or sponsor's address balance. `tx.gas` can be borrowed by reference and consumed by value only through permitted commands (`TransferObjects`, `coin::send_funds`).
+
+In most cases, prefer `tx.coin()` / `tx.balance()` over `tx.splitCoins(tx.gas, ...)`. The higher-level methods handle balance resolution automatically and work correctly across all gas modes.
 
 ---
 

--- a/sui-ts-sdk-backend/transactions.md
+++ b/sui-ts-sdk-backend/transactions.md
@@ -64,13 +64,17 @@ tx.transferObjects([usdcCoin], '0xRecipientAddress');
 
 ### `tx.balance()` — produces a `Balance<T>`
 
-Use for Move functions that accept `Balance<T>` directly.
+Use for Move functions that accept `Balance<T>` directly. Always specify the `type` for non-SUI tokens — omitting it defaults to `Balance<SUI>`, which causes a type mismatch.
 
 ```typescript
-const bal = tx.balance({ balance: 500_000_000n });
+const bal = tx.balance({
+  balance: 500_000_000n,
+  type: '0x...::usdc::USDC',
+});
 tx.moveCall({
   target: '0x...::my_module::deposit',
   arguments: [someObject, bal],
+  typeArguments: ['0x...::usdc::USDC'],
 });
 ```
 

--- a/sui-ts-sdk-backend/transactions.md
+++ b/sui-ts-sdk-backend/transactions.md
@@ -4,30 +4,62 @@
 
 ---
 
-## Coin access: `tx.coin()` and `tx.balance()`
+## The gas coin (`tx.gas`)
 
-These are the recommended way to access funds in a transaction. They automatically resolve from both address balances and coin objects.
+Every transaction has a gas coin, referenced via `tx.gas`. This is the primary way to access SUI funds in a transaction.
 
-### `tx.coin()` — produces a `Coin<T>`
+### Synthetic gas coin with address-balance gas
 
-Use for transfers, Move functions that accept `Coin<T>`, and standard coin operations.
+When you call `tx.setGasPayment([])`, the protocol materializes a **synthetic GasCoin** from the sender's (or sponsor's) address balance. `tx.gas` still works — it refers to this synthetic coin. No coin objects are needed as transaction inputs, which means:
+
+- No versioned object references required
+- Concurrent transactions from the same address work without conflicts
+- Transactions can be built fully offline (no network lookups for gas)
+
+### Using `tx.gas`
+
+The gas coin can be:
+- **Borrowed by reference** — pass as `&Coin<SUI>` or `&mut Coin<SUI>` to Move calls
+- **Split** — use `tx.splitCoins(tx.gas, [...])` to create new coins from it
+- **Consumed by value** — only through permitted commands: `TransferObjects` or `coin::send_funds`
 
 ```typescript
 import { Transaction } from '@mysten/sui/transactions';
 
 const tx = new Transaction();
 
-// Get 1 SUI (in MIST — 1 SUI = 1_000_000_000 MIST)
-const coin = tx.coin({ balance: 1_000_000_000n });
+// Split SUI from gas coin — works offline, no network resolution needed
+const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
+tx.transferObjects([coin], '0xRecipientAddress');
+```
 
-// Get a specific coin type
+This is the simplest pattern for SUI transfers. It works with both traditional coin-object gas and address-balance gas (`setGasPayment([])`).
+
+### When to use `tx.gas` vs `tx.coin()`
+
+| | `tx.splitCoins(tx.gas, ...)` | `tx.coin({ balance })` |
+|--|----------------------------|----------------------|
+| Coin type | SUI only | Any coin type |
+| Network access | Not required (works offline) | Required at build time (resolves balances) |
+| Gas mode | Works with both coin-object and address-balance gas | Also works with both, but adds resolution overhead |
+| Use case | SUI transfers, Move calls needing SUI | Non-SUI tokens (USDC, custom coins) |
+
+**Prefer `tx.splitCoins(tx.gas, ...)` for SUI** — it's simpler, works offline, and avoids client-side balance resolution.
+
+---
+
+## `tx.coin()` and `tx.balance()` — for non-SUI tokens
+
+Use these when you need tokens other than SUI. They automatically resolve from both address balances and coin objects, but require network access at build time.
+
+### `tx.coin()` — produces a `Coin<T>`
+
+```typescript
 const usdcCoin = tx.coin({
   balance: 1_000_000n,
   type: '0x...::usdc::USDC',
 });
-
-// Transfer it
-tx.transferObjects([coin], '0xRecipientAddress');
+tx.transferObjects([usdcCoin], '0xRecipientAddress');
 ```
 
 ### `tx.balance()` — produces a `Balance<T>`
@@ -36,7 +68,6 @@ Use for Move functions that accept `Balance<T>` directly.
 
 ```typescript
 const bal = tx.balance({ balance: 500_000_000n });
-// Pass to a Move function expecting Balance<SUI>
 tx.moveCall({
   target: '0x...::my_module::deposit',
   arguments: [someObject, bal],
@@ -49,13 +80,15 @@ tx.moveCall({
 |-----------|------|---------|-------------|
 | `balance` | `bigint \| number` | required | Amount in base units |
 | `type` | `string` | `'0x2::sui::SUI'` | Coin type |
-| `useGasCoin` | `boolean` | `true` | Set `false` for sponsored transactions |
+| `useGasCoin` | `boolean` | `true` | Whether to include the gas coin as a source. Set `false` in sponsored transactions where the gas coin belongs to the sponsor. |
 
 ### How resolution works at build time
 
 1. If the address balance alone is sufficient, the SDK uses a direct withdrawal (no versioned object inputs needed).
 2. Otherwise, it fetches coin objects and address balance in parallel, then merges and splits as needed.
 3. A zero-balance request resolves to `balance::zero` with no network lookups.
+
+Note: because resolution requires network access, `tx.coin()` / `tx.balance()` prevent fully offline transaction builds. For SUI, prefer `tx.splitCoins(tx.gas, ...)` instead.
 
 ---
 
@@ -143,10 +176,8 @@ const keypair = Ed25519Keypair.fromSecretKey('suiprivkey1...');
 const client = new SuiGrpcClient({ network: 'testnet' });
 
 const tx = new Transaction();
-tx.transferObjects(
-  [tx.coin({ balance: 1_000_000_000n })],
-  '0xRecipient',
-);
+const [coin] = tx.splitCoins(tx.gas, [1_000_000_000n]);
+tx.transferObjects([coin], '0xRecipient');
 
 const result = await keypair.signAndExecuteTransaction({
   transaction: tx,


### PR DESCRIPTION
## Summary

- Adds a new skill covering the full programmatic TypeScript SDK workflow for agents and backend services that **cannot use the Sui CLI**
- Fills 9 identified gaps in existing skills: keypair creation, faucet funding, client setup, tx.coin()/tx.balance(), programmatic publishing, sponsored transactions (@mysten-incubation/sponsor), transaction executors (Serial/Parallel), cloud KMS signing (AWS/GCP), and multisig
- All content sourced exclusively from [sdk.mystenlabs.com](https://sdk.mystenlabs.com) and fact-checked against source pages (two rounds of verification, 22 corrections applied)

### Reference files

| File | Covers |
|------|--------|
| `bootstrap.md` | Keypair creation, programmatic faucet, client setup, extensions |
| `transactions.md` | tx.coin()/tx.balance(), address balances, signing, result handling, gasless |
| `publishing.md` | Programmatic publish/upgrade via PTBs, simulateTransaction |
| `sponsorship.md` | @mysten-incubation/sponsor, client-builds flow, coin-based sponsorship |
| `executors.md` | SerialTransactionExecutor, ParallelTransactionExecutor |
| `signing.md` | AWS/GCP KMS signers, multisig, hybrid multisig (zkLogin + passkey) |

## Test plan

- [ ] Verify all code examples compile against `@mysten/sui` v2
- [ ] Verify faucet `recipient` parameter name matches SDK
- [ ] Verify `@mysten-incubation/sponsor` package name is current
- [ ] Verify KMS signer constructor params match SDK docs
- [ ] Run evals against the 5 test prompts in `evals/evals.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)